### PR TITLE
Prepare Pi Stuff packages for release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "IgorWarzocha/howaboua-pi-stuff" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/initial-skill-packages.md
+++ b/.changeset/initial-skill-packages.md
@@ -1,0 +1,11 @@
+---
+"@howaboua/pi-skill-agent-native-hardening": patch
+"@howaboua/pi-skill-anti-ai-copy": patch
+"@howaboua/pi-skill-chrome-cdp": patch
+"@howaboua/pi-skill-gh-issue-pr-flow": patch
+"@howaboua/pi-skill-omarchy-help": patch
+"@howaboua/pi-skill-project-reference-research": patch
+"@howaboua/pi-skill-skill-creator": patch
+---
+
+Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/.changeset/typecheck-strictness-fixes.md
+++ b/.changeset/typecheck-strictness-fixes.md
@@ -1,0 +1,12 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-explore-subagents": patch
+"@howaboua/pi-markdown-workflows": patch
+"@howaboua/pi-memories": patch
+"@howaboua/pi-semantic-grep": patch
+"@howaboua/pi-smart-btw": patch
+"@howaboua/pi-subagent-review": patch
+"@howaboua/pi-vent": patch
+---
+
+Fix TypeScript errors under the shared workspace typecheck settings.

--- a/.github/workflows/apply-patch-binaries.yml
+++ b/.github/workflows/apply-patch-binaries.yml
@@ -32,14 +32,14 @@ jobs:
             platform_arch: win32-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - name: Build apply_patch
         working-directory: packages/pi-codex-conversion
         run: bun run build:apply-patch
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: apply-patch-${{ matrix.platform_arch }}
           path: packages/pi-codex-conversion/vendor/apply-patch/${{ matrix.platform_arch }}/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   changed-packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Add aggregate package changesets
         run: bun run changeset:aggregates
       - name: Changesets release
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: bun run release
@@ -30,3 +31,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Delete Changesets release branch after publish
+        if: steps.changesets.outputs.published == 'true'
+        run: git push origin --delete changeset-release/main || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           publish: bun run release
           version: bun run version-packages
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,131 +8,133 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
-### Bundles
+GitHub pipe tables mangle long install commands, so this uses an HTML table with selectable command blocks.
 
-General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.
-
-```bash
-pi install npm:@howaboua/pi-stuff
-```
-
-General extension packages. Excludes `pi-codex-conversion`; install that separately if you run Codex/GPT models and want native-tool adaptation.
-
-```bash
-pi install npm:@howaboua/pi-extensions
-```
-
-Shareable skill packages. Excludes `omarchy-help` because not everyone is running my kind of desktop setup.
-
-```bash
-pi install npm:@howaboua/pi-skills
-```
-
-### Extensions
-
-Codex-style tools for Pi: `exec_command`, `write_stdin`, `apply_patch`, image tools, native Codex web search, and prompt/tool adaptation. Install separately if you run Codex/GPT-style models.
-
-```bash
-pi install npm:@howaboua/pi-codex-conversion
-```
-
-Gives the agent a `change_reasoning` tool so it can raise/lower reasoning level when the work changes shape.
-
-```bash
-pi install npm:@howaboua/pi-auto-reasoning-tool
-```
-
-Adds `/marker` and `/end` for long sessions. Set a useful return point, summarize what was accomplished, then keep going.
-
-```bash
-pi install npm:@howaboua/pi-auto-trees
-```
-
-Adds `/review`, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.
-
-```bash
-pi install npm:@howaboua/pi-subagent-review
-```
-
-Adds `semantic_grep`, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.
-
-```bash
-pi install npm:@howaboua/pi-semantic-grep
-```
-
-Adds `vent`, a small tool for logging repeated workflow friction into `VENT.md`.
-
-```bash
-pi install npm:@howaboua/pi-vent
-```
-
-Adds `explore_subagent`, discovery-only shallow/deep subagents for reading and summarizing code without editing files.
-
-```bash
-pi install npm:@howaboua/pi-explore-subagents
-```
-
-Adds `/skills`, `/workflows`, workflow capture, `/learn`, and nested `AGENTS.md` context loading.
-
-```bash
-pi install npm:@howaboua/pi-markdown-workflows
-```
-
-Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.
-
-```bash
-pi install npm:@howaboua/pi-smart-btw
-```
-
-KISS local memory for Pi based on global `AGENTS.md`.
-
-```bash
-pi install npm:@howaboua/pi-memories
-```
-
-### Skills
-
-Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.
-
-```bash
-pi install npm:@howaboua/pi-skill-agent-native-hardening
-```
-
-Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.
-
-```bash
-pi install npm:@howaboua/pi-skill-anti-ai-copy
-```
-
-Browser inspection/control through Chrome DevTools Protocol. Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local Pi packaging changes.
-
-```bash
-pi install npm:@howaboua/pi-skill-chrome-cdp
-```
-
-A generic GitHub issue/PR workflow with `gh`, branches, validation, PR bodies, and review triage.
-
-```bash
-pi install npm:@howaboua/pi-skill-gh-issue-pr-flow
-```
-
-Looks up external or local repos as reference context, then returns evidence-backed findings.
-
-```bash
-pi install npm:@howaboua/pi-skill-project-reference-research
-```
-
-Helps design, write, package, and tighten reusable agent skills.
-
-```bash
-pi install npm:@howaboua/pi-skill-skill-creator
-```
-
-Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.
-
-```bash
-pi install npm:@howaboua/pi-skill-omarchy-help
-```
+<table>
+<thead><tr><th>Group</th><th>Install</th><th>Type</th><th>What it does</th></tr></thead>
+<tbody>
+<tr>
+<td>Bundles</td>
+<td><pre><code>pi install npm:@howaboua/pi-stuff</code></pre></td>
+<td>bundle</td>
+<td>General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-extensions</code></pre></td>
+<td>bundle</td>
+<td>General extension packages. Excludes <code>pi-codex-conversion</code>; install that separately if you run Codex/GPT models and want native-tool adaptation.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skills</code></pre></td>
+<td>bundle</td>
+<td>Shareable skill packages. Excludes <code>omarchy-help</code> because not everyone is running my kind of desktop setup.</td>
+</tr>
+<tr>
+<td>Extensions</td>
+<td><pre><code>pi install npm:@howaboua/pi-codex-conversion</code></pre></td>
+<td>extension, separate</td>
+<td>Codex-style tools for Pi: <code>exec_command</code>, <code>write_stdin</code>, <code>apply_patch</code>, image tools, native Codex web search, and prompt/tool adaptation.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-auto-reasoning-tool</code></pre></td>
+<td>extension</td>
+<td>Gives the agent a <code>change_reasoning</code> tool so it can raise/lower reasoning level when the work changes shape.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-auto-trees</code></pre></td>
+<td>extension</td>
+<td>Adds <code>/marker</code> and <code>/end</code> for long sessions. Set a useful return point, summarize what was accomplished, then keep going.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-subagent-review</code></pre></td>
+<td>extension</td>
+<td>Adds <code>/review</code>, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-semantic-grep</code></pre></td>
+<td>extension</td>
+<td>Adds <code>semantic_grep</code>, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-vent</code></pre></td>
+<td>extension</td>
+<td>Adds <code>vent</code>, a small tool for logging repeated workflow friction into <code>VENT.md</code>.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-explore-subagents</code></pre></td>
+<td>extension</td>
+<td>Adds <code>explore_subagent</code>, discovery-only shallow/deep subagents for reading and summarizing code without editing files.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-markdown-workflows</code></pre></td>
+<td>extension</td>
+<td>Adds <code>/skills</code>, <code>/workflows</code>, workflow capture, <code>/learn</code>, and nested <code>AGENTS.md</code> context loading.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-smart-btw</code></pre></td>
+<td>extension</td>
+<td>Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-memories</code></pre></td>
+<td>extension</td>
+<td>KISS local memory for Pi based on global <code>AGENTS.md</code>.</td>
+</tr>
+<tr>
+<td>Skills</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-agent-native-hardening</code></pre></td>
+<td>skill</td>
+<td>Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-anti-ai-copy</code></pre></td>
+<td>skill</td>
+<td>Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-chrome-cdp</code></pre></td>
+<td>skill</td>
+<td>Browser inspection/control through Chrome DevTools Protocol. Based on <a href="https://github.com/pasky/chrome-cdp-skill"><code>pasky/chrome-cdp-skill</code></a>, with local Pi packaging changes.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-gh-issue-pr-flow</code></pre></td>
+<td>skill</td>
+<td>A generic GitHub issue/PR workflow with <code>gh</code>, branches, validation, PR bodies, and review triage.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-project-reference-research</code></pre></td>
+<td>skill</td>
+<td>Looks up external or local repos as reference context, then returns evidence-backed findings.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-skill-creator</code></pre></td>
+<td>skill</td>
+<td>Helps design, write, package, and tighten reusable agent skills.</td>
+</tr>
+<tr>
+<td></td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-omarchy-help</code></pre></td>
+<td>skill, separate</td>
+<td>Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.</td>
+</tr>
+</tbody>
+</table>
 
 ## The workflow
 

--- a/README.md
+++ b/README.md
@@ -8,128 +8,114 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
+Install any package by prefixing its package name with `pi install npm:@howaboua/`. For example:
+
+```bash
+pi install npm:@howaboua/pi-codex-conversion
+```
+
 <table>
-<thead><tr><th>Group</th><th>Type</th><th>What it does</th><th>Install</th></tr></thead>
+<thead><tr><th>Install</th><th>Type</th><th>What it does</th></tr></thead>
 <tbody>
 <tr>
-<td>Bundles</td>
+<td><strong>Bundles</strong><br><code>pi-stuff</code></td>
 <td>bundle</td>
 <td>General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.</td>
-<td><pre><code>pi install npm:@howaboua/pi-stuff</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-extensions</code></td>
 <td>bundle</td>
 <td>General extension packages. Excludes <code>pi-codex-conversion</code>; install that separately if you run Codex/GPT models and want native-tool adaptation.</td>
-<td><pre><code>pi install npm:@howaboua/pi-extensions</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skills</code></td>
 <td>bundle</td>
 <td>Shareable skill packages. Excludes <code>omarchy-help</code> because not everyone is running my kind of desktop setup.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skills</code></pre></td>
 </tr>
 <tr>
-<td>Extensions</td>
+<td><strong>Extensions</strong><br><code>pi-codex-conversion</code></td>
 <td>extension, separate</td>
 <td>Codex-style tools for Pi: <code>exec_command</code>, <code>write_stdin</code>, <code>apply_patch</code>, image tools, native Codex web search, and prompt/tool adaptation.</td>
-<td><pre><code>pi install npm:@howaboua/pi-codex-conversion</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-auto-reasoning-tool</code></td>
 <td>extension</td>
 <td>Gives the agent a <code>change_reasoning</code> tool so it can raise/lower reasoning level when the work changes shape.</td>
-<td><pre><code>pi install npm:@howaboua/pi-auto-reasoning-tool</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-auto-trees</code></td>
 <td>extension</td>
 <td>Adds <code>/marker</code> and <code>/end</code> for long sessions. Set a useful return point, summarize what was accomplished, then keep going.</td>
-<td><pre><code>pi install npm:@howaboua/pi-auto-trees</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-subagent-review</code></td>
 <td>extension</td>
 <td>Adds <code>/review</code>, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.</td>
-<td><pre><code>pi install npm:@howaboua/pi-subagent-review</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-semantic-grep</code></td>
 <td>extension</td>
 <td>Adds <code>semantic_grep</code>, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.</td>
-<td><pre><code>pi install npm:@howaboua/pi-semantic-grep</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-vent</code></td>
 <td>extension</td>
 <td>Adds <code>vent</code>, a small tool for logging repeated workflow friction into <code>VENT.md</code>.</td>
-<td><pre><code>pi install npm:@howaboua/pi-vent</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-explore-subagents</code></td>
 <td>extension</td>
 <td>Adds <code>explore_subagent</code>, discovery-only shallow/deep subagents for reading and summarizing code without editing files.</td>
-<td><pre><code>pi install npm:@howaboua/pi-explore-subagents</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-markdown-workflows</code></td>
 <td>extension</td>
 <td>Adds <code>/skills</code>, <code>/workflows</code>, workflow capture, <code>/learn</code>, and nested <code>AGENTS.md</code> context loading.</td>
-<td><pre><code>pi install npm:@howaboua/pi-markdown-workflows</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-smart-btw</code></td>
 <td>extension</td>
 <td>Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.</td>
-<td><pre><code>pi install npm:@howaboua/pi-smart-btw</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-memories</code></td>
 <td>extension</td>
 <td>KISS local memory for Pi based on global <code>AGENTS.md</code>.</td>
-<td><pre><code>pi install npm:@howaboua/pi-memories</code></pre></td>
 </tr>
 <tr>
-<td>Skills</td>
+<td><strong>Skills</strong><br><code>pi-skill-agent-native-hardening</code></td>
 <td>skill</td>
 <td>Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-agent-native-hardening</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-anti-ai-copy</code></td>
 <td>skill</td>
 <td>Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-anti-ai-copy</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-chrome-cdp</code></td>
 <td>skill</td>
 <td>Browser inspection/control through Chrome DevTools Protocol. Based on <a href="https://github.com/pasky/chrome-cdp-skill"><code>pasky/chrome-cdp-skill</code></a>, with local Pi packaging changes.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-chrome-cdp</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-gh-issue-pr-flow</code></td>
 <td>skill</td>
 <td>A generic GitHub issue/PR workflow with <code>gh</code>, branches, validation, PR bodies, and review triage.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-gh-issue-pr-flow</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-project-reference-research</code></td>
 <td>skill</td>
 <td>Looks up external or local repos as reference context, then returns evidence-backed findings.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-project-reference-research</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-skill-creator</code></td>
 <td>skill</td>
 <td>Helps design, write, package, and tighten reusable agent skills.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-skill-creator</code></pre></td>
 </tr>
 <tr>
-<td></td>
+<td><code>pi-skill-omarchy-help</code></td>
 <td>skill, separate</td>
 <td>Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-omarchy-help</code></pre></td>
 </tr>
 </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
-Install any package by prefixing its package name with `pi install npm:@howaboua/`. For example:
+Install any package by prefixing its package name with `pi install npm:@howaboua/`:
 
 ```bash
-pi install npm:@howaboua/pi-codex-conversion
+pi install npm:@howaboua/<package>
 ```
 
 <table>
-<thead><tr><th>Install</th><th>Type</th><th>What it does</th></tr></thead>
+<thead><tr><th>Package</th><th>Type</th><th>What it does</th></tr></thead>
 <tbody>
 <tr>
 <td><strong>Bundles</strong><br><code>pi-stuff</code></td>

--- a/README.md
+++ b/README.md
@@ -8,28 +8,131 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
-| Install | Type | What it does |
-| --- | --- | --- |
-| `pi install npm:@howaboua/pi-stuff` | bundle | The general setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup. |
-| `pi install npm:@howaboua/pi-extensions` | bundle | General extension packages. Excludes `pi-codex-conversion`; install it separately if you run Codex/GPT models and want native-tool adaptation. |
-| `pi install npm:@howaboua/pi-skills` | bundle | Shareable skill packages. Excludes `omarchy-help` because not everyone is running my kind of desktop setup. |
-| `pi install npm:@howaboua/pi-codex-conversion` | extension, separate | Codex-style tools for Pi: `exec_command`, `write_stdin`, `apply_patch`, image tools, native Codex web search, and prompt/tool adaptation. Install separately if you run Codex/GPT-style models. |
-| `pi install npm:@howaboua/pi-auto-reasoning-tool` | extension | Gives the agent a `change_reasoning` tool so it can raise/lower reasoning level when the work changes shape. |
-| `pi install npm:@howaboua/pi-auto-trees` | extension | Adds `/marker` and `/end` for long sessions. Set a useful return point, summarize what was accomplished, then keep going. |
-| `pi install npm:@howaboua/pi-subagent-review` | extension | Adds `/review`, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address. |
-| `pi install npm:@howaboua/pi-semantic-grep` | extension | Adds `semantic_grep`, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings. |
-| `pi install npm:@howaboua/pi-vent` | extension | Adds `vent`, a small tool for logging repeated workflow friction into `VENT.md`. |
-| `pi install npm:@howaboua/pi-explore-subagents` | extension | Adds `explore_subagent`, discovery-only shallow/deep subagents for reading and summarizing code without editing files. |
-| `pi install npm:@howaboua/pi-markdown-workflows` | extension | Adds `/skills`, `/workflows`, workflow capture, `/learn`, and nested `AGENTS.md` context loading. |
-| `pi install npm:@howaboua/pi-smart-btw` | extension | Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread. |
-| `pi install npm:@howaboua/pi-memories` | extension | KISS local memoryfor Pi based on global AGENTS.md. |
-| `pi install npm:@howaboua/pi-skill-agent-native-hardening` | skill | Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability. |
-| `pi install npm:@howaboua/pi-skill-anti-ai-copy` | skill | Rewrites text so it sounds specific, human, and less like a polite SaaS brochure. |
-| `pi install npm:@howaboua/pi-skill-chrome-cdp` | skill | Browser inspection/control through Chrome DevTools Protocol. Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local Pi packaging changes. |
-| `pi install npm:@howaboua/pi-skill-gh-issue-pr-flow` | skill | A generic GitHub issue/PR workflow with `gh`, branches, validation, PR bodies, and review triage. |
-| `pi install npm:@howaboua/pi-skill-project-reference-research` | skill | Looks up external or local repos as reference context, then returns evidence-backed findings. |
-| `pi install npm:@howaboua/pi-skill-skill-creator` | skill | Helps design, write, package, and tighten reusable agent skills. |
-| `pi install npm:@howaboua/pi-skill-omarchy-help` | skill, separate | Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine. |
+### Bundles
+
+General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.
+
+```bash
+pi install npm:@howaboua/pi-stuff
+```
+
+General extension packages. Excludes `pi-codex-conversion`; install that separately if you run Codex/GPT models and want native-tool adaptation.
+
+```bash
+pi install npm:@howaboua/pi-extensions
+```
+
+Shareable skill packages. Excludes `omarchy-help` because not everyone is running my kind of desktop setup.
+
+```bash
+pi install npm:@howaboua/pi-skills
+```
+
+### Extensions
+
+Codex-style tools for Pi: `exec_command`, `write_stdin`, `apply_patch`, image tools, native Codex web search, and prompt/tool adaptation. Install separately if you run Codex/GPT-style models.
+
+```bash
+pi install npm:@howaboua/pi-codex-conversion
+```
+
+Gives the agent a `change_reasoning` tool so it can raise/lower reasoning level when the work changes shape.
+
+```bash
+pi install npm:@howaboua/pi-auto-reasoning-tool
+```
+
+Adds `/marker` and `/end` for long sessions. Set a useful return point, summarize what was accomplished, then keep going.
+
+```bash
+pi install npm:@howaboua/pi-auto-trees
+```
+
+Adds `/review`, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.
+
+```bash
+pi install npm:@howaboua/pi-subagent-review
+```
+
+Adds `semantic_grep`, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.
+
+```bash
+pi install npm:@howaboua/pi-semantic-grep
+```
+
+Adds `vent`, a small tool for logging repeated workflow friction into `VENT.md`.
+
+```bash
+pi install npm:@howaboua/pi-vent
+```
+
+Adds `explore_subagent`, discovery-only shallow/deep subagents for reading and summarizing code without editing files.
+
+```bash
+pi install npm:@howaboua/pi-explore-subagents
+```
+
+Adds `/skills`, `/workflows`, workflow capture, `/learn`, and nested `AGENTS.md` context loading.
+
+```bash
+pi install npm:@howaboua/pi-markdown-workflows
+```
+
+Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.
+
+```bash
+pi install npm:@howaboua/pi-smart-btw
+```
+
+KISS local memory for Pi based on global `AGENTS.md`.
+
+```bash
+pi install npm:@howaboua/pi-memories
+```
+
+### Skills
+
+Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.
+
+```bash
+pi install npm:@howaboua/pi-skill-agent-native-hardening
+```
+
+Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.
+
+```bash
+pi install npm:@howaboua/pi-skill-anti-ai-copy
+```
+
+Browser inspection/control through Chrome DevTools Protocol. Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local Pi packaging changes.
+
+```bash
+pi install npm:@howaboua/pi-skill-chrome-cdp
+```
+
+A generic GitHub issue/PR workflow with `gh`, branches, validation, PR bodies, and review triage.
+
+```bash
+pi install npm:@howaboua/pi-skill-gh-issue-pr-flow
+```
+
+Looks up external or local repos as reference context, then returns evidence-backed findings.
+
+```bash
+pi install npm:@howaboua/pi-skill-project-reference-research
+```
+
+Helps design, write, package, and tighten reusable agent skills.
+
+```bash
+pi install npm:@howaboua/pi-skill-skill-creator
+```
+
+Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.
+
+```bash
+pi install npm:@howaboua/pi-skill-omarchy-help
+```
 
 ## The workflow
 

--- a/README.md
+++ b/README.md
@@ -8,130 +8,128 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
-GitHub pipe tables mangle long install commands, so this uses an HTML table with selectable command blocks.
-
 <table>
-<thead><tr><th>Group</th><th>Install</th><th>Type</th><th>What it does</th></tr></thead>
+<thead><tr><th>Group</th><th>Type</th><th>What it does</th><th>Install</th></tr></thead>
 <tbody>
 <tr>
 <td>Bundles</td>
-<td><pre><code>pi install npm:@howaboua/pi-stuff</code></pre></td>
 <td>bundle</td>
 <td>General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.</td>
+<td><pre><code>pi install npm:@howaboua/pi-stuff</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-extensions</code></pre></td>
 <td>bundle</td>
 <td>General extension packages. Excludes <code>pi-codex-conversion</code>; install that separately if you run Codex/GPT models and want native-tool adaptation.</td>
+<td><pre><code>pi install npm:@howaboua/pi-extensions</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skills</code></pre></td>
 <td>bundle</td>
 <td>Shareable skill packages. Excludes <code>omarchy-help</code> because not everyone is running my kind of desktop setup.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skills</code></pre></td>
 </tr>
 <tr>
 <td>Extensions</td>
-<td><pre><code>pi install npm:@howaboua/pi-codex-conversion</code></pre></td>
 <td>extension, separate</td>
 <td>Codex-style tools for Pi: <code>exec_command</code>, <code>write_stdin</code>, <code>apply_patch</code>, image tools, native Codex web search, and prompt/tool adaptation.</td>
+<td><pre><code>pi install npm:@howaboua/pi-codex-conversion</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-auto-reasoning-tool</code></pre></td>
 <td>extension</td>
 <td>Gives the agent a <code>change_reasoning</code> tool so it can raise/lower reasoning level when the work changes shape.</td>
+<td><pre><code>pi install npm:@howaboua/pi-auto-reasoning-tool</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-auto-trees</code></pre></td>
 <td>extension</td>
 <td>Adds <code>/marker</code> and <code>/end</code> for long sessions. Set a useful return point, summarize what was accomplished, then keep going.</td>
+<td><pre><code>pi install npm:@howaboua/pi-auto-trees</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-subagent-review</code></pre></td>
 <td>extension</td>
 <td>Adds <code>/review</code>, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.</td>
+<td><pre><code>pi install npm:@howaboua/pi-subagent-review</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-semantic-grep</code></pre></td>
 <td>extension</td>
 <td>Adds <code>semantic_grep</code>, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.</td>
+<td><pre><code>pi install npm:@howaboua/pi-semantic-grep</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-vent</code></pre></td>
 <td>extension</td>
 <td>Adds <code>vent</code>, a small tool for logging repeated workflow friction into <code>VENT.md</code>.</td>
+<td><pre><code>pi install npm:@howaboua/pi-vent</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-explore-subagents</code></pre></td>
 <td>extension</td>
 <td>Adds <code>explore_subagent</code>, discovery-only shallow/deep subagents for reading and summarizing code without editing files.</td>
+<td><pre><code>pi install npm:@howaboua/pi-explore-subagents</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-markdown-workflows</code></pre></td>
 <td>extension</td>
 <td>Adds <code>/skills</code>, <code>/workflows</code>, workflow capture, <code>/learn</code>, and nested <code>AGENTS.md</code> context loading.</td>
+<td><pre><code>pi install npm:@howaboua/pi-markdown-workflows</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-smart-btw</code></pre></td>
 <td>extension</td>
 <td>Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.</td>
+<td><pre><code>pi install npm:@howaboua/pi-smart-btw</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-memories</code></pre></td>
 <td>extension</td>
 <td>KISS local memory for Pi based on global <code>AGENTS.md</code>.</td>
+<td><pre><code>pi install npm:@howaboua/pi-memories</code></pre></td>
 </tr>
 <tr>
 <td>Skills</td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-agent-native-hardening</code></pre></td>
 <td>skill</td>
 <td>Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-agent-native-hardening</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-anti-ai-copy</code></pre></td>
 <td>skill</td>
 <td>Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-anti-ai-copy</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-chrome-cdp</code></pre></td>
 <td>skill</td>
 <td>Browser inspection/control through Chrome DevTools Protocol. Based on <a href="https://github.com/pasky/chrome-cdp-skill"><code>pasky/chrome-cdp-skill</code></a>, with local Pi packaging changes.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-chrome-cdp</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-gh-issue-pr-flow</code></pre></td>
 <td>skill</td>
 <td>A generic GitHub issue/PR workflow with <code>gh</code>, branches, validation, PR bodies, and review triage.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-gh-issue-pr-flow</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-project-reference-research</code></pre></td>
 <td>skill</td>
 <td>Looks up external or local repos as reference context, then returns evidence-backed findings.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-project-reference-research</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-skill-creator</code></pre></td>
 <td>skill</td>
 <td>Helps design, write, package, and tighten reusable agent skills.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-skill-creator</code></pre></td>
 </tr>
 <tr>
 <td></td>
-<td><pre><code>pi install npm:@howaboua/pi-skill-omarchy-help</code></pre></td>
 <td>skill, separate</td>
 <td>Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.</td>
+<td><pre><code>pi install npm:@howaboua/pi-skill-omarchy-help</code></pre></td>
 </tr>
 </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -8,117 +8,173 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 ## Packages
 
-Install any package by prefixing its package name with `pi install npm:@howaboua/`:
+GitHub does not render proper copy-button codeblocks inside Markdown tables. So you get a long list instead. At least the commands copy cleanly. Or send your clanker here to argue about which ones you actually want.
+
+### Bundles
+
+#### `pi-stuff`
+
+General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.
 
 ```bash
-pi install npm:@howaboua/<package>
+pi install npm:@howaboua/pi-stuff
 ```
 
-<table>
-<thead><tr><th>Package</th><th>Type</th><th>What it does</th></tr></thead>
-<tbody>
-<tr>
-<td><strong>Bundles</strong><br><code>pi-stuff</code></td>
-<td>bundle</td>
-<td>General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.</td>
-</tr>
-<tr>
-<td><code>pi-extensions</code></td>
-<td>bundle</td>
-<td>General extension packages. Excludes <code>pi-codex-conversion</code>; install that separately if you run Codex/GPT models and want native-tool adaptation.</td>
-</tr>
-<tr>
-<td><code>pi-skills</code></td>
-<td>bundle</td>
-<td>Shareable skill packages. Excludes <code>omarchy-help</code> because not everyone is running my kind of desktop setup.</td>
-</tr>
-<tr>
-<td><strong>Extensions</strong><br><code>pi-codex-conversion</code></td>
-<td>extension, separate</td>
-<td>Codex-style tools for Pi: <code>exec_command</code>, <code>write_stdin</code>, <code>apply_patch</code>, image tools, native Codex web search, and prompt/tool adaptation.</td>
-</tr>
-<tr>
-<td><code>pi-auto-reasoning-tool</code></td>
-<td>extension</td>
-<td>Gives the agent a <code>change_reasoning</code> tool so it can raise/lower reasoning level when the work changes shape.</td>
-</tr>
-<tr>
-<td><code>pi-auto-trees</code></td>
-<td>extension</td>
-<td>Adds <code>/marker</code> and <code>/end</code> for long sessions. Set a useful return point, summarize what was accomplished, then keep going.</td>
-</tr>
-<tr>
-<td><code>pi-subagent-review</code></td>
-<td>extension</td>
-<td>Adds <code>/review</code>, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.</td>
-</tr>
-<tr>
-<td><code>pi-semantic-grep</code></td>
-<td>extension</td>
-<td>Adds <code>semantic_grep</code>, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.</td>
-</tr>
-<tr>
-<td><code>pi-vent</code></td>
-<td>extension</td>
-<td>Adds <code>vent</code>, a small tool for logging repeated workflow friction into <code>VENT.md</code>.</td>
-</tr>
-<tr>
-<td><code>pi-explore-subagents</code></td>
-<td>extension</td>
-<td>Adds <code>explore_subagent</code>, discovery-only shallow/deep subagents for reading and summarizing code without editing files.</td>
-</tr>
-<tr>
-<td><code>pi-markdown-workflows</code></td>
-<td>extension</td>
-<td>Adds <code>/skills</code>, <code>/workflows</code>, workflow capture, <code>/learn</code>, and nested <code>AGENTS.md</code> context loading.</td>
-</tr>
-<tr>
-<td><code>pi-smart-btw</code></td>
-<td>extension</td>
-<td>Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.</td>
-</tr>
-<tr>
-<td><code>pi-memories</code></td>
-<td>extension</td>
-<td>KISS local memory for Pi based on global <code>AGENTS.md</code>.</td>
-</tr>
-<tr>
-<td><strong>Skills</strong><br><code>pi-skill-agent-native-hardening</code></td>
-<td>skill</td>
-<td>Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.</td>
-</tr>
-<tr>
-<td><code>pi-skill-anti-ai-copy</code></td>
-<td>skill</td>
-<td>Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.</td>
-</tr>
-<tr>
-<td><code>pi-skill-chrome-cdp</code></td>
-<td>skill</td>
-<td>Browser inspection/control through Chrome DevTools Protocol. Based on <a href="https://github.com/pasky/chrome-cdp-skill"><code>pasky/chrome-cdp-skill</code></a>, with local Pi packaging changes.</td>
-</tr>
-<tr>
-<td><code>pi-skill-gh-issue-pr-flow</code></td>
-<td>skill</td>
-<td>A generic GitHub issue/PR workflow with <code>gh</code>, branches, validation, PR bodies, and review triage.</td>
-</tr>
-<tr>
-<td><code>pi-skill-project-reference-research</code></td>
-<td>skill</td>
-<td>Looks up external or local repos as reference context, then returns evidence-backed findings.</td>
-</tr>
-<tr>
-<td><code>pi-skill-skill-creator</code></td>
-<td>skill</td>
-<td>Helps design, write, package, and tighten reusable agent skills.</td>
-</tr>
-<tr>
-<td><code>pi-skill-omarchy-help</code></td>
-<td>skill, separate</td>
-<td>Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.</td>
-</tr>
-</tbody>
-</table>
+#### `pi-extensions`
+
+General extension packages. Excludes `pi-codex-conversion`; install that separately if you run Codex/GPT models and want native-tool adaptation.
+
+```bash
+pi install npm:@howaboua/pi-extensions
+```
+
+#### `pi-skills`
+
+Shareable skill packages. Excludes `omarchy-help` because not everyone is running my kind of desktop setup.
+
+```bash
+pi install npm:@howaboua/pi-skills
+```
+
+### Extensions
+
+#### `pi-codex-conversion`
+
+Codex-style tools for Pi: `exec_command`, `write_stdin`, `apply_patch`, image tools, native Codex web search, and prompt/tool adaptation.
+
+```bash
+pi install npm:@howaboua/pi-codex-conversion
+```
+
+#### `pi-auto-reasoning-tool`
+
+Gives the agent a `change_reasoning` tool so it can raise/lower reasoning level when the work changes shape.
+
+```bash
+pi install npm:@howaboua/pi-auto-reasoning-tool
+```
+
+#### `pi-auto-trees`
+
+Adds `/marker` and `/end` for long sessions. Set a useful return point, summarize what was accomplished, then keep going.
+
+```bash
+pi install npm:@howaboua/pi-auto-trees
+```
+
+#### `pi-subagent-review`
+
+Adds `/review`, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.
+
+```bash
+pi install npm:@howaboua/pi-subagent-review
+```
+
+#### `pi-semantic-grep`
+
+Adds `semantic_grep`, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.
+
+```bash
+pi install npm:@howaboua/pi-semantic-grep
+```
+
+#### `pi-vent`
+
+Adds `vent`, a small tool for logging repeated workflow friction into `VENT.md`.
+
+```bash
+pi install npm:@howaboua/pi-vent
+```
+
+#### `pi-explore-subagents`
+
+Adds `explore_subagent`, discovery-only shallow/deep subagents for reading and summarizing code without editing files.
+
+```bash
+pi install npm:@howaboua/pi-explore-subagents
+```
+
+#### `pi-markdown-workflows`
+
+Adds `/skills`, `/workflows`, workflow capture, `/learn`, and nested `AGENTS.md` context loading.
+
+```bash
+pi install npm:@howaboua/pi-markdown-workflows
+```
+
+#### `pi-smart-btw`
+
+Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.
+
+```bash
+pi install npm:@howaboua/pi-smart-btw
+```
+
+#### `pi-memories`
+
+KISS local memory for Pi based on global `AGENTS.md`.
+
+```bash
+pi install npm:@howaboua/pi-memories
+```
+
+### Skills
+
+#### `pi-skill-agent-native-hardening`
+
+Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.
+
+```bash
+pi install npm:@howaboua/pi-skill-agent-native-hardening
+```
+
+#### `pi-skill-anti-ai-copy`
+
+Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.
+
+```bash
+pi install npm:@howaboua/pi-skill-anti-ai-copy
+```
+
+#### `pi-skill-chrome-cdp`
+
+Browser inspection/control through Chrome DevTools Protocol. Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local Pi packaging changes.
+
+```bash
+pi install npm:@howaboua/pi-skill-chrome-cdp
+```
+
+#### `pi-skill-gh-issue-pr-flow`
+
+A generic GitHub issue/PR workflow with `gh`, branches, validation, PR bodies, and review triage.
+
+```bash
+pi install npm:@howaboua/pi-skill-gh-issue-pr-flow
+```
+
+#### `pi-skill-project-reference-research`
+
+Looks up external or local repos as reference context, then returns evidence-backed findings.
+
+```bash
+pi install npm:@howaboua/pi-skill-project-reference-research
+```
+
+#### `pi-skill-skill-creator`
+
+Helps design, write, package, and tighten reusable agent skills.
+
+```bash
+pi install npm:@howaboua/pi-skill-skill-creator
+```
+
+#### `pi-skill-omarchy-help`
+
+Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.
+
+```bash
+pi install npm:@howaboua/pi-skill-omarchy-help
+```
 
 ## The workflow
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@howaboua/pi-stuff-monorepo",
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
+        "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.29.0",
         "@earendil-works/pi-agent-core": "^0.76.0",
         "@earendil-works/pi-ai": "^0.76.0",
@@ -104,16 +105,15 @@
       "name": "@howaboua/pi-extensions",
       "version": "0.0.0",
       "dependencies": {
-        "@howaboua/pi-auto-reasoning-tool": "workspace:*",
-        "@howaboua/pi-auto-trees": "workspace:*",
-        "@howaboua/pi-codex-conversion": "workspace:*",
-        "@howaboua/pi-explore-subagents": "workspace:*",
-        "@howaboua/pi-markdown-workflows": "workspace:*",
-        "@howaboua/pi-memories": "workspace:*",
-        "@howaboua/pi-semantic-grep": "workspace:*",
-        "@howaboua/pi-smart-btw": "workspace:*",
-        "@howaboua/pi-subagent-review": "workspace:*",
-        "@howaboua/pi-vent": "workspace:*",
+        "@howaboua/pi-auto-reasoning-tool": "0.1.5",
+        "@howaboua/pi-auto-trees": "0.1.3",
+        "@howaboua/pi-explore-subagents": "0.1.4",
+        "@howaboua/pi-markdown-workflows": "0.2.9",
+        "@howaboua/pi-memories": "0.0.0",
+        "@howaboua/pi-semantic-grep": "0.1.10",
+        "@howaboua/pi-smart-btw": "0.1.1",
+        "@howaboua/pi-subagent-review": "0.1.52",
+        "@howaboua/pi-vent": "0.2.4",
       },
     },
     "packages/pi-markdown-workflows": {
@@ -164,11 +164,44 @@
         "@earendil-works/pi-tui": "^0.76.0",
       },
     },
+    "packages/pi-skill-agent-native-hardening": {
+      "name": "@howaboua/pi-skill-agent-native-hardening",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-anti-ai-copy": {
+      "name": "@howaboua/pi-skill-anti-ai-copy",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-chrome-cdp": {
+      "name": "@howaboua/pi-skill-chrome-cdp",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-gh-issue-pr-flow": {
+      "name": "@howaboua/pi-skill-gh-issue-pr-flow",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-omarchy-help": {
+      "name": "@howaboua/pi-skill-omarchy-help",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-project-reference-research": {
+      "name": "@howaboua/pi-skill-project-reference-research",
+      "version": "0.0.0",
+    },
+    "packages/pi-skill-skill-creator": {
+      "name": "@howaboua/pi-skill-skill-creator",
+      "version": "0.0.0",
+    },
     "packages/pi-skills": {
       "name": "@howaboua/pi-skills",
       "version": "0.0.0",
       "dependencies": {
-        "@howaboua/pi-markdown-workflows": "workspace:*",
+        "@howaboua/pi-skill-agent-native-hardening": "0.0.0",
+        "@howaboua/pi-skill-anti-ai-copy": "0.0.0",
+        "@howaboua/pi-skill-chrome-cdp": "0.0.0",
+        "@howaboua/pi-skill-gh-issue-pr-flow": "0.0.0",
+        "@howaboua/pi-skill-project-reference-research": "0.0.0",
+        "@howaboua/pi-skill-skill-creator": "0.0.0",
       },
     },
     "packages/pi-smart-btw": {
@@ -192,16 +225,21 @@
       "name": "@howaboua/pi-stuff",
       "version": "0.0.0",
       "dependencies": {
-        "@howaboua/pi-auto-reasoning-tool": "workspace:*",
-        "@howaboua/pi-auto-trees": "workspace:*",
-        "@howaboua/pi-codex-conversion": "workspace:*",
-        "@howaboua/pi-explore-subagents": "workspace:*",
-        "@howaboua/pi-markdown-workflows": "workspace:*",
-        "@howaboua/pi-memories": "workspace:*",
-        "@howaboua/pi-semantic-grep": "workspace:*",
-        "@howaboua/pi-smart-btw": "workspace:*",
-        "@howaboua/pi-subagent-review": "workspace:*",
-        "@howaboua/pi-vent": "workspace:*",
+        "@howaboua/pi-auto-reasoning-tool": "0.1.5",
+        "@howaboua/pi-auto-trees": "0.1.3",
+        "@howaboua/pi-explore-subagents": "0.1.4",
+        "@howaboua/pi-markdown-workflows": "0.2.9",
+        "@howaboua/pi-memories": "0.0.0",
+        "@howaboua/pi-semantic-grep": "0.1.10",
+        "@howaboua/pi-skill-agent-native-hardening": "0.0.0",
+        "@howaboua/pi-skill-anti-ai-copy": "0.0.0",
+        "@howaboua/pi-skill-chrome-cdp": "0.0.0",
+        "@howaboua/pi-skill-gh-issue-pr-flow": "0.0.0",
+        "@howaboua/pi-skill-project-reference-research": "0.0.0",
+        "@howaboua/pi-skill-skill-creator": "0.0.0",
+        "@howaboua/pi-smart-btw": "0.1.1",
+        "@howaboua/pi-subagent-review": "0.1.52",
+        "@howaboua/pi-vent": "0.2.4",
       },
     },
     "packages/pi-subagent-review": {
@@ -316,6 +354,8 @@
 
     "@changesets/changelog-git": ["@changesets/changelog-git@0.2.1", "", { "dependencies": { "@changesets/types": "^6.1.0" } }, "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q=="],
 
+    "@changesets/changelog-github": ["@changesets/changelog-github@0.7.0", "", { "dependencies": { "@changesets/get-github-info": "^0.8.0", "@changesets/types": "^6.1.0", "dotenv": "^8.1.0" } }, "sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA=="],
+
     "@changesets/cli": ["@changesets/cli@2.31.0", "", { "dependencies": { "@changesets/apply-release-plan": "^7.1.1", "@changesets/assemble-release-plan": "^6.0.10", "@changesets/changelog-git": "^0.2.1", "@changesets/config": "^3.1.4", "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.4", "@changesets/get-release-plan": "^4.0.16", "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@changesets/write": "^0.4.0", "@inquirer/external-editor": "^1.0.2", "@manypkg/get-packages": "^1.1.3", "ansi-colors": "^4.1.3", "enquirer": "^2.4.1", "fs-extra": "^7.0.1", "mri": "^1.2.0", "package-manager-detector": "^0.2.0", "picocolors": "^1.1.0", "resolve-from": "^5.0.0", "semver": "^7.5.3", "spawndamnit": "^3.0.1", "term-size": "^2.1.0" }, "bin": { "changeset": "bin.js" } }, "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg=="],
 
     "@changesets/config": ["@changesets/config@3.1.4", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.4", "@changesets/logger": "^0.1.1", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1", "micromatch": "^4.0.8" } }, "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q=="],
@@ -323,6 +363,8 @@
     "@changesets/errors": ["@changesets/errors@0.2.0", "", { "dependencies": { "extendable-error": "^0.1.5" } }, "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow=="],
 
     "@changesets/get-dependents-graph": ["@changesets/get-dependents-graph@2.1.4", "", { "dependencies": { "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "picocolors": "^1.1.0", "semver": "^7.5.3" } }, "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg=="],
+
+    "@changesets/get-github-info": ["@changesets/get-github-info@0.8.0", "", { "dependencies": { "dataloader": "^1.4.0", "node-fetch": "^2.5.0" } }, "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ=="],
 
     "@changesets/get-release-plan": ["@changesets/get-release-plan@4.0.16", "", { "dependencies": { "@changesets/assemble-release-plan": "^6.0.10", "@changesets/config": "^3.1.4", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g=="],
 
@@ -423,6 +465,20 @@
     "@howaboua/pi-memories": ["@howaboua/pi-memories@workspace:packages/pi-memories"],
 
     "@howaboua/pi-semantic-grep": ["@howaboua/pi-semantic-grep@workspace:packages/pi-semantic-grep"],
+
+    "@howaboua/pi-skill-agent-native-hardening": ["@howaboua/pi-skill-agent-native-hardening@workspace:packages/pi-skill-agent-native-hardening"],
+
+    "@howaboua/pi-skill-anti-ai-copy": ["@howaboua/pi-skill-anti-ai-copy@workspace:packages/pi-skill-anti-ai-copy"],
+
+    "@howaboua/pi-skill-chrome-cdp": ["@howaboua/pi-skill-chrome-cdp@workspace:packages/pi-skill-chrome-cdp"],
+
+    "@howaboua/pi-skill-gh-issue-pr-flow": ["@howaboua/pi-skill-gh-issue-pr-flow@workspace:packages/pi-skill-gh-issue-pr-flow"],
+
+    "@howaboua/pi-skill-omarchy-help": ["@howaboua/pi-skill-omarchy-help@workspace:packages/pi-skill-omarchy-help"],
+
+    "@howaboua/pi-skill-project-reference-research": ["@howaboua/pi-skill-project-reference-research@workspace:packages/pi-skill-project-reference-research"],
+
+    "@howaboua/pi-skill-skill-creator": ["@howaboua/pi-skill-skill-creator@workspace:packages/pi-skill-skill-creator"],
 
     "@howaboua/pi-skills": ["@howaboua/pi-skills@workspace:packages/pi-skills"],
 
@@ -616,6 +672,8 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "dataloader": ["dataloader@1.4.0", "", {}, "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -629,6 +687,8 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
@@ -774,7 +834,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
@@ -892,6 +952,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tree-sitter-bash": ["tree-sitter-bash@0.25.1", "", { "dependencies": { "node-addon-api": "^8.2.1", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
@@ -917,6 +979,10 @@
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.26.9", "", {}, "sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -973,6 +1039,8 @@
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@types/better-sqlite3/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
+    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.29.0",
     "@earendil-works/pi-agent-core": "^0.76.0",
     "@earendil-works/pi-ai": "^0.76.0",
@@ -30,8 +31,10 @@
     "@earendil-works/pi-tui": "^0.76.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.10.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260519.1",
     "better-sqlite3": "^12.10.0",
     "node-pty": "^1.1.0",
+    "openai": "^6.26.0",
     "oxfmt": "^0.35.0",
     "partial-json": "^0.1.7",
     "proxy-from-env": "1.1.0",
@@ -39,9 +42,7 @@
     "tsx": "^4.20.5",
     "typebox": "^1.1.24",
     "typescript": "^6.0.3",
-    "web-tree-sitter": "^0.26.7",
-    "openai": "^6.26.0",
-    "@typescript/native-preview": "^7.0.0-dev.20260519.1"
+    "web-tree-sitter": "^0.26.7"
   },
   "version": "0.0.1"
 }

--- a/packages/pi-auto-reasoning-tool/package.json
+++ b/packages/pi-auto-reasoning-tool/package.json
@@ -1,58 +1,58 @@
 {
-  "name": "@howaboua/pi-auto-reasoning-tool",
-  "version": "0.1.5",
-  "description": "Pi package that gives agents a change_reasoning tool for adjusting reasoning level when substantial work is likely.",
-  "type": "module",
-  "main": "src/index.ts",
-  "exports": "./src/index.ts",
-  "files": [
-    "src",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "pi": {
-    "extensions": [
-      "./src/index.ts"
-    ]
-  },
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "keywords": [
-    "pi",
-    "pi-package",
-    "pi-extension",
-    "reasoning",
-    "reasoning-level",
-    "coding-agent"
-  ],
-  "author": "howaboua",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-auto-reasoning-tool"
-  },
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-auto-reasoning-tool#readme",
-  "publishConfig": {
-    "access": "public"
-  },
-  "dependencies": {
-    "@earendil-works/pi-ai": "^0.76.0"
-  },
-  "devDependencies": {
-    "@types/node": "^24.10.0",
-    "typescript": "^5.9.3",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@biomejs/biome": "^2.4.16"
-  }
+	"name": "@howaboua/pi-auto-reasoning-tool",
+	"version": "0.1.5",
+	"description": "Pi package that gives agents a change_reasoning tool for adjusting reasoning level when substantial work is likely.",
+	"type": "module",
+	"main": "src/index.ts",
+	"exports": "./src/index.ts",
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"keywords": [
+		"pi",
+		"pi-package",
+		"pi-extension",
+		"reasoning",
+		"reasoning-level",
+		"coding-agent"
+	],
+	"author": "howaboua",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-auto-reasoning-tool"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-auto-reasoning-tool#readme",
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@earendil-works/pi-ai": "^0.76.0"
+	},
+	"devDependencies": {
+		"@types/node": "^24.10.0",
+		"typescript": "^5.9.3",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@biomejs/biome": "^2.4.16"
+	}
 }

--- a/packages/pi-auto-reasoning-tool/tsconfig.json
+++ b/packages/pi-auto-reasoning-tool/tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["src/**/*.ts"]
 }

--- a/packages/pi-codex-conversion/src/adapter/activation.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation.ts
@@ -79,7 +79,7 @@ function disableAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterS
 	}
 	if (state.enabled) {
 		state.enabled = false;
-		state.adapterOwnedToolNames = undefined;
+		delete state.adapterOwnedToolNames;
 	}
 	setStatus(ctx, false, state.config);
 }

--- a/packages/pi-codex-conversion/src/adapter/codex-context-budget.ts
+++ b/packages/pi-codex-conversion/src/adapter/codex-context-budget.ts
@@ -29,9 +29,9 @@ function readSettings(path: string): Record<string, unknown> | undefined {
 }
 
 function getReserveTokens(settings: Record<string, unknown> | undefined): number | undefined {
-	const compaction = settings?.compaction;
+	const compaction = settings?.["compaction"];
 	if (!compaction || typeof compaction !== "object" || Array.isArray(compaction)) return undefined;
-	const reserveTokens = (compaction as { reserveTokens?: unknown }).reserveTokens;
+	const reserveTokens = (compaction as { reserveTokens?: unknown | undefined }).reserveTokens;
 	return typeof reserveTokens === "number" && Number.isFinite(reserveTokens) && reserveTokens >= 0 ? reserveTokens : undefined;
 }
 

--- a/packages/pi-codex-conversion/src/adapter/compact-client.ts
+++ b/packages/pi-codex-conversion/src/adapter/compact-client.ts
@@ -4,8 +4,8 @@ import type { NativeCompactionRequestBody } from "./serializer.ts";
 const JSON_CONTENT_TYPE = "application/json";
 
 type CompactResponseEnvelope = {
-	id?: string;
-	created_at?: number | string;
+	id?: string | undefined;
+	created_at?: number | string | undefined;
 	output: unknown[];
 	[key: string]: unknown;
 };
@@ -23,18 +23,18 @@ export type NativeCompactionClientSuccess = {
 	ok: true;
 	status: number;
 	compactedWindow: unknown[];
-	compactResponseId?: string;
-	createdAt?: string;
+	compactResponseId?: string | undefined;
+	createdAt?: string | undefined;
 	response: CompactResponseEnvelope;
 };
 
 export type NativeCompactionClientFailure = {
 	ok: false;
 	reason: NativeCompactionClientFailureReason;
-	status?: number;
-	errorMessage?: string;
-	responseText?: string;
-	responseJson?: unknown;
+	status?: number | undefined;
+	errorMessage?: string | undefined;
+	responseText?: string | undefined;
+	responseJson?: unknown | undefined;
 };
 
 export type NativeCompactionClientResult = NativeCompactionClientSuccess | NativeCompactionClientFailure;
@@ -42,7 +42,7 @@ export type NativeCompactionClientResult = NativeCompactionClientSuccess | Nativ
 export type ExecuteNativeCompactionOptions = {
 	runtime: NativeCompactionRuntime;
 	request: NativeCompactionRequestBody;
-	signal?: AbortSignal;
+	signal?: AbortSignal | undefined;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -80,7 +80,7 @@ function isCompactOutputItem(value: unknown): value is Record<string, unknown> {
 }
 
 function isCompactResponseEnvelope(value: unknown): value is CompactResponseEnvelope {
-	return isRecord(value) && Array.isArray(value.output) && value.output.every(isCompactOutputItem);
+	return isRecord(value) && Array.isArray(value["output"]!) && value["output"]!.every(isCompactOutputItem);
 }
 
 function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
@@ -105,7 +105,7 @@ function extractCodexAccountId(token: string): string | undefined {
 		return undefined;
 	}
 
-	const accountId = authClaims.chatgpt_account_id;
+	const accountId = authClaims["chatgpt_account_id"]!;
 	return typeof accountId === "string" && accountId.trim().length > 0 ? accountId.trim() : undefined;
 }
 
@@ -164,7 +164,7 @@ export async function executeNativeCompaction(
 			method: "POST",
 			headers,
 			body: JSON.stringify(request),
-			signal,
+			...(signal ? { signal } : {}),
 		});
 		const responseText = await response.text();
 

--- a/packages/pi-codex-conversion/src/adapter/compaction-output.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction-output.ts
@@ -30,7 +30,7 @@ function cloneCompactedOutputItem(item: Record<string, unknown>): Record<string,
 }
 
 export function shouldKeepCompactedOutputItem(item: unknown): item is Record<string, unknown> {
-	return isRecord(item) && typeof item.type === "string";
+	return isRecord(item) && typeof item["type"]! === "string";
 }
 
 export function sanitizeCompactedWindow(output: readonly unknown[]): Record<string, unknown>[] {
@@ -45,28 +45,28 @@ export function sanitizeCompactedWindow(output: readonly unknown[]): Record<stri
 
 export function extractCompactionSummaryText(compactedWindow: readonly unknown[]): string | undefined {
 	for (const item of compactedWindow) {
-		if (!isRecord(item) || typeof item.type !== "string" || !COMPACTION_ITEM_TYPES.has(item.type)) continue;
-		if (typeof item.encrypted_content === "string" && item.encrypted_content.trim().length > 0) return item.encrypted_content.trim();
+		if (!isRecord(item) || typeof item["type"]! !== "string" || !COMPACTION_ITEM_TYPES.has(item["type"]!)) continue;
+		if (typeof item["encrypted_content"]! === "string" && item["encrypted_content"]!.trim().length > 0) return item["encrypted_content"]!.trim();
 	}
 	return undefined;
 }
 
 export function hasCompactionOutputItem(compactedWindow: readonly unknown[]): boolean {
-	return compactedWindow.some((item) => isRecord(item) && typeof item.type === "string" && COMPACTION_ITEM_TYPES.has(item.type));
+	return compactedWindow.some((item) => isRecord(item) && typeof item["type"]! === "string" && COMPACTION_ITEM_TYPES.has(item["type"]!));
 }
 
 function describeOutputItem(item: unknown): string {
 	if (!isRecord(item)) return typeof item;
-	const type = typeof item.type === "string" ? item.type : "<missing-type>";
-	const role = typeof item.role === "string" ? `/${item.role}` : "";
-	const content = Array.isArray(item.content) ? ` content=${item.content.length}` : "";
+	const type = typeof item["type"]! === "string" ? item["type"]! : "<missing-type>";
+	const role = typeof item["role"]! === "string" ? `/${item["role"]!}` : "";
+	const content = Array.isArray(item["content"]!) ? ` content=${item["content"]!.length}` : "";
 	const keys = Object.keys(item).sort().slice(0, 8).join(",");
 	return `${type}${role}${content} keys=[${keys}]`;
 }
 
 export function summarizeCompactionOutputForDiagnostics(rawOutput: readonly unknown[], sanitizedOutput: readonly unknown[]): string {
-	const rawTypes = rawOutput.map((item) => isRecord(item) && typeof item.type === "string" ? item.type : typeof item);
-	const sanitizedTypes = sanitizedOutput.map((item) => isRecord(item) && typeof item.type === "string" ? item.type : typeof item);
+	const rawTypes = rawOutput.map((item) => isRecord(item) && typeof item["type"]! === "string" ? item["type"]! : typeof item);
+	const sanitizedTypes = sanitizedOutput.map((item) => isRecord(item) && typeof item["type"]! === "string" ? item["type"]! : typeof item);
 	const rawCounts = countValues(rawTypes);
 	const sanitizedCounts = countValues(sanitizedTypes);
 	const sample = rawOutput.slice(0, 8).map((item, index) => `${index}: ${describeOutputItem(item)}`).join("; ");

--- a/packages/pi-codex-conversion/src/adapter/compaction-runtime.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction-runtime.ts
@@ -22,15 +22,15 @@ type NativeCompactionFailureReason =
 	| "payload-model-mismatch";
 
 export type NativeCompactionSupportOptions = {
-	enabled?: boolean;
-	supportedProviders?: readonly string[];
-	supportedApis?: readonly string[];
+	enabled?: boolean | undefined;
+	supportedProviders?: readonly string[] | undefined;
+	supportedApis?: readonly string[] | undefined;
 };
 
 export type ResponsesCompatibleRequestPayload = {
 	model: string;
 	input: unknown[];
-	instructions?: unknown;
+	instructions?: unknown | undefined;
 	[key: string]: unknown;
 };
 
@@ -40,21 +40,21 @@ export type NativeCompactionRuntime = {
 	apiFamily: DefaultSupportedApi;
 	model: string;
 	baseUrl: string;
-	apiKey?: string;
-	headers?: Record<string, string>;
+	apiKey?: string | undefined;
+	headers?: Record<string, string> | undefined;
 	compactPath: string;
 	compactUrl: string;
-	payload?: ResponsesCompatibleRequestPayload;
+	payload?: ResponsesCompatibleRequestPayload | undefined;
 	currentModel: RuntimeModel;
 };
 
 export type NativeCompactionEnvironmentFailure = {
 	ok: false;
 	reason: NativeCompactionFailureReason;
-	provider?: string;
-	api?: string;
-	model?: string;
-	baseUrl?: string;
+	provider?: string | undefined;
+	api?: string | undefined;
+	model?: string | undefined;
+	baseUrl?: string | undefined;
 };
 
 export type NativeCompactionEnvironmentSuccess = {
@@ -110,12 +110,12 @@ export function isSupportedProvider(provider: string): provider is BuiltInSuppor
 async function resolveRequestAuth(
 	ctx: ExtensionContext,
 	model: RuntimeModel,
-): Promise<{ apiKey?: string; headers?: Record<string, string> }> {
+): Promise<{ apiKey?: string | undefined; headers?: Record<string, string> | undefined }> {
 	const modelRegistry = ctx.modelRegistry as {
 		getApiKeyAndHeaders?: (currentModel: RuntimeModel) => Promise<
-			| { ok: true; apiKey?: string; headers?: Record<string, string> }
+			| { ok: true; apiKey?: string | undefined; headers?: Record<string, string> | undefined }
 			| { ok: false; error: string }
-		>;
+		> | undefined;
 	};
 
 	if (typeof modelRegistry.getApiKeyAndHeaders !== "function") {
@@ -123,7 +123,7 @@ async function resolveRequestAuth(
 	}
 
 	const auth = await modelRegistry.getApiKeyAndHeaders(model);
-	return auth.ok ? { apiKey: auth.apiKey, headers: auth.headers } : {};
+	return auth && auth.ok ? { apiKey: auth.apiKey, headers: auth.headers } : {};
 }
 
 export function isSupportedApi(api: string): api is DefaultSupportedApi {
@@ -136,14 +136,14 @@ export function isResponsesCompatiblePayload(payload: unknown): payload is Respo
 	}
 
 	const candidate = payload as Record<string, unknown>;
-	return typeof candidate.model === "string" && Array.isArray(candidate.input);
+	return typeof candidate["model"]! === "string" && Array.isArray(candidate["input"]!);
 }
 
 export function getRuntimeModelDescriptor(model: RuntimeModel | undefined): {
-	provider?: string;
-	api?: string;
-	model?: string;
-	baseUrl?: string;
+	provider?: string | undefined;
+	api?: string | undefined;
+	model?: string | undefined;
+	baseUrl?: string | undefined;
 } {
 	if (!model) {
 		return {};

--- a/packages/pi-codex-conversion/src/adapter/compaction.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction.ts
@@ -88,7 +88,7 @@ function buildCompactionReasoning(pi: ExtensionAPI, ctx: ExtensionContext, state
 function clampCodexReasoningEffort(modelId: string, effort: string): string {
 	const id = modelId.includes("/") ? (modelId.split("/").pop() ?? modelId) : modelId;
 	const gpt5MinorMatch = /^gpt-5\.(\d+)/.exec(id);
-	const gpt5Minor = gpt5MinorMatch ? Number.parseInt(gpt5MinorMatch[1], 10) : undefined;
+	const gpt5Minor = gpt5MinorMatch ? Number.parseInt(gpt5MinorMatch[1]!, 10) : undefined;
 	if (gpt5Minor !== undefined && gpt5Minor >= 2 && effort === "minimal") return "low";
 	if (id === "gpt-5.1" && effort === "xhigh") return "high";
 	if (id === "gpt-5.1-codex-mini") return effort === "high" || effort === "xhigh" ? "high" : "medium";
@@ -116,7 +116,7 @@ function buildCompactionRequestOptions(pi: ExtensionAPI, ctx: ExtensionContext, 
 	};
 }
 
-function getCompactionIdentity(entry: { details?: unknown } | undefined) {
+function getCompactionIdentity(entry: { details?: unknown | undefined } | undefined) {
 	return isNativeCompactionDetails(entry?.details)
 		? { provider: entry.details.provider, api: entry.details.api, model: entry.details.model, baseUrl: entry.details.baseUrl }
 		: undefined;
@@ -131,7 +131,7 @@ function formatCompactFailureMessage(compactResult: Awaited<ReturnType<typeof ex
 }
 
 function formatCompactRequestDiagnostics(request: NativeCompactionRequestBody): string {
-	const reasoning = isRecord(request.reasoning) && typeof request.reasoning.effort === "string" ? request.reasoning.effort : "none";
+	const reasoning = isRecord(request.reasoning) && typeof request.reasoning["effort"]! === "string" ? request.reasoning["effort"]! : "none";
 	const serviceTier = typeof request.service_tier === "string" ? request.service_tier : "none";
 	const tools = Array.isArray(request.tools) ? request.tools.length : 0;
 	return `model=${request.model}, input=${request.input.length}, tools=${tools}, reasoning=${reasoning}, service_tier=${serviceTier}`;
@@ -146,7 +146,7 @@ function textFromResponsesContent(content: unknown): string {
 	if (typeof content === "string") return content;
 	if (!Array.isArray(content)) return "";
 	return content
-		.map((item) => isRecord(item) && item.type === "input_text" && typeof item.text === "string" ? item.text : "")
+		.map((item) => isRecord(item) && item["type"] === "input_text" && typeof item["text"]! === "string" ? item["text"]! : "")
 		.join("\n");
 }
 
@@ -156,8 +156,8 @@ function isPiCompactionSummarizationPayload(payload: ResponsesCompatibleRequestP
 
 	return payload.input.some((item) => {
 		if (!isRecord(item)) return false;
-		const role = item.role;
-		const text = textFromResponsesContent(item.content);
+		const role = item["role"]!;
+		const text = textFromResponsesContent(item["content"]!);
 		if ((role === "system" || role === "developer") && /compact|summar/i.test(text)) return true;
 		if (role === "user" && /<conversation>|previous compaction summary|summary/i.test(text)) return true;
 		return false;
@@ -315,7 +315,7 @@ export async function rewriteCodexCompactedProviderRequest(payload: unknown, ctx
 	});
 	if (latestNativeCompactionIndex === undefined) return undefined;
 	if (!runtime.payload) return undefined;
-	const rewrite = rewriteResponsesPayloadWithNativeReplay({ model: runtime.currentModel, payload: runtime.payload, branchEntries, compactionEntry: branchEntries[latestNativeCompactionIndex] as NativeCompactionEntry });
+	const rewrite = rewriteResponsesPayloadWithNativeReplay({ model: runtime.currentModel, payload: runtime.payload, branchEntries, compactionEntry: branchEntries[latestNativeCompactionIndex]! as NativeCompactionEntry });
 	if (rewrite.ok) return rewrite.rewrittenPayload;
 	const detail = rewrite.parity?.mismatches.slice(0, 3).join("; ");
 	const message = `OpenAI native compaction replay failed (${rewrite.reason})${detail ? `: ${detail}` : ""}; request was not sent with placeholder compaction context.`;
@@ -344,8 +344,8 @@ export async function injectPendingNativeWindowIntoPiCompactionRequest(payload: 
 	const input = [...payload.input];
 	let insertAt = 0;
 	while (insertAt < input.length) {
-		const item = input[insertAt];
-		if (!isRecord(item) || (item.role !== "system" && item.role !== "developer")) break;
+		const item = input[insertAt]!;
+		if (!isRecord(item) || (item["role"] !== "system" && item["role"] !== "developer")) break;
 		insertAt++;
 	}
 

--- a/packages/pi-codex-conversion/src/adapter/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/config.ts
@@ -12,11 +12,11 @@ export const COMPACTION_REASONING_LEVELS: readonly CompactionReasoning[] = ["cur
 export interface CodexConversionConfig {
 	applyPatchOnly: boolean;
 	fast: boolean;
-	forceCachedWebSockets?: boolean;
+	forceCachedWebSockets?: boolean | undefined;
 	imageGeneration: boolean;
 	compactionModel: CompactionModel;
 	compactionReasoning: CompactionReasoning;
-	responsesCompaction?: boolean;
+	responsesCompaction?: boolean | undefined;
 	statusLine: boolean;
 	useOnAllModels: boolean;
 	webSearch: boolean;
@@ -72,17 +72,17 @@ export function readCodexConversionConfig(configPath: string = getCodexConversio
 		const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
 		if (!isObject(parsed)) return { ...DEFAULT_CODEX_CONVERSION_CONFIG };
 		return {
-			applyPatchOnly: typeof parsed.applyPatchOnly === "boolean" ? parsed.applyPatchOnly : DEFAULT_CODEX_CONVERSION_CONFIG.applyPatchOnly,
-			fast: typeof parsed.fast === "boolean" ? parsed.fast : DEFAULT_CODEX_CONVERSION_CONFIG.fast,
-			forceCachedWebSockets: typeof parsed.forceCachedWebSockets === "boolean" ? parsed.forceCachedWebSockets : DEFAULT_CODEX_CONVERSION_CONFIG.forceCachedWebSockets,
-			imageGeneration: typeof parsed.imageGeneration === "boolean" ? parsed.imageGeneration : DEFAULT_CODEX_CONVERSION_CONFIG.imageGeneration,
-			compactionModel: normalizeCompactionModel(parsed.compactionModel) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionModel,
-			compactionReasoning: normalizeCompactionReasoning(parsed.compactionReasoning) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionReasoning,
-			responsesCompaction: typeof parsed.responsesCompaction === "boolean" ? parsed.responsesCompaction : DEFAULT_CODEX_CONVERSION_CONFIG.responsesCompaction,
-			statusLine: typeof parsed.statusLine === "boolean" ? parsed.statusLine : DEFAULT_CODEX_CONVERSION_CONFIG.statusLine,
-			useOnAllModels: typeof parsed.useOnAllModels === "boolean" ? parsed.useOnAllModels : DEFAULT_CODEX_CONVERSION_CONFIG.useOnAllModels,
-			webSearch: typeof parsed.webSearch === "boolean" ? parsed.webSearch : DEFAULT_CODEX_CONVERSION_CONFIG.webSearch,
-			verbosity: normalizeCodexVerbosity(parsed.verbosity) ?? DEFAULT_CODEX_CONVERSION_CONFIG.verbosity,
+			applyPatchOnly: typeof parsed["applyPatchOnly"]! === "boolean" ? parsed["applyPatchOnly"]! : DEFAULT_CODEX_CONVERSION_CONFIG.applyPatchOnly,
+			fast: typeof parsed["fast"]! === "boolean" ? parsed["fast"]! : DEFAULT_CODEX_CONVERSION_CONFIG.fast,
+			forceCachedWebSockets: typeof parsed["forceCachedWebSockets"]! === "boolean" ? parsed["forceCachedWebSockets"]! : DEFAULT_CODEX_CONVERSION_CONFIG.forceCachedWebSockets,
+			imageGeneration: typeof parsed["imageGeneration"]! === "boolean" ? parsed["imageGeneration"]! : DEFAULT_CODEX_CONVERSION_CONFIG.imageGeneration,
+			compactionModel: normalizeCompactionModel(parsed["compactionModel"]!) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionModel,
+			compactionReasoning: normalizeCompactionReasoning(parsed["compactionReasoning"]!) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionReasoning,
+			responsesCompaction: typeof parsed["responsesCompaction"]! === "boolean" ? parsed["responsesCompaction"]! : DEFAULT_CODEX_CONVERSION_CONFIG.responsesCompaction,
+			statusLine: typeof parsed["statusLine"]! === "boolean" ? parsed["statusLine"]! : DEFAULT_CODEX_CONVERSION_CONFIG.statusLine,
+			useOnAllModels: typeof parsed["useOnAllModels"]! === "boolean" ? parsed["useOnAllModels"]! : DEFAULT_CODEX_CONVERSION_CONFIG.useOnAllModels,
+			webSearch: typeof parsed["webSearch"]! === "boolean" ? parsed["webSearch"]! : DEFAULT_CODEX_CONVERSION_CONFIG.webSearch,
+			verbosity: normalizeCodexVerbosity(parsed["verbosity"]!) ?? DEFAULT_CODEX_CONVERSION_CONFIG.verbosity,
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -109,10 +109,10 @@ export function writeCodexConversionConfig(
 export function applyCodexRequestParams(
 	payload: unknown,
 	config: CodexConversionConfig,
-	options: { serviceTier?: boolean; verbosity?: boolean } = { serviceTier: true, verbosity: true },
+	options: { serviceTier?: boolean | undefined; verbosity?: boolean | undefined } = { serviceTier: true, verbosity: true },
 ): unknown {
 	if (!isObject(payload)) return payload;
-	const text = isObject(payload.text) ? payload.text : {};
+	const text = isObject(payload["text"]!) ? payload["text"]! : {};
 	return {
 		...payload,
 		...(options.serviceTier && config.fast ? { service_tier: "priority" } : {}),

--- a/packages/pi-codex-conversion/src/adapter/context-filter.ts
+++ b/packages/pi-codex-conversion/src/adapter/context-filter.ts
@@ -11,7 +11,7 @@ const ADAPTER_CONTEXT_EXCLUDED_CUSTOM_MESSAGE_TYPES = new Set([
 	NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
 ]);
 
-export function isAdapterContextExcludedCustomMessage(message: Pick<AgentMessage, "role"> & { customType?: string }): boolean {
+export function isAdapterContextExcludedCustomMessage(message: Pick<AgentMessage, "role"> & { customType?: string | undefined }): boolean {
 	return message.role === "custom" && typeof message.customType === "string" && ADAPTER_CONTEXT_EXCLUDED_CUSTOM_MESSAGE_TYPES.has(message.customType);
 }
 

--- a/packages/pi-codex-conversion/src/adapter/details-store.ts
+++ b/packages/pi-codex-conversion/src/adapter/details-store.ts
@@ -5,7 +5,7 @@ import {
 	type NativeCompactionDetails,
 	type NativeCompactionEntry,
 	type NativeCompactionIdentity,
-} from "./types";
+} from "./types.js";
 
 export type NativeCompactionEntryMatch = Partial<NativeCompactionIdentity>;
 

--- a/packages/pi-codex-conversion/src/adapter/details-store.ts
+++ b/packages/pi-codex-conversion/src/adapter/details-store.ts
@@ -24,8 +24,8 @@ export type LatestNativeCompactionResolution =
 	| {
 			ok: false;
 			reason: LatestNativeCompactionResolutionFailureReason;
-			latestCompactionIndex?: number;
-			latestCompaction?: CompactionEntry;
+			latestCompactionIndex?: number | undefined;
+			latestCompaction?: CompactionEntry | undefined;
 	  };
 
 function entryMatches(entry: NativeCompactionEntry, match: NativeCompactionEntryMatch): boolean {
@@ -60,7 +60,7 @@ export function isPersistedNativeCompactionEntry(
 
 export function findLatestCompactionEntryIndex(entries: readonly SessionEntry[]): number | undefined {
 	for (let index = entries.length - 1; index >= 0; index--) {
-		if (entries[index]?.type === "compaction") {
+		if (entries[index]!?.type === "compaction") {
 			return index;
 		}
 	}
@@ -70,7 +70,7 @@ export function findLatestCompactionEntryIndex(entries: readonly SessionEntry[])
 
 export function findLatestCompactionEntry(entries: readonly SessionEntry[]): CompactionEntry | undefined {
 	const index = findLatestCompactionEntryIndex(entries);
-	return index === undefined ? undefined : (entries[index] as CompactionEntry);
+	return index === undefined ? undefined : (entries[index]! as CompactionEntry);
 }
 
 export function findLatestNativeCompactionEntryIndex(
@@ -78,7 +78,7 @@ export function findLatestNativeCompactionEntryIndex(
 	match: NativeCompactionEntryMatch = {},
 ): number | undefined {
 	for (let index = entries.length - 1; index >= 0; index--) {
-		const entry = entries[index];
+		const entry = entries[index]!;
 		if (!isPersistedNativeCompactionEntry(entry)) {
 			continue;
 		}
@@ -98,7 +98,7 @@ export function findLatestNativeCompactionEntry(
 	match: NativeCompactionEntryMatch = {},
 ): NativeCompactionEntry | undefined {
 	const index = findLatestNativeCompactionEntryIndex(entries, match);
-	return index === undefined ? undefined : (entries[index] as NativeCompactionEntry);
+	return index === undefined ? undefined : (entries[index]! as NativeCompactionEntry);
 }
 
 export function findLatestNativeCompactionDetails(
@@ -120,7 +120,7 @@ export function resolveLatestNativeCompactionEntry(
 		};
 	}
 
-	const latestCompaction = entries[latestCompactionIndex];
+	const latestCompaction = entries[latestCompactionIndex]!;
 	if (!latestCompaction || latestCompaction.type !== "compaction" || !isPersistedNativeCompactionEntry(latestCompaction)) {
 		return {
 			ok: false,

--- a/packages/pi-codex-conversion/src/adapter/payload-rewrite.ts
+++ b/packages/pi-codex-conversion/src/adapter/payload-rewrite.ts
@@ -18,7 +18,7 @@ import {
 import { isAdapterContextExcludedCustomMessageEntry } from "./context-filter.ts";
 
 export type FreshAuthoritativePreamble = {
-	instructions?: string;
+	instructions?: string | undefined;
 	leadingInput: ResponsesInputMessageItem[];
 	trailingInput: ResponsesInputMessageItem[];
 };
@@ -32,7 +32,7 @@ export type SerializedReplaySlice = {
 export type NativeReplaySegments = {
 	boundaryIndex: number;
 	firstKeptEntryIndex: number;
-	instructions?: string;
+	instructions?: string | undefined;
 	freshPreamble: ResponsesInputMessageItem[];
 	trailingPreamble: ResponsesInputMessageItem[];
 	compactionSummary: ResponsesInputItem[];
@@ -64,7 +64,7 @@ export type NativeReplayPayloadRewriteFailure = {
 		actual: string[];
 		expected: string[];
 		mismatches: string[];
-	};
+	} | undefined;
 };
 
 export type NativeReplayPayloadRewriteResult =
@@ -89,16 +89,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isResponsesInputContentItem(value: unknown): value is ResponsesInputContentItem {
-	if (!isRecord(value) || typeof value.type !== "string") {
+	if (!isRecord(value) || typeof value["type"]! !== "string") {
 		return false;
 	}
 
-	if (value.type === "input_text") {
-		return typeof value.text === "string";
+	if (value["type"] === "input_text") {
+		return typeof value["text"]! === "string";
 	}
 
-	if (value.type === "input_image") {
-		return value.detail === "auto" && typeof value.image_url === "string";
+	if (value["type"] === "input_image") {
+		return value["detail"] === "auto" && typeof value["image_url"]! === "string";
 	}
 
 	return false;
@@ -113,7 +113,7 @@ function isPreambleRole(value: ResponsesInputMessageItem["role"]): value is "dev
 }
 
 function isResponsesInputMessageItem(value: unknown): value is ResponsesInputMessageItem {
-	if (!isRecord(value) || !isResponsesInputMessageRole(value.role)) {
+	if (!isRecord(value) || !isResponsesInputMessageRole(value["role"]!)) {
 		return false;
 	}
 
@@ -210,7 +210,7 @@ function areEquivalentValues(left: unknown, right: unknown): boolean {
 		}
 
 		for (let index = 0; index < left.length; index++) {
-			if (!areEquivalentValues(left[index], right[index])) {
+			if (!areEquivalentValues(left[index]!, right[index]!)) {
 				return false;
 			}
 		}
@@ -230,7 +230,7 @@ function areEquivalentValues(left: unknown, right: unknown): boolean {
 		}
 
 		for (const key of leftKeys) {
-			if (!areEquivalentValues(left[key], right[key])) {
+			if (!areEquivalentValues(left[key]!, right[key]!)) {
 				return false;
 			}
 		}
@@ -305,17 +305,17 @@ export function extractFreshAuthoritativePreamble(
 	// or trailing position that Pi authored so provider-added suffix prompts like
 	// GPT-5's trailing developer "# Juice: 0 !important" survive replay unchanged.
 	let leadingBoundary = 0;
-	while (leadingBoundary < payload.input.length && isPromptEnvelopeItem(payload.input[leadingBoundary])) {
+	while (leadingBoundary < payload.input.length && isPromptEnvelopeItem(payload.input[leadingBoundary]!)) {
 		leadingBoundary += 1;
 	}
 
 	let trailingBoundary = payload.input.length;
-	while (trailingBoundary > leadingBoundary && isPromptEnvelopeItem(payload.input[trailingBoundary - 1])) {
+	while (trailingBoundary > leadingBoundary && isPromptEnvelopeItem((payload.input[trailingBoundary - 1])!)) {
 		trailingBoundary -= 1;
 	}
 
 	for (let index = leadingBoundary; index < trailingBoundary; index++) {
-		if (isPromptEnvelopeItem(payload.input[index])) {
+		if (isPromptEnvelopeItem(payload.input[index]!)) {
 			return undefined;
 		}
 	}

--- a/packages/pi-codex-conversion/src/adapter/payload-rewrite.ts
+++ b/packages/pi-codex-conversion/src/adapter/payload-rewrite.ts
@@ -7,14 +7,14 @@ import type {
 	SessionMessageEntry,
 } from "@earendil-works/pi-coding-agent";
 import type { ResponsesCompatibleRequestPayload } from "./compaction-runtime.ts";
-import type { NativeCompactionEntry } from "./types";
+import type { NativeCompactionEntry } from "./types.js";
 import {
 	compareResponsesInputParity,
 	serializeMessagesToResponsesInput,
 	type ResponsesInputContentItem,
 	type ResponsesInputItem,
 	type ResponsesInputMessageItem,
-} from "./serializer";
+} from "./serializer.js";
 import { isAdapterContextExcludedCustomMessageEntry } from "./context-filter.ts";
 
 export type FreshAuthoritativePreamble = {
@@ -653,10 +653,8 @@ function buildNativeReplaySegmentsInternal<TApi extends Api>(args: {
 	}
 
 	const freshPreambleCount = freshPreamble.leadingInput.length;
-	const trailingPreambleCount = freshPreamble.trailingInput.length;
 	const compactionSummaryCount = serializeMessagesToResponsesInput(args.model, [compactionSummaryMessage]).length;
 	const preCompactionKeptCount = replayMatch.preCompactionKept.input.length;
-	const tailEndIndex = args.payload.input.length - trailingPreambleCount;
 	const actualCompactionSummary = cloneResponsesInputSlice(
 		args.payload.input.slice(freshPreambleCount, freshPreambleCount + compactionSummaryCount),
 	);

--- a/packages/pi-codex-conversion/src/adapter/serializer.ts
+++ b/packages/pi-codex-conversion/src/adapter/serializer.ts
@@ -45,12 +45,12 @@ export type ResponsesAssistantOutputItem = {
 	}>;
 	status: "completed";
 	id: string;
-	phase?: AssistantPhase;
+	phase?: AssistantPhase | undefined;
 };
 
 export type ResponsesFunctionCallItem = {
 	type: "function_call";
-	id?: string;
+	id?: string | undefined;
 	call_id: string;
 	name: string;
 	arguments: string;
@@ -75,12 +75,12 @@ export type NativeCompactionRequestBody = {
 	model: string;
 	input: ResponsesInputItem[];
 	instructions: string;
-	parallel_tool_calls?: boolean;
-	prompt_cache_key?: string;
-	service_tier?: string;
-	text?: { verbosity: string };
-	tools?: unknown[];
-	reasoning?: unknown;
+	parallel_tool_calls?: boolean | undefined;
+	prompt_cache_key?: string | undefined;
+	service_tier?: string | undefined;
+	text?: { verbosity: string } | undefined;
+	tools?: unknown[] | undefined;
+	reasoning?: unknown | undefined;
 };
 
 export type NativeCompactionRequestOptions = Pick<
@@ -89,9 +89,9 @@ export type NativeCompactionRequestOptions = Pick<
 >;
 
 export type SerializeResponsesMessagesOptions = {
-	instructions?: string;
-	includeInstructionsInInput?: boolean;
-	blockImages?: boolean;
+	instructions?: string | undefined;
+	includeInstructionsInInput?: boolean | undefined;
+	blockImages?: boolean | undefined;
 };
 
 export type ResponsesParityReport = {
@@ -116,7 +116,7 @@ function readBlockImagesSetting(): boolean {
 	if (cachedBlockImagesSetting !== undefined) return cachedBlockImagesSetting;
 	try {
 		const parsed = JSON.parse(readFileSync(join(getAgentDir(), "settings.json"), "utf-8")) as unknown;
-		cachedBlockImagesSetting = isRecord(parsed) && isRecord(parsed.images) && parsed.images.blockImages === true;
+		cachedBlockImagesSetting = isRecord(parsed) && isRecord(parsed["images"]!) && parsed["images"]["blockImages"] === true;
 	} catch {
 		cachedBlockImagesSetting = false;
 	}
@@ -128,7 +128,7 @@ function replaceImagesWithDisabledPlaceholder<TMessage extends UserMessage | Too
 	const content = message.content
 		.map((item): TextContent | ImageContent => item.type === "image" ? { type: "text", text: "Image reading is disabled." } : item)
 		.filter((item, index, items) => {
-			const previous = items[index - 1];
+			const previous = (items[index - 1])!;
 			return !(item.type === "text" && item.text === "Image reading is disabled." && previous?.type === "text" && previous.text === "Image reading is disabled.");
 		});
 	return { ...message, content };
@@ -142,7 +142,7 @@ function applyBlockImages(messages: Message[], blockImages: boolean): Message[] 
 	});
 }
 
-type CompactionPreparationLike = { messagesToSummarize: AgentMessage[]; turnPrefixMessages: AgentMessage[]; previousSummary?: string };
+type CompactionPreparationLike = { messagesToSummarize: AgentMessage[]; turnPrefixMessages: AgentMessage[]; previousSummary?: string | undefined };
 
 export function collectCompactionWindowMessages(preparation: CompactionPreparationLike): AgentMessage[] {
 	const previousSummary = preparation.previousSummary?.trim();
@@ -162,7 +162,7 @@ export function serializeCompactionPreparationToRequest<TApi extends Api>(args: 
 	model: Model<TApi>;
 	preparation: CompactionPreparationLike;
 	instructions: string;
-	requestOptions?: NativeCompactionRequestOptions;
+	requestOptions?: NativeCompactionRequestOptions | undefined;
 }): NativeCompactionRequestBody {
 	return serializeMessagesToCompactRequest({
 		model: args.model,
@@ -176,7 +176,7 @@ export function serializeMessagesToCompactRequest<TApi extends Api>(args: {
 	model: Model<TApi>;
 	messages: AgentMessage[];
 	instructions: string;
-	requestOptions?: NativeCompactionRequestOptions;
+	requestOptions?: NativeCompactionRequestOptions | undefined;
 }): NativeCompactionRequestBody {
 	return {
 		model: args.model.id,
@@ -214,8 +214,8 @@ export function compareResponsesInputParity(actual: readonly unknown[], expected
 	const mismatches: string[] = [];
 
 	for (let index = 0; index < maxLength; index++) {
-		const actualValue = actualSignature[index];
-		const expectedValue = expectedSignature[index];
+		const actualValue = actualSignature[index]!;
+		const expectedValue = expectedSignature[index]!;
 		if (actualValue !== expectedValue) {
 			mismatches.push(`index ${index}: expected ${expectedValue ?? "<missing>"}, got ${actualValue ?? "<missing>"}`);
 		}
@@ -258,17 +258,17 @@ function describeResponsesInputItem(item: unknown): string {
 	}
 
 	const record = item as Record<string, unknown>;
-	const type = typeof record.type === "string" ? record.type : undefined;
+	const type = typeof record["type"]! === "string" ? record["type"]! : undefined;
 	if (type === "message") {
 		const phase =
-			record.phase === "commentary" || record.phase === "final_answer"
-				? `:${record.phase}`
+			record["phase"] === "commentary" || record["phase"] === "final_answer"
+				? `:${record["phase"]!}`
 				: "";
-		return `message:${typeof record.role === "string" ? record.role : "unknown"}${phase}`;
+		return `message:${typeof record["role"]! === "string" ? record["role"]! : "unknown"}${phase}`;
 	}
 
 	if (type === "function_call") {
-		return `function_call:${typeof record.name === "string" ? record.name : "unknown"}`;
+		return `function_call:${typeof record["name"]! === "string" ? record["name"]! : "unknown"}`;
 	}
 
 	if (type === "function_call_output") {
@@ -279,9 +279,9 @@ function describeResponsesInputItem(item: unknown): string {
 		return "reasoning";
 	}
 
-	if (typeof record.role === "string") {
-		const content = Array.isArray(record.content) ? `[${record.content.length}]` : "";
-		return `input:${record.role}${content}`;
+	if (typeof record["role"]! === "string") {
+		const content = Array.isArray(record["content"]!) ? `[${record["content"]!.length}]` : "";
+		return `input:${record["role"]!}${content}`;
 	}
 
 	return type ? `item:${type}` : "object";

--- a/packages/pi-codex-conversion/src/adapter/state.ts
+++ b/packages/pi-codex-conversion/src/adapter/state.ts
@@ -8,18 +8,18 @@ export interface PendingPiCompactionNativeWindow {
 	api: string;
 	baseUrl: string;
 	sessionId: string;
-	sourceCompactionEntryId?: string;
+	sourceCompactionEntryId?: string | undefined;
 }
 
 export interface AdapterState {
 	enabled: boolean;
 	cwd: string;
-	adapterOwnedToolNames?: string[];
-	previousToolNames?: string[];
+	adapterOwnedToolNames?: string[] | undefined;
+	previousToolNames?: string[] | undefined;
 	promptSkills: PromptSkill[];
 	config: CodexConversionConfig;
-	pendingPiCompactionNativeWindow?: PendingPiCompactionNativeWindow;
-	codexContextBudgetRawWindows?: Record<string, number>;
-	codexContextBudgetAdjustedWindows?: Record<string, number>;
-	codexContextBudgetReserveTokens?: number;
+	pendingPiCompactionNativeWindow?: PendingPiCompactionNativeWindow | undefined;
+	codexContextBudgetRawWindows?: Record<string, number> | undefined;
+	codexContextBudgetAdjustedWindows?: Record<string, number> | undefined;
+	codexContextBudgetReserveTokens?: number | undefined;
 }

--- a/packages/pi-codex-conversion/src/adapter/tool-set.ts
+++ b/packages/pi-codex-conversion/src/adapter/tool-set.ts
@@ -2,7 +2,7 @@ export const STATUS_KEY = "codex-adapter";
 export const STATUS_TEXT = "\u001b[38;2;0;76;255mCodex adapter\u001b[0m";
 export const APPLY_PATCH_ONLY_STATUS_TEXT = `${STATUS_TEXT} • apply patch only`;
 
-export function buildStatusText(options: { verbosity?: string; webSearch: boolean; imageGeneration: boolean; fast: boolean; useOnAllModels: boolean; compaction?: { enabled: boolean; model: string; reasoning: string } }): string {
+export function buildStatusText(options: { verbosity?: string | undefined; webSearch: boolean; imageGeneration: boolean; fast: boolean; useOnAllModels: boolean; compaction?: { enabled: boolean; model: string; reasoning: string } | undefined }): string {
 	const extras = [
 		options.useOnAllModels ? "all models" : undefined,
 		options.webSearch ? "web search" : undefined,

--- a/packages/pi-codex-conversion/src/adapter/types.ts
+++ b/packages/pi-codex-conversion/src/adapter/types.ts
@@ -16,9 +16,9 @@ export type NativeCompactionStrategy = typeof NATIVE_COMPACTION_STRATEGY;
 export type NativeCompactionShimSummary = typeof NATIVE_COMPACTION_SHIM_SUMMARY;
 
 export type NativeCompactionRequestMeta = {
-	tokensBefore?: number;
-	previousSummaryPresent?: boolean;
-	compactedKeptWindow?: boolean;
+	tokensBefore?: number | undefined;
+	previousSummaryPresent?: boolean | undefined;
+	compactedKeptWindow?: boolean | undefined;
 };
 
 export type NativeCompactionIdentity = {
@@ -31,18 +31,18 @@ export type NativeCompactionIdentity = {
 export type NativeCompactionDetails = NativeCompactionIdentity & {
 	strategy: NativeCompactionStrategy;
 	compactedWindow: unknown[];
-	compactResponseId?: string;
+	compactResponseId?: string | undefined;
 	createdAt: string;
-	requestMeta?: NativeCompactionRequestMeta;
+	requestMeta?: NativeCompactionRequestMeta | undefined;
 };
 
 export type NativeCompactionEntry = CompactionEntry<NativeCompactionDetails>;
 
 export type CreateNativeCompactionDetailsInput = NativeCompactionIdentity & {
 	compactedWindow: unknown[];
-	compactResponseId?: string;
-	createdAt?: string;
-	requestMeta?: NativeCompactionRequestMeta;
+	compactResponseId?: string | undefined;
+	createdAt?: string | undefined;
+	requestMeta?: NativeCompactionRequestMeta | undefined;
 };
 
 export type CreateNativeCompactionShimResultInput = {
@@ -145,10 +145,10 @@ export function isNativeCompactionIdentity(value: unknown): value is NativeCompa
 	}
 
 	return (
-		isNonEmptyString(value.provider) &&
-		isNonEmptyString(value.api) &&
-		isNonEmptyString(value.model) &&
-		isNonEmptyString(value.baseUrl)
+		isNonEmptyString(value["provider"]!) &&
+		isNonEmptyString(value["api"]!) &&
+		isNonEmptyString(value["model"]!) &&
+		isNonEmptyString(value["baseUrl"]!)
 	);
 }
 
@@ -159,21 +159,21 @@ export function isNativeCompactionDetails(value: unknown): value is NativeCompac
 	const candidate = value as Record<string, unknown>;
 
 	return (
-		candidate.strategy === NATIVE_COMPACTION_STRATEGY &&
-		isNonEmptyString(candidate.provider) &&
-		isNonEmptyString(candidate.api) &&
-		isNonEmptyString(candidate.model) &&
-		isNonEmptyString(candidate.baseUrl) &&
-		Array.isArray(candidate.compactedWindow) &&
-		candidate.compactedWindow.every(isCompactedWindowItem) &&
-		isNonEmptyString(candidate.createdAt) &&
-		(candidate.compactResponseId === undefined || isNonEmptyString(candidate.compactResponseId)) &&
-		(candidate.requestMeta === undefined || isNativeCompactionRequestMeta(candidate.requestMeta))
+		candidate["strategy"] === NATIVE_COMPACTION_STRATEGY &&
+		isNonEmptyString(candidate["provider"]!) &&
+		isNonEmptyString(candidate["api"]!) &&
+		isNonEmptyString(candidate["model"]!) &&
+		isNonEmptyString(candidate["baseUrl"]!) &&
+		Array.isArray(candidate["compactedWindow"]!) &&
+		candidate["compactedWindow"]!.every(isCompactedWindowItem) &&
+		isNonEmptyString(candidate["createdAt"]!) &&
+		(candidate["compactResponseId"] === undefined || isNonEmptyString(candidate["compactResponseId"]!)) &&
+		(candidate["requestMeta"] === undefined || isNativeCompactionRequestMeta(candidate["requestMeta"]!))
 	);
 }
 
 export function isNativeCompactionEntry(value: unknown): value is NativeCompactionEntry {
-	return isRecord(value) && value.type === "compaction" && isNativeCompactionDetails(value.details);
+	return isRecord(value) && value["type"] === "compaction" && isNativeCompactionDetails(value["details"]!);
 }
 
 export function isNativeCompactionShimSummary(value: unknown): value is NativeCompactionShimSummary {

--- a/packages/pi-codex-conversion/src/codex-settings/ui.ts
+++ b/packages/pi-codex-conversion/src/codex-settings/ui.ts
@@ -10,7 +10,7 @@ import {
 	type CodexConversionConfig,
 } from "../adapter/config.ts";
 import { CHANGELOG_URL, DISCORD_URL, GITHUB_URL, ISSUE_URL, openExternalUrl } from "./links.ts";
-import { fetchCodexUsage, formatCodexUsage, type CodexUsageSnapshot } from "./usage.ts";
+import { fetchCodexUsage, type CodexUsageSnapshot } from "./usage.ts";
 
 export interface CodexSettingsScreenOptions {
 	initialConfig: CodexConversionConfig;

--- a/packages/pi-codex-conversion/src/codex-settings/ui.ts
+++ b/packages/pi-codex-conversion/src/codex-settings/ui.ts
@@ -15,8 +15,8 @@ import { fetchCodexUsage, type CodexUsageSnapshot } from "./usage.ts";
 export interface CodexSettingsScreenOptions {
 	initialConfig: CodexConversionConfig;
 	onChange: (nextConfig: CodexConversionConfig) => boolean;
-	initialTab?: SettingsTab;
-	initialUsage?: CodexUsageSnapshot | { error: string };
+	initialTab?: SettingsTab | undefined;
+	initialUsage?: CodexUsageSnapshot | { error: string } | undefined;
 	onRefreshUsage?: () => Promise<CodexUsageSnapshot>;
 }
 
@@ -223,7 +223,7 @@ function formatUsageRow(row: string[], widths: number[]): string {
 	return `  ${row.map((cell, index) => padCell(cell, widths[index] ?? 0)).join("  ")}`;
 }
 
-function usageColumns(window: { usedPercent?: number; windowMinutes?: number; resetsAt?: number } | undefined): { bar: string; percent: string; reset: string } {
+function usageColumns(window: { usedPercent?: number | undefined; windowMinutes?: number | undefined; resetsAt?: number | undefined } | undefined): { bar: string; percent: string; reset: string } {
 	if (!window) return { bar: "—", percent: "", reset: "" };
 	const percent = window.usedPercent === undefined ? undefined : Math.max(0, Math.min(100, window.usedPercent));
 	return {

--- a/packages/pi-codex-conversion/src/codex-settings/usage.ts
+++ b/packages/pi-codex-conversion/src/codex-settings/usage.ts
@@ -7,20 +7,20 @@ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 type RuntimeModel = Model<Api>;
 
 export interface CodexUsageWindow {
-	usedPercent?: number;
-	windowMinutes?: number;
-	resetsAt?: number;
+	usedPercent?: number | undefined;
+	windowMinutes?: number | undefined;
+	resetsAt?: number | undefined;
 }
 
 export interface CodexUsageLimit {
 	limitId: string;
-	limitName?: string;
-	primary?: CodexUsageWindow;
-	secondary?: CodexUsageWindow;
+	limitName?: string | undefined;
+	primary?: CodexUsageWindow | undefined;
+	secondary?: CodexUsageWindow | undefined;
 }
 
 export interface CodexUsageSnapshot {
-	planType?: string;
+	planType?: string | undefined;
 	limits: CodexUsageLimit[];
 	raw: unknown;
 }
@@ -52,8 +52,8 @@ function extractAccountId(token: string): string | undefined {
 		const parts = token.split(".");
 		if (parts.length !== 3) return undefined;
 		const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64").toString("utf8")) as unknown;
-		const authClaims = isRecord(payload) ? payload[JWT_CLAIM_PATH] : undefined;
-		const accountId = isRecord(authClaims) ? authClaims.chatgpt_account_id : undefined;
+		const authClaims = isRecord(payload) ? payload[JWT_CLAIM_PATH]! : undefined;
+		const accountId = isRecord(authClaims) ? authClaims["chatgpt_account_id"]! : undefined;
 		return stringValue(accountId);
 	} catch {
 		return undefined;
@@ -76,18 +76,18 @@ async function buildCodexUsageHeaders(ctx: ExtensionContext, model: RuntimeModel
 
 function parseWindow(value: unknown): CodexUsageWindow | undefined {
 	if (!isRecord(value)) return undefined;
-	const usedPercent = numberValue(value.used_percent);
-	const limitWindowSeconds = numberValue(value.limit_window_seconds);
-	const windowMinutes = numberValue(value.window_minutes) ?? (limitWindowSeconds === undefined ? undefined : Math.ceil(limitWindowSeconds / 60));
-	const resetsAt = numberValue(value.resets_at) ?? numberValue(value.reset_at);
+	const usedPercent = numberValue(value["used_percent"]!);
+	const limitWindowSeconds = numberValue(value["limit_window_seconds"]!);
+	const windowMinutes = numberValue(value["window_minutes"]!) ?? (limitWindowSeconds === undefined ? undefined : Math.ceil(limitWindowSeconds / 60));
+	const resetsAt = numberValue(value["resets_at"]!) ?? numberValue(value["reset_at"]!);
 	return usedPercent === undefined && windowMinutes === undefined && resetsAt === undefined ? undefined : { usedPercent, windowMinutes, resetsAt };
 }
 
-function parseRateLimit(value: unknown): { primary?: CodexUsageWindow; secondary?: CodexUsageWindow } {
+function parseRateLimit(value: unknown): { primary?: CodexUsageWindow | undefined; secondary?: CodexUsageWindow | undefined } {
 	if (!isRecord(value)) return {};
 	return {
-		primary: parseWindow(value.primary_window) ?? parseWindow(value.primary),
-		secondary: parseWindow(value.secondary_window) ?? parseWindow(value.secondary),
+		primary: parseWindow(value["primary_window"]!) ?? parseWindow(value["primary"]!),
+		secondary: parseWindow(value["secondary_window"]!) ?? parseWindow(value["secondary"]!),
 	};
 }
 
@@ -95,7 +95,7 @@ export function parseCodexUsagePayload(payload: unknown): CodexUsageSnapshot {
 	const root = isRecord(payload) ? payload : {};
 	const limits: CodexUsageLimit[] = [];
 	const addLimit = (limitId: string, limitName: string | undefined, source: unknown) => {
-		const rateLimit = isRecord(source) && "rate_limit" in source ? source.rate_limit : source;
+		const rateLimit = isRecord(source) && "rate_limit" in source ? source["rate_limit"]! : source;
 		const parsed = parseRateLimit(rateLimit);
 		limits.push({
 			limitId,
@@ -104,14 +104,14 @@ export function parseCodexUsagePayload(payload: unknown): CodexUsageSnapshot {
 			...(parsed.secondary ? { secondary: parsed.secondary } : {}),
 		});
 	};
-	addLimit("codex", undefined, root.rate_limit);
-	if (Array.isArray(root.additional_rate_limits)) {
-		for (const item of root.additional_rate_limits) {
+	addLimit("codex", undefined, root["rate_limit"]!);
+	if (Array.isArray(root["additional_rate_limits"]!)) {
+		for (const item of root["additional_rate_limits"]!) {
 			if (!isRecord(item)) continue;
-			addLimit(stringValue(item.metered_feature) ?? "additional", stringValue(item.limit_name), item);
+			addLimit(stringValue(item["metered_feature"]!) ?? "additional", stringValue(item["limit_name"]!), item);
 		}
 	}
-	return { planType: stringValue(root.plan_type), limits, raw: payload };
+	return { planType: stringValue(root["plan_type"]!), limits, raw: payload };
 }
 
 export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsageSnapshot> {
@@ -120,7 +120,7 @@ export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsage
 	if (model.provider !== "openai-codex") {
 		throw new Error("Codex usage is only available for OpenAI Codex subscription models.");
 	}
-	const response = await fetch(buildCodexUsageUrl(), { method: "GET", headers: await buildCodexUsageHeaders(ctx, model), signal: ctx.signal });
+	const response = await fetch(buildCodexUsageUrl(), { method: "GET", headers: await buildCodexUsageHeaders(ctx, model), ...(ctx.signal ? { signal: ctx.signal } : {}) });
 	const text = await response.text();
 	if (!response.ok) throw new Error(`Usage request failed (${response.status}): ${text || response.statusText}`);
 	return parseCodexUsagePayload(JSON.parse(text));

--- a/packages/pi-codex-conversion/src/index.ts
+++ b/packages/pi-codex-conversion/src/index.ts
@@ -158,7 +158,7 @@ export default function codexConversion(pi: ExtensionAPI) {
 		return {
 			systemPrompt: buildCodexSystemPrompt(event.systemPrompt, {
 				skills,
-				shell: getCodexRuntimeShell(process.env.SHELL),
+				shell: getCodexRuntimeShell(process.env["SHELL"]),
 			}),
 		};
 	});

--- a/packages/pi-codex-conversion/src/index.ts
+++ b/packages/pi-codex-conversion/src/index.ts
@@ -158,7 +158,7 @@ export default function codexConversion(pi: ExtensionAPI) {
 		return {
 			systemPrompt: buildCodexSystemPrompt(event.systemPrompt, {
 				skills,
-				shell: getCodexRuntimeShell(process.env["SHELL"]),
+				shell: getCodexRuntimeShell(process.env["SHELL"]!),
 			}),
 		};
 	});

--- a/packages/pi-codex-conversion/src/patch/core.ts
+++ b/packages/pi-codex-conversion/src/patch/core.ts
@@ -66,7 +66,7 @@ function getUpdatedFile({ text, action, path }: { text: string; action: PatchAct
 
 		for (const line of chunk.delLines) {
 			if (!linesMatch(origLines[origIndex] ?? "", line)) {
-				throw new DiffError(`_get_updated_file: ${path}: Expected ${line} but got ${origLines[origIndex]} at line ${origIndex + 1}`);
+				throw new DiffError(`_get_updated_file: ${path}: Expected ${line} but got ${origLines[origIndex]!} at line ${origIndex + 1}`);
 			}
 			origIndex += 1;
 		}
@@ -247,7 +247,7 @@ export function executePatch({ cwd, patchText }: { cwd: string; patchText: strin
 		if (overlappingPaths.length > 0) {
 			failures.push({
 				action,
-				message: `Skipped because an earlier failed action affected ${actionPaths.filter((_, index) => overlappingPaths.includes(canonicalActionPaths[index])).join(", ")}`,
+				message: `Skipped because an earlier failed action affected ${actionPaths.filter((_, index) => overlappingPaths.includes(canonicalActionPaths[index]!)).join(", ")}`,
 			});
 			continue;
 		}
@@ -273,7 +273,7 @@ export function executePatch({ cwd, patchText }: { cwd: string; patchText: strin
 	if (failures.length > 0) {
 		const message =
 			failures.length === 1
-				? failures[0].message
+				? failures[0]!.message
 				: failures.map(({ action, message: failureMessage }) => `${action.path}: ${failureMessage}`).join("\n");
 		throw new ExecutePatchError(
 			message,

--- a/packages/pi-codex-conversion/src/patch/matching.ts
+++ b/packages/pi-codex-conversion/src/patch/matching.ts
@@ -20,7 +20,7 @@ export function linesEqualFuzz({ left, right }: { left: string[]; right: string[
 	let fuzz = 0;
 	let worstLineFuzz = 0;
 	for (let index = 0; index < left.length; index++) {
-		const lineFuzz = lineMatchFuzz(left[index], right[index]);
+		const lineFuzz = lineMatchFuzz(left[index]!, right[index]!);
 		if (lineFuzz === undefined) return undefined;
 		fuzz += lineFuzz;
 		worstLineFuzz = Math.max(worstLineFuzz, lineFuzz);

--- a/packages/pi-codex-conversion/src/patch/parser.ts
+++ b/packages/pi-codex-conversion/src/patch/parser.ts
@@ -12,13 +12,6 @@ function parserIsDone({ state, prefixes }: { state: ParserState; prefixes?: stri
 	return false;
 }
 
-function parserStartsWith({ state, prefix }: { state: ParserState; prefix: string }): boolean {
-	if (state.index >= state.lines.length) {
-		throw new DiffError(`Index: ${state.index} >= ${state.lines.length}`);
-	}
-	return state.lines[state.index].startsWith(prefix);
-}
-
 function parserReadStr({
 	state,
 	prefix,

--- a/packages/pi-codex-conversion/src/patch/parser.ts
+++ b/packages/pi-codex-conversion/src/patch/parser.ts
@@ -2,11 +2,11 @@ import { lineMatchFuzz, linesEqualFuzz } from "./matching.ts";
 import { normalizePatchPath } from "./paths.ts";
 import { DiffError, type Chunk, type ParseMode, type ParsedPatchAction, type ParserState, type PatchAction } from "./types.ts";
 
-function parserIsDone({ state, prefixes }: { state: ParserState; prefixes?: string[] }): boolean {
+function parserIsDone({ state, prefixes }: { state: ParserState; prefixes?: string[] | undefined }): boolean {
 	if (state.index >= state.lines.length) {
 		return true;
 	}
-	if (prefixes && prefixes.some((prefix) => state.lines[state.index].startsWith(prefix))) {
+	if (prefixes && prefixes.some((prefix) => state.lines[state.index]!.startsWith(prefix))) {
 		return true;
 	}
 	return false;
@@ -18,16 +18,16 @@ function parserReadStr({
 	returnEverything,
 }: {
 	state: ParserState;
-	prefix?: string;
-	returnEverything?: boolean;
+	prefix?: string | undefined;
+	returnEverything?: boolean | undefined;
 }): string {
 	if (state.index >= state.lines.length) {
 		throw new DiffError(`Index: ${state.index} >= ${state.lines.length}`);
 	}
 
 	const expectedPrefix = prefix ?? "";
-	if (state.lines[state.index].startsWith(expectedPrefix)) {
-		const text = returnEverything ? state.lines[state.index] : state.lines[state.index].slice(expectedPrefix.length);
+	if (state.lines[state.index]!.startsWith(expectedPrefix)) {
+		const text = returnEverything ? state.lines[state.index]! : state.lines[state.index]!.slice(expectedPrefix.length);
 		state.index += 1;
 		return text;
 	}
@@ -70,7 +70,7 @@ function findSectionAnchor({ lines, target, start }: { lines: string[]; target: 
 		}
 
 		for (let index = start; index < lines.length; index++) {
-			const fuzz = lineMatchFuzz(lines[index], target);
+			const fuzz = lineMatchFuzz(lines[index]!, target);
 			if (fuzz === tier) {
 				return { newIndex: index, fuzz };
 			}
@@ -117,7 +117,7 @@ function peekNextSection({ lines, index }: { lines: string[]; index: number }): 
 	const origIndex = index;
 
 	while (index < lines.length) {
-		const rawLine = lines[index];
+		const rawLine = lines[index]!;
 		if (
 			rawLine.startsWith("@@") ||
 			rawLine.startsWith("*** End Patch") ||
@@ -245,12 +245,12 @@ export function parseUpdateFile({ state, text, path }: { state: ParserState; tex
 		const defStr = parserReadStr({ state, prefix: "@@ " });
 		let sectionStr = "";
 		if (!defStr && state.index < state.lines.length && state.lines[state.index] === "@@") {
-			sectionStr = state.lines[state.index];
+			sectionStr = state.lines[state.index]!;
 			state.index += 1;
 		}
 
 		if (!(defStr || sectionStr || index === 0)) {
-			throw new DiffError(`Invalid Line:\n${state.lines[state.index]}`);
+			throw new DiffError(`Invalid Line:\n${state.lines[state.index]!}`);
 		}
 
 		if (defStr.trim().length > 0) {
@@ -299,7 +299,7 @@ const VALID_HUNK_HEADERS = [
 
 export function parsePatchActions({ text }: { text: string }): ParsedPatchAction[] {
 	const lines = text.trim().split("\n");
-	if (lines.length < 2 || !lines[0].startsWith("*** Begin Patch") || lines[lines.length - 1] !== "*** End Patch") {
+	if (lines.length < 2 || !lines[0]!.startsWith("*** Begin Patch") || lines[lines.length - 1] !== "*** End Patch") {
 		throw new DiffError("Invalid patch text");
 	}
 
@@ -308,7 +308,7 @@ export function parsePatchActions({ text }: { text: string }): ParsedPatchAction
 	let index = 1;
 
 	while (index < lines.length - 1) {
-		const line = lines[index];
+		const line = lines[index]!;
 		const lineNumber = index + 1;
 
 		if (line.startsWith("*** Update File: ")) {
@@ -319,16 +319,16 @@ export function parsePatchActions({ text }: { text: string }): ParsedPatchAction
 			seenPaths.add(updatePath);
 			index += 1;
 			let movePath: string | undefined;
-			if (index < lines.length - 1 && lines[index].startsWith("*** Move to: ")) {
-				movePath = normalizePatchPath({ path: lines[index].slice("*** Move to: ".length) });
+			if (index < lines.length - 1 && lines[index]!.startsWith("*** Move to: ")) {
+				movePath = normalizePatchPath({ path: lines[index]!.slice("*** Move to: ".length) });
 				index += 1;
 			}
 			const bodyStart = index;
 			while (
 				index < lines.length - 1 &&
-				!lines[index].startsWith("*** Update File: ") &&
-				!lines[index].startsWith("*** Delete File: ") &&
-				!lines[index].startsWith("*** Add File: ")
+				!lines[index]!.startsWith("*** Update File: ") &&
+				!lines[index]!.startsWith("*** Delete File: ") &&
+				!lines[index]!.startsWith("*** Add File: ")
 			) {
 				index += 1;
 			}

--- a/packages/pi-codex-conversion/src/patch/types.ts
+++ b/packages/pi-codex-conversion/src/patch/types.ts
@@ -9,17 +9,17 @@ export interface Chunk {
 
 export interface PatchAction {
 	type: ActionType;
-	newFile?: string;
+	newFile?: string | undefined;
 	chunks: Chunk[];
-	movePath?: string;
+	movePath?: string | undefined;
 }
 
 export interface ParsedPatchAction {
 	type: ActionType;
 	path: string;
-	newFile?: string;
-	lines?: string[];
-	movePath?: string;
+	newFile?: string | undefined;
+	lines?: string[] | undefined;
+	movePath?: string | undefined;
 }
 
 export interface ParserState {
@@ -50,7 +50,7 @@ export class DiffError extends Error {
 
 export class ExecutePatchError extends DiffError {
 	result: ExecutePatchResult;
-	failedAction?: ParsedPatchAction;
+	failedAction?: ParsedPatchAction | undefined;
 	failures: ExecutePatchFailure[];
 
 	constructor(message: string, result: ExecutePatchResult, failures: ExecutePatchFailure[] = []) {
@@ -58,7 +58,7 @@ export class ExecutePatchError extends DiffError {
 		this.name = "ExecutePatchError";
 		this.result = result;
 		this.failures = failures;
-		this.failedAction = failures[0]?.action;
+		this.failedAction = failures[0]!?.action;
 	}
 
 	hasPartialSuccess(): boolean {

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -8,7 +8,7 @@ export interface StructuredPromptSkill {
 	name: string;
 	description: string;
 	filePath: string;
-	disableModelInvocation?: boolean;
+	disableModelInvocation?: boolean | undefined;
 }
 
 const CODEX_GUIDELINES = [
@@ -52,14 +52,14 @@ export function extractPiPromptSkills(prompt: string): PromptSkill[] {
 		return [];
 	}
 
-	const skillMatches = skillsBlockMatch[1].matchAll(
+	const skillMatches = skillsBlockMatch[1]!.matchAll(
 		/<skill>\n\s*<name>([\s\S]*?)<\/name>\n\s*<description>([\s\S]*?)<\/description>\n\s*<location>([\s\S]*?)<\/location>\n\s*<\/skill>/g,
 	);
 
 	return Array.from(skillMatches, (match) => ({
-		name: decodeXml(match[1].trim()),
-		description: decodeXml(match[2].trim()),
-		filePath: decodeXml(match[3].trim()),
+		name: decodeXml(match[1]!.trim()),
+		description: decodeXml(match[2]!.trim()),
+		filePath: decodeXml(match[3]!.trim()),
 	}));
 }
 
@@ -118,7 +118,7 @@ function injectGuidelines(prompt: string): string {
 		return insertBeforeTrailingContext(prompt, fallbackSection);
 	}
 
-	const [, header, body, suffix] = match;
+	const [, header, body, suffix] = match as RegExpMatchArray & { 1: string; 2: string; 3: string };
 	const existingLines = body
 		.split("\n")
 		.map((line) => line.trim())
@@ -131,9 +131,9 @@ function injectGuidelines(prompt: string): string {
 
 	const normalizedBody = body.trimEnd();
 	const replacement = `${header}${normalizedBody}\n${additions.join("\n")}${suffix}`;
-	return `${prompt.slice(0, match.index)}${replacement}${prompt.slice(match.index + match[0].length)}`;
+	return `${prompt.slice(0, match.index)}${replacement}${prompt.slice(match.index + match[0]!.length)}`;
 }
 
-export function buildCodexSystemPrompt(basePrompt: string, options: { skills?: PromptSkill[]; shell?: string } = {}): string {
+export function buildCodexSystemPrompt(basePrompt: string, options: { skills?: PromptSkill[] | undefined; shell?: string | undefined } = {}): string {
 	return injectShell(injectSkills(injectGuidelines(basePrompt), options.skills ?? []), options.shell);
 }

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -243,18 +243,6 @@ function normalizeImageOutputFormat(value: string | undefined): string {
 	return format === "png" || format === "jpg" || format === "jpeg" || format === "webp" ? format : "png";
 }
 
-function shortHash(str: string): string {
-	let h1 = 0xdeadbeef;
-	let h2 = 0x41c6ce57;
-	for (let i = 0; i < str.length; i++) {
-		const ch = str.charCodeAt(i);
-		h1 = Math.imul(h1 ^ ch, 2654435761);
-		h2 = Math.imul(h2 ^ ch, 1597334677);
-	}
-	h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-	h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-	return (h2 >>> 0).toString(36) + (h1 >>> 0).toString(36);
-}
 
 function normalizePath(value: string): string {
 	if (!value) return ".";
@@ -737,7 +725,7 @@ async function getWebSocketConstructor(): Promise<WebSocketConstructorLike | nul
 	if (
 		typeof process !== "undefined" &&
 		process.versions?.bun &&
-		(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
+		(process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"] || process.env["http_proxy"] || process.env["https_proxy"])
 	) {
 		const module = await dynamicImport("proxy-from-env");
 		const getProxyForUrl = (module as { getProxyForUrl: (url: string | object | URL) => string }).getProxyForUrl;
@@ -1373,7 +1361,7 @@ async function processWebSocketStream<TApi extends Api>(
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options?.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
 
 	for (let attempt = 0; attempt < 2; attempt++) {
-		const { socket, entry, reused, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal, websocketConnectTimeoutMs);
+		const { socket, entry, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal, websocketConnectTimeoutMs);
 		let keepConnection = true;
 		let released = false;
 		let eventCount = 0;
@@ -1664,7 +1652,7 @@ export function buildProviderErrorMessage(error: unknown): string {
 	return message;
 }
 
-function finalizeUsage<TApi extends Api>(model: Model<TApi>, output: AssistantMessage): void {
+function finalizeUsage<TApi extends Api>(_model: Model<TApi>, output: AssistantMessage): void {
 	output.usage.cost.total = output.usage.cost.input + output.usage.cost.output + output.usage.cost.cacheRead + output.usage.cost.cacheWrite;
 }
 

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -51,7 +51,7 @@ function clampOpenAIPromptCacheKey(key: string | undefined): string | undefined 
 }
 let _os: { platform(): string; release(): string; arch(): string } | null = null;
 
-if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
+if (typeof process !== "undefined" && (process.versions?.node || process.versions["bun"]!)) {
 	dynamicImport("node:os")
 		.then((module) => {
 			_os = module;
@@ -69,7 +69,7 @@ interface SavedGeneratedImage {
 	responseId: string | undefined;
 	callId: string;
 	outputFormat: string;
-	revisedPrompt?: string;
+	revisedPrompt?: string | undefined;
 }
 
 interface ImageDisplayMessageDetails {
@@ -87,10 +87,10 @@ interface QueuedImageActivity extends PendingImageDisplay {
 
 interface SurfacedWebSearch {
 	callId: string;
-	status?: string;
-	query?: string;
+	status?: string | undefined;
+	query?: string | undefined;
 	queries: string[];
-	sources: Array<{ title?: string; url: string }>;
+	sources: Array<{ title?: string | undefined; url: string }>;
 }
 
 interface QueuedWebSearchActivity {
@@ -107,7 +107,7 @@ interface CachedImagePreview {
 }
 
 interface WebSocketLike {
-	readyState?: number;
+	readyState?: number | undefined;
 	send(data: string): void;
 	close(code?: number, reason?: string): void;
 	addEventListener(type: string, listener: (event: unknown) => void): void;
@@ -115,21 +115,21 @@ interface WebSocketLike {
 }
 
 interface WebSocketConstructorLike {
-	new (url: string, options?: { headers?: Record<string, string> } | string | string[]): WebSocketLike;
+	new (url: string, options?: { headers?: Record<string, string> | undefined } | string | string[]): WebSocketLike;
 }
 
 interface SessionWebSocketCacheEntry {
 	socket: WebSocketLike;
 	busy: boolean;
-	idleTimer?: ReturnType<typeof setTimeout>;
-	continuation?: CachedWebSocketContinuationState;
+	idleTimer?: ReturnType<typeof setTimeout> | undefined;
+	continuation?: CachedWebSocketContinuationState | undefined;
 }
 
 interface AcquiredWebSocket {
 	socket: WebSocketLike;
-	entry?: SessionWebSocketCacheEntry;
+	entry?: SessionWebSocketCacheEntry | undefined;
 	reused: boolean;
-	release: (options?: { keep?: boolean }) => void;
+	release: (options?: { keep?: boolean | undefined }) => void;
 }
 
 export interface CachedWebSocketContinuationState {
@@ -153,11 +153,11 @@ export interface CachedWebSocketRequestBodyResult {
 	decision: WebSocketContinuationDecision;
 }
 
-type CodexProviderStreamOptions = SimpleStreamOptions & { serviceTier?: ServiceTier; textVerbosity?: string; reasoningSummary?: string };
+type CodexProviderStreamOptions = SimpleStreamOptions & { serviceTier?: ServiceTier | undefined; textVerbosity?: string | undefined; reasoningSummary?: string | undefined };
 type CodexReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 type OpenAICodexStreamOptions = CodexProviderStreamOptions & {
-	reasoningEffort?: CodexReasoningEffort;
-	websocketConnectTimeoutMs?: number;
+	reasoningEffort?: CodexReasoningEffort | undefined;
+	websocketConnectTimeoutMs?: number | undefined;
 };
 
 let fsPromisesPromise: Promise<typeof import("node:fs/promises")> | undefined;
@@ -169,35 +169,35 @@ export interface ResponsesBody {
 	model: string;
 	store: boolean;
 	stream: boolean;
-	instructions?: string;
-	previous_response_id?: string;
+	instructions?: string | undefined;
+	previous_response_id?: string | undefined;
 	input: unknown[];
 	text: { verbosity: string };
 	include: string[];
-	prompt_cache_key?: string;
+	prompt_cache_key?: string | undefined;
 	tool_choice: "auto";
 	parallel_tool_calls: boolean;
-	temperature?: number;
-	service_tier?: string;
-	tools?: unknown[];
+	temperature?: number | undefined;
+	service_tier?: string | undefined;
+	tools?: unknown[] | undefined;
 	reasoning?: {
 		effort: string;
 		summary: string;
-	};
+	} | undefined;
 	[key: string]: unknown;
 }
 
 interface ResponseEnvelope {
-	id?: string;
-	status?: string;
+	id?: string | undefined;
+	status?: string | undefined;
 	usage?: {
-		input_tokens?: number;
-		output_tokens?: number;
-		total_tokens?: number;
-		input_tokens_details?: { cached_tokens?: number };
-	};
-	service_tier?: string;
-	error?: { message?: string };
+		input_tokens?: number | undefined;
+		output_tokens?: number | undefined;
+		total_tokens?: number | undefined;
+		input_tokens_details?: { cached_tokens?: number | undefined } | undefined;
+	} | undefined;
+	service_tier?: string | undefined;
+	error?: { message?: string | undefined } | undefined;
 	[key: string]: unknown;
 }
 
@@ -207,19 +207,19 @@ const websocketSessionCache = new Map<string, SessionWebSocketCacheEntry>();
 class NonRetryableProviderError extends Error {}
 
 interface StreamEventShape {
-	type?: string;
-	response?: ResponseEnvelope;
+	type?: string | undefined;
+	response?: ResponseEnvelope | undefined;
 	item?: {
-		id?: string;
-		type?: string;
-		result?: string | null;
-		output_format?: string;
-		revised_prompt?: string;
-		status?: string;
+		id?: string | undefined;
+		type?: string | undefined;
+		result?: string | null | undefined;
+		output_format?: string | undefined;
+		revised_prompt?: string | undefined;
+		status?: string | undefined;
 		[key: string]: unknown;
-	};
-	code?: string;
-	message?: string;
+	} | undefined;
+	code?: string | undefined;
+	message?: string | undefined;
 	[key: string]: unknown;
 }
 
@@ -255,7 +255,7 @@ function joinPaths(...parts: string[]): string {
 	if (parts.length === 0) return ".";
 	let result = parts[0] ?? "";
 	for (let i = 1; i < parts.length; i++) {
-		const part = parts[i];
+		const part = parts[i]!;
 		if (!part) continue;
 		if (!result || result.endsWith(PATH_SEPARATOR)) {
 			result += part.replace(/^\/+/, "");
@@ -288,7 +288,7 @@ function relativePath(from: string, to: string): string {
 	const fromSegments = splitPathSegments(normalizedFrom);
 	const toSegments = splitPathSegments(normalizedTo);
 	let shared = 0;
-	while (shared < fromSegments.length && shared < toSegments.length && fromSegments[shared] === toSegments[shared]) {
+	while (shared < fromSegments.length && shared < toSegments.length && fromSegments[shared] === toSegments[shared]!) {
 		shared++;
 	}
 	const upSegments = new Array(fromSegments.length - shared).fill("..");
@@ -304,16 +304,17 @@ async function getNodeFsPromises(): Promise<typeof import("node:fs/promises")> {
 }
 
 function getNodeFsSync(): { readFileSync(path: string): Buffer } | null {
-	if (typeof process === "undefined" || !(process.versions?.node || process.versions?.bun)) {
+	if (typeof process === "undefined" || !(process.versions?.node || process.versions["bun"]!)) {
 		return null;
 	}
-	const builtinProcess = process as typeof process & { getBuiltinModule?: (specifier: string) => unknown };
+	const builtinProcess = process as typeof process & { getBuiltinModule?: (specifier: string) => unknown | undefined };
 	if (typeof builtinProcess.getBuiltinModule !== "function") {
 		return null;
 	}
 	try {
-		const module = builtinProcess.getBuiltinModule("node:fs") as { readFileSync?: (path: string) => Buffer } | undefined;
-		return typeof module?.readFileSync === "function" ? { readFileSync: module.readFileSync } : null;
+		const module = builtinProcess.getBuiltinModule("node:fs") as { readFileSync?: unknown } | undefined;
+		if (typeof module?.readFileSync !== "function") return null;
+		return { readFileSync: module.readFileSync as (path: string) => Buffer };
 	} catch {
 		return null;
 	}
@@ -367,7 +368,7 @@ export function getOpenAICodexLatestImagePath(cwd: string): string {
 	return joinPaths(getOpenAICodexImageDirectory(cwd), OPENAI_CODEX_LATEST_IMAGE_NAME);
 }
 
-export function buildGeneratedImageDisplayText(savedImage: SavedGeneratedImage, options?: { expanded?: boolean }): string {
+export function buildGeneratedImageDisplayText(savedImage: SavedGeneratedImage, options?: { expanded?: boolean | undefined }): string {
 	const lines: string[] = [];
 	if (options?.expanded && savedImage.revisedPrompt) {
 		lines.push(`Prompt: ${savedImage.revisedPrompt}`);
@@ -378,7 +379,7 @@ export function buildGeneratedImageDisplayText(savedImage: SavedGeneratedImage, 
 
 export async function saveOpenAICodexGeneratedImage(
 	cwd: string,
-	image: { responseId?: string; callId: string; result: string; outputFormat?: string; revisedPrompt?: string },
+	image: { responseId?: string | undefined; callId: string; result: string; outputFormat?: string | undefined; revisedPrompt?: string | undefined },
 ): Promise<SavedGeneratedImage> {
 	const workspaceRoot = await resolveWorkspaceRoot(cwd);
 	const fs = await getNodeFsPromises();
@@ -507,7 +508,7 @@ function clampReasoningEffort(modelId: string, effort: string): string {
 	if (effort === "none") return effort;
 	const id = modelId.includes("/") ? (modelId.split("/").pop() ?? modelId) : modelId;
 	const gpt5MinorMatch = /^gpt-5\.(\d+)/.exec(id);
-	const gpt5Minor = gpt5MinorMatch ? Number.parseInt(gpt5MinorMatch[1], 10) : undefined;
+	const gpt5Minor = gpt5MinorMatch ? Number.parseInt(gpt5MinorMatch[1]!, 10) : undefined;
 	if (gpt5Minor !== undefined && gpt5Minor >= 2 && effort === "minimal") return "low";
 	if (id === "gpt-5.1" && effort === "xhigh") return "high";
 	if (id === "gpt-5.1-codex-mini") return effort === "high" || effort === "xhigh" ? "high" : "medium";
@@ -553,7 +554,7 @@ export function buildRequestBody<TApi extends Api>(model: Model<TApi>, context: 
 		stream: true,
 		instructions: context.systemPrompt || "You are a helpful assistant.",
 		input: messages,
-		text: { verbosity: ((options as { textVerbosity?: string } | undefined)?.textVerbosity ?? "low") as string },
+		text: { verbosity: ((options as { textVerbosity?: string | undefined } | undefined)?.textVerbosity ?? "low") as string },
 		include: ["reasoning.encrypted_content"],
 		prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
 		tool_choice: "auto",
@@ -565,11 +566,11 @@ export function buildRequestBody<TApi extends Api>(model: Model<TApi>, context: 
 	// `maxTokens`, so forwarding it breaks `/tree` summaries and extensions that
 	// use `ctx.navigateTree(..., { summarize: true })`.
 
-	if ((options as { temperature?: number } | undefined)?.temperature !== undefined) {
-		body.temperature = (options as { temperature?: number }).temperature;
+	if ((options as { temperature?: number | undefined } | undefined)?.temperature !== undefined) {
+		body.temperature = (options as { temperature?: number | undefined }).temperature;
 	}
 
-	const serviceTier = (options as { serviceTier?: string } | undefined)?.serviceTier;
+	const serviceTier = (options as { serviceTier?: string | undefined } | undefined)?.serviceTier;
 	if (serviceTier !== undefined) {
 		body.service_tier = serviceTier;
 	}
@@ -589,7 +590,7 @@ export function buildRequestBody<TApi extends Api>(model: Model<TApi>, context: 
 		if (effort === null) return body;
 		body.reasoning = {
 			effort: clampReasoningEffort(model.id, effort),
-			summary: ((options as { reasoningSummary?: string } | undefined)?.reasoningSummary ?? "auto") as string,
+			summary: ((options as { reasoningSummary?: string | undefined } | undefined)?.reasoningSummary ?? "auto") as string,
 		};
 	}
 
@@ -724,13 +725,13 @@ async function getWebSocketConstructor(): Promise<WebSocketConstructorLike | nul
 	if (_cachedWebSocket) return _cachedWebSocket;
 	if (
 		typeof process !== "undefined" &&
-		process.versions?.bun &&
-		(process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"] || process.env["http_proxy"] || process.env["https_proxy"])
+		process.versions["bun"]! &&
+		(process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"]! || process.env["http_proxy"]! || process.env["https_proxy"]!)
 	) {
 		const module = await dynamicImport("proxy-from-env");
 		const getProxyForUrl = (module as { getProxyForUrl: (url: string | object | URL) => string }).getProxyForUrl;
 		_cachedWebSocket = class extends WebSocket {
-			constructor(url: string, options?: { headers?: Record<string, string> } | string | string[]) {
+			constructor(url: string, options?: { headers?: Record<string, string> | undefined } | string | string[]) {
 				const proxy = getProxyForUrl(url.replace(/^wss:/, "https:").replace(/^ws:/, "http:"));
 				const baseOptions = Array.isArray(options) || typeof options === "string" ? { protocols: options } : { ...options };
 				super(url, { ...baseOptions, ...(proxy ? { proxy } : {}) } as never);
@@ -738,7 +739,7 @@ async function getWebSocketConstructor(): Promise<WebSocketConstructorLike | nul
 		};
 		return _cachedWebSocket;
 	}
-	const ctor = (globalThis as typeof globalThis & { WebSocket?: WebSocketConstructorLike }).WebSocket;
+	const ctor = (globalThis as typeof globalThis & { WebSocket?: WebSocketConstructorLike | undefined }).WebSocket;
 	return typeof ctor === "function" ? ctor : null;
 }
 
@@ -795,7 +796,7 @@ function scheduleSessionWebSocketExpiry(cacheKey: string, entry: SessionWebSocke
 
 function extractWebSocketError(event: unknown): Error {
 	if (event && typeof event === "object" && "message" in event) {
-		const message = (event as { message?: unknown }).message;
+		const message = (event as { message?: unknown | undefined }).message;
 		if (typeof message === "string" && message.length > 0) {
 			return new Error(message);
 		}
@@ -805,8 +806,8 @@ function extractWebSocketError(event: unknown): Error {
 
 function extractWebSocketCloseError(event: unknown): Error {
 	if (event && typeof event === "object") {
-		const code = "code" in event ? (event as { code?: unknown }).code : undefined;
-		const reason = "reason" in event ? (event as { reason?: unknown }).reason : undefined;
+		const code = "code" in event ? (event as { code?: unknown | undefined }).code : undefined;
+		const reason = "reason" in event ? (event as { reason?: unknown | undefined }).reason : undefined;
 		const codeText = typeof code === "number" ? ` ${code}` : "";
 		let reasonText = typeof reason === "string" && reason.length > 0 ? ` ${reason}` : "";
 		if (!reasonText && code === WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE) {
@@ -1012,7 +1013,7 @@ function requestBodiesMatchExceptInput(a: ResponsesBody, b: ResponsesBody): bool
 	return JSON.stringify(requestBodyForWebSocketContinuationComparison(a)) === JSON.stringify(requestBodyForWebSocketContinuationComparison(b));
 }
 
-function getCachedWebSocketInputDelta(body: ResponsesBody, continuation: CachedWebSocketContinuationState): { delta?: unknown[]; decision: WebSocketContinuationDecision } {
+function getCachedWebSocketInputDelta(body: ResponsesBody, continuation: CachedWebSocketContinuationState): { delta?: unknown[] | undefined; decision: WebSocketContinuationDecision } {
 	if (!requestBodiesMatchExceptInput(body, continuation.lastRequestBody)) {
 		return { decision: "body_mismatch" };
 	}
@@ -1077,7 +1078,7 @@ async function* parseWebSocket(socket: WebSocketLike, signal: AbortSignal | unde
 		messageChain = messageChain
 			.then(async () => {
 				if (!event || typeof event !== "object" || !("data" in event)) return;
-				const text = await decodeWebSocketData((event as { data?: unknown }).data);
+				const text = await decodeWebSocketData((event as { data?: unknown | undefined }).data);
 				if (!text) return;
 				try {
 					const parsed = JSON.parse(text) as StreamEventShape;
@@ -1244,7 +1245,7 @@ function normalizeCodexStatus(status: string | undefined): string | undefined {
 
 function getLatestUserText(context: Context): string | undefined {
 	for (let i = context.messages.length - 1; i >= 0; i--) {
-		const message = context.messages[i];
+		const message = context.messages[i]!;
 		if (message.role !== "user") continue;
 		if (typeof message.content === "string") {
 			const trimmed = message.content.trim();
@@ -1265,9 +1266,9 @@ async function* captureGeneratedImages(
 	events: AsyncIterable<StreamEventShape>,
 	options: {
 		cwd: string;
-		requestPrompt?: string;
+		requestPrompt?: string | undefined;
 		onImageSaved: (image: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void;
-		onWebSearchCaptured?: (search: SurfacedWebSearch) => void;
+		onWebSearchCaptured?: (search: SurfacedWebSearch) => void | undefined;
 	},
 ): AsyncIterable<StreamEventShape> {
 	let responseId: string | undefined;
@@ -1320,8 +1321,8 @@ async function processCapturedResponsesStream<TApi extends Api>(
 	model: Model<TApi>,
 	options: OpenAICodexStreamOptions | undefined,
 	deps: {
-		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void;
-		onWebSearchCaptured?: (search: SurfacedWebSearch) => void;
+		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void | undefined;
+		onWebSearchCaptured?: (search: SurfacedWebSearch) => void | undefined;
 	},
 	cwd: string,
 	requestPrompt: string | undefined,
@@ -1334,7 +1335,7 @@ async function processCapturedResponsesStream<TApi extends Api>(
 	});
 
 	await processResponsesStream(tappedEvents as AsyncIterable<never>, output, stream, model, {
-		serviceTier: (options as { serviceTier?: ServiceTier } | undefined)?.serviceTier,
+		serviceTier: (options as { serviceTier?: ServiceTier | undefined } | undefined)?.serviceTier,
 		resolveServiceTier: resolveCodexServiceTier,
 		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model as Model<Api>),
 	});
@@ -1350,8 +1351,8 @@ async function processWebSocketStream<TApi extends Api>(
 	onStart: () => void,
 	options: SimpleStreamOptions | undefined,
 	deps: {
-		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void;
-		onWebSearchCaptured?: (search: SurfacedWebSearch) => void;
+		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void | undefined;
+		onWebSearchCaptured?: (search: SurfacedWebSearch) => void | undefined;
 	},
 	cwd: string,
 	requestPrompt: string | undefined,
@@ -1365,7 +1366,7 @@ async function processWebSocketStream<TApi extends Api>(
 		let keepConnection = true;
 		let released = false;
 		let eventCount = 0;
-		const transport = (options as { transport?: string } | undefined)?.transport ?? "auto";
+		const transport = (options as { transport?: string | undefined } | undefined)?.transport ?? "auto";
 		const useCachedContext = transport === "websocket-cached" || transport === "auto";
 		// ChatGPT Codex Responses rejects `store: true` ("Store must be set to false").
 		// WebSocket continuation still works via connection-scoped previous_response_id state.
@@ -1375,7 +1376,7 @@ async function processWebSocketStream<TApi extends Api>(
 			: { body: fullBody, decision: useCachedContext ? "no_session_cache_entry" : "disabled" } satisfies CachedWebSocketRequestBodyResult;
 		const requestBody = cachedRequest.body;
 
-		const releaseOnce = (releaseOptions?: { keep?: boolean }) => {
+		const releaseOnce = (releaseOptions?: { keep?: boolean | undefined }) => {
 			if (released) return;
 			released = true;
 			release(releaseOptions);
@@ -1408,7 +1409,7 @@ async function processWebSocketStream<TApi extends Api>(
 			} else if (useCachedContext && entry && output.responseId) {
 				const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
 					includeSystemPrompt: false,
-				}).filter((item) => typeof item === "object" && item !== null && (item as { type?: unknown }).type !== "function_call_output");
+				}).filter((item) => typeof item === "object" && item !== null && (item as { type?: unknown | undefined }).type !== "function_call_output");
 				entry.continuation = {
 					lastRequestBody: fullBody,
 					lastResponseId: output.responseId,
@@ -1441,33 +1442,33 @@ function extractWebSearch(item: StreamEventShape["item"]): SurfacedWebSearch | u
 	const callId = typeof item.id === "string" ? item.id : undefined;
 	if (!callId) return undefined;
 
-	const action = typeof item.action === "object" && item.action !== null ? (item.action as Record<string, unknown>) : undefined;
-	const query = typeof action?.query === "string" ? action.query : undefined;
-	const queries = Array.isArray(action?.queries) ? action.queries.filter((value): value is string => typeof value === "string") : [];
-	const sourceUrls = Array.isArray(action?.sources)
-		? action.sources
+	const action = typeof item["action"]! === "object" && item["action"] !== null ? (item["action"]! as Record<string, unknown>) : undefined;
+	const query = typeof action?.["query"] === "string" ? action["query"]! : undefined;
+	const queries = Array.isArray(action?.["queries"]) ? action["queries"]!.filter((value): value is string => typeof value === "string") : [];
+	const sourceUrls = Array.isArray(action?.["sources"])
+		? action["sources"]!
 				.map((source) => (typeof source === "object" && source !== null ? (source as Record<string, unknown>) : undefined))
-				.map((source) => (typeof source?.url === "string" ? source.url : undefined))
+				.map((source) => (typeof source?.["url"] === "string" ? source["url"]! : undefined))
 				.filter((url): url is string => typeof url === "string")
 		: [];
 
-	const results = Array.isArray(item.results)
-		? item.results
+	const results = Array.isArray(item["results"]!)
+		? item["results"]!
 				.map((result) => (typeof result === "object" && result !== null ? (result as Record<string, unknown>) : undefined))
 				.filter((result): result is Record<string, unknown> => !!result)
 		: [];
 
-	const titledSources: Array<{ title?: string; url: string }> = [];
+	const titledSources: Array<{ title?: string | undefined; url: string }> = [];
 	for (const result of results) {
-		if (typeof result.url !== "string") continue;
+		if (typeof result["url"]! !== "string") continue;
 		titledSources.push({
-			title: typeof result.title === "string" ? result.title : undefined,
-			url: result.url,
+			title: typeof result["title"]! === "string" ? result["title"]! : undefined,
+			url: result["url"]!,
 		});
 	}
 
 	const seenUrls = new Set<string>();
-	const sources: Array<{ title?: string; url: string }> = [];
+	const sources: Array<{ title?: string | undefined; url: string }> = [];
 	for (const source of titledSources) {
 		if (seenUrls.has(source.url)) continue;
 		seenUrls.add(source.url);
@@ -1521,7 +1522,7 @@ function sendActivityMessages(
 	activities: PendingActivity[],
 ): void {
 	for (let index = 0; index < activities.length; index++) {
-		const activity = activities[index];
+		const activity = activities[index]!;
 		if (activity.kind === "image") {
 			imagePreviewCache.set(activity.savedImage.absolutePath, activity.imageData);
 			sendMessage(
@@ -1537,8 +1538,8 @@ function sendActivityMessages(
 		}
 
 		const searches = [activity.search];
-		while (index + 1 < activities.length && activities[index + 1]?.kind === "web-search") {
-			searches.push((activities[++index] as QueuedWebSearchActivity).search);
+		while (index + 1 < activities.length && (activities[index + 1])!?.kind === "web-search") {
+			searches.push((activities[++index]! as QueuedWebSearchActivity).search);
 		}
 		sendMessage(
 			{
@@ -1636,7 +1637,7 @@ function createInitialAssistantMessage<TApi extends Api>(model: Model<TApi>): As
 function createErrorMessage(message: AssistantMessage, error: unknown, aborted: boolean): AssistantMessage {
 	for (const block of message.content) {
 		if (typeof block === "object" && block !== null && "partialJson" in block) {
-			delete (block as { partialJson?: string }).partialJson;
+			delete (block as { partialJson?: string | undefined }).partialJson;
 		}
 	}
 	message.stopReason = aborted ? "aborted" : "error";
@@ -1656,13 +1657,13 @@ function finalizeUsage<TApi extends Api>(_model: Model<TApi>, output: AssistantM
 	output.usage.cost.total = output.usage.cost.input + output.usage.cost.output + output.usage.cost.cacheRead + output.usage.cost.cacheWrite;
 }
 
-async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string }> {
+async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string | undefined }> {
 	const raw = await response.text();
 	let message = raw || response.statusText || "Request failed";
 	let friendlyMessage: string | undefined;
 
 	try {
-		const parsed = JSON.parse(raw) as { error?: { code?: string; type?: string; plan_type?: string; resets_at?: number; message?: string } };
+		const parsed = JSON.parse(raw) as { error?: { code?: string | undefined; type?: string | undefined; plan_type?: string | undefined; resets_at?: number | undefined; message?: string | undefined } | undefined };
 		const err = parsed?.error;
 		if (err) {
 			const code = err.code || err.type || "";
@@ -1697,11 +1698,11 @@ function createCodexStream<TApi extends Api>(
 	options: CodexProviderStreamOptions | undefined,
 	deps: {
 		getCurrentCwd: () => string;
-		getConfig?: () => Pick<CodexConversionConfig, "forceCachedWebSockets">;
-		getNativeToolRewriteConfig?: () => { webSearch: boolean; imageGeneration: boolean };
-		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void;
-		onWebSearchCaptured?: (search: SurfacedWebSearch) => void;
-		onStreamSettled?: () => void;
+		getConfig?: () => Pick<CodexConversionConfig, "forceCachedWebSockets"> | undefined;
+		getNativeToolRewriteConfig?: () => { webSearch: boolean; imageGeneration: boolean } | undefined;
+		onImageSaved?: (savedImage: SavedGeneratedImage, imageData: { data: string; mimeType: string }) => void | undefined;
+		onWebSearchCaptured?: (search: SurfacedWebSearch) => void | undefined;
+		onStreamSettled?: () => void | undefined;
 	},
 ): AssistantMessageEventStream {
 	const effectiveTransport = getEffectiveCodexTransport(options?.transport, deps.getConfig?.());
@@ -1878,7 +1879,7 @@ function createCodexStream<TApi extends Api>(
 	return stream;
 }
 
-export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { getCurrentCwd: () => string; getConfig?: () => Pick<CodexConversionConfig, "forceCachedWebSockets">; getNativeToolRewriteConfig?: () => { webSearch: boolean; imageGeneration: boolean } }): void {
+export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { getCurrentCwd: () => string; getConfig?: () => Pick<CodexConversionConfig, "forceCachedWebSockets"> | undefined; getNativeToolRewriteConfig?: () => { webSearch: boolean; imageGeneration: boolean } | undefined }): void {
 	const activityDispatcher = createActivityMessageDispatcher(pi.sendMessage.bind(pi));
 
 	const clearPendingMessages = () => {
@@ -1891,8 +1892,8 @@ export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { g
 			const turnActivities: PendingActivity[] = [];
 			return createCodexStream(model, context, streamOptions, {
 				getCurrentCwd: options.getCurrentCwd,
-				getConfig: options.getConfig,
-				getNativeToolRewriteConfig: options.getNativeToolRewriteConfig,
+				...(options.getConfig ? { getConfig: options.getConfig } : {}),
+				...(options.getNativeToolRewriteConfig ? { getNativeToolRewriteConfig: options.getNativeToolRewriteConfig } : {}),
 				onImageSaved: (savedImage, imageData) => {
 					turnActivities.push({ kind: "image", savedImage, imageData });
 				},
@@ -1946,7 +1947,7 @@ export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { g
 		return box;
 	});
 
-	pi.registerMessageRenderer<{ searches?: SurfacedWebSearch[] }>(WEB_SEARCH_ACTIVITY_MESSAGE_TYPE, (message, options, theme) => {
+	pi.registerMessageRenderer<{ searches?: SurfacedWebSearch[] | undefined }>(WEB_SEARCH_ACTIVITY_MESSAGE_TYPE, (message, options, theme) => {
 		const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
 		const searches = message.details?.searches ?? [];
 		box.addChild(new Text(theme.fg("customMessageLabel", theme.bold(buildWebSearchSummaryText(searches))), 0, 0));

--- a/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
@@ -3,7 +3,6 @@ import type { ResponseCreateParamsStreaming, ResponseInput, ResponseStreamEvent,
 import { parse as partialParse } from "partial-json";
 import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
 
-type MessageRole = Context["messages"][number]["role"];
 type Message = Context["messages"][number];
 
 interface ImageGenerationCallItem {

--- a/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
@@ -10,7 +10,7 @@ interface ImageGenerationCallItem {
 	id: string;
 	status: string;
 	result: string | null;
-	revised_prompt?: string;
+	revised_prompt?: string | undefined;
 }
 
 interface ImageGenerationCallBlock {
@@ -21,7 +21,7 @@ interface ImageGenerationCallBlock {
 type InternalAssistantContent = Extract<Message, { role: "assistant" }>["content"][number] | ImageGenerationCallBlock;
 
 export interface OpenAIResponsesStreamOptions {
-	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+	serviceTier?: ResponseCreateParamsStreaming["service_tier"] | undefined;
 	resolveServiceTier?: (
 		responseServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
 		requestServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
@@ -32,11 +32,11 @@ export interface OpenAIResponsesStreamOptions {
 type TextSignaturePhase = "commentary" | "final_answer";
 
 interface ConvertResponsesMessagesOptions {
-	includeSystemPrompt?: boolean;
+	includeSystemPrompt?: boolean | undefined;
 }
 
 interface ConvertResponsesToolsOptions {
-	strict?: boolean | null;
+	strict?: boolean | null | undefined;
 }
 
 export const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
@@ -78,17 +78,17 @@ function isImageGenerationCallBlock(block: InternalAssistantContent): block is I
 function sanitizeImageGenerationCallItem(item: unknown): ImageGenerationCallItem | undefined {
 	if (!item || typeof item !== "object") return undefined;
 	const candidate = item as Record<string, unknown>;
-	if (candidate.type !== "image_generation_call") return undefined;
-	if (typeof candidate.id !== "string" || candidate.id === "") return undefined;
-	if (typeof candidate.status !== "string" || candidate.status === "") return undefined;
-	if (!(typeof candidate.result === "string" || candidate.result === null)) return undefined;
+	if (candidate["type"] !== "image_generation_call") return undefined;
+	if (typeof candidate["id"]! !== "string" || candidate["id"] === "") return undefined;
+	if (typeof candidate["status"]! !== "string" || candidate["status"] === "") return undefined;
+	if (!(typeof candidate["result"]! === "string" || candidate["result"] === null)) return undefined;
 
 	return {
 		type: "image_generation_call",
-		id: candidate.id,
-		status: candidate.status,
-		result: candidate.result,
-		...(typeof candidate.revised_prompt === "string" ? { revised_prompt: candidate.revised_prompt } : {}),
+		id: candidate["id"]!,
+		status: candidate["status"]!,
+		result: candidate["result"]!,
+		...(typeof candidate["revised_prompt"]! === "string" ? { revised_prompt: candidate["revised_prompt"]! } : {}),
 	};
 }
 
@@ -229,16 +229,16 @@ function transformMessages(
 }
 
 function encodeTextSignatureV1(id: string, phase?: string): string {
-	const payload: { v: 1; id: string; phase?: string } = { v: 1, id };
+	const payload: { v: 1; id: string; phase?: string | undefined } = { v: 1, id };
 	if (phase) payload.phase = phase;
 	return JSON.stringify(payload);
 }
 
-function parseTextSignature(signature: string | undefined): { id: string; phase?: TextSignaturePhase } | undefined {
+function parseTextSignature(signature: string | undefined): { id: string; phase?: TextSignaturePhase | undefined } | undefined {
 	if (!signature) return undefined;
 	if (signature.startsWith("{")) {
 		try {
-			const parsed = JSON.parse(signature) as { v?: number; id?: string; phase?: TextSignaturePhase | string };
+			const parsed = JSON.parse(signature) as { v?: number | undefined; id?: string | undefined; phase?: TextSignaturePhase | string | undefined };
 			if (parsed.v === 1 && typeof parsed.id === "string") {
 				return parsed.phase === "commentary" || parsed.phase === "final_answer"
 					? { id: parsed.id, phase: parsed.phase }
@@ -270,7 +270,7 @@ export function convertResponsesMessages<TApi extends Api>(
 	const normalizeToolCallId = (id: string, _targetModel: Model<TApi>, source: Extract<Message, { role: "assistant" }>) => {
 		if (!allowedToolCallProviders.has(model.provider)) return normalizeIdPart(id);
 		if (!id.includes("|")) return normalizeIdPart(id);
-		const [callId, itemId] = id.split("|");
+		const [callId, itemId] = id.split("|") as [string, string | undefined];
 		const normalizedCallId = normalizeIdPart(callId);
 		const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
 		let normalizedItemId = isForeignToolCall ? buildForeignResponsesItemId(itemId ?? "") : normalizeIdPart(itemId ?? "");
@@ -351,7 +351,7 @@ export function convertResponsesMessages<TApi extends Api>(
 							})),
 					]
 				: sanitizeSurrogates(hasText ? textResult : "(see attached image)");
-			messages.push({ type: "function_call_output", call_id: callId, output });
+			messages.push({ type: "function_call_output", call_id: callId!, output });
 		}
 		msgIndex++;
 	}
@@ -381,7 +381,7 @@ export async function processResponsesStream<TApi extends Api>(
 	const blockIndex = () => blocks.length - 1;
 	type ThinkingBlock = Extract<AssistantMessage["content"][number], { type: "thinking" }>;
 	type TextBlock = Extract<AssistantMessage["content"][number], { type: "text" }>;
-	type ToolCallBlock = Extract<AssistantMessage["content"][number], { type: "toolCall" }> & { partialJson?: string };
+	type ToolCallBlock = Extract<AssistantMessage["content"][number], { type: "toolCall" }> & { partialJson?: string | undefined };
 
 	type ReasoningState = {
 		kind: "reasoning";
@@ -637,7 +637,7 @@ export async function processResponsesStream<TApi extends Api>(
 			throw new Error(details || "Unknown error");
 		} else if (event.type === "response.failed") {
 			const error = event.response?.error;
-			const details = (event.response as { incomplete_details?: { reason?: string } } | undefined)?.incomplete_details;
+			const details = (event.response as { incomplete_details?: { reason?: string | undefined } | undefined } | undefined)?.incomplete_details;
 			const msg = error
 				? `${error.code || "unknown"}: ${error.message || "no message"}`
 				: details?.reason

--- a/packages/pi-codex-conversion/src/shell/bash.ts
+++ b/packages/pi-codex-conversion/src/shell/bash.ts
@@ -11,7 +11,7 @@ export function hasBashAstSupport(): boolean {
 
 export function extractBashCommand(command: string[]): [shell: string, script: string] | undefined {
 	if (command.length !== 3) return undefined;
-	const [shell, flag, script] = command;
+	const [shell, flag, script] = command as [string, string, string];
 	if (flag !== "-lc" && flag !== "-c") return undefined;
 	const shellName = shell.replace(/\\/g, "/").split("/").pop()?.toLowerCase();
 	if (shellName !== "bash" && shellName !== "zsh" && shellName !== "sh") return undefined;

--- a/packages/pi-codex-conversion/src/shell/parse-command.ts
+++ b/packages/pi-codex-conversion/src/shell/parse-command.ts
@@ -11,8 +11,8 @@ import {
 
 export type ParsedShellCommand =
 	| { kind: "read"; command: string; name: string; path: string }
-	| { kind: "list"; command: string; path?: string }
-	| { kind: "search"; command: string; query?: string; path?: string }
+	| { kind: "list"; command: string; path?: string | undefined }
+	| { kind: "search"; command: string; query?: string | undefined; path?: string | undefined }
 	| { kind: "unknown"; command: string };
 
 export function parseCommandString(command: string): ParsedShellCommand[] {
@@ -23,7 +23,7 @@ export function parseCommandTokens(command: string[]): ParsedShellCommand[] {
 	const parsed = parseCommandImpl(command);
 	const deduped: ParsedShellCommand[] = [];
 	for (const part of parsed) {
-		const previous = deduped[deduped.length - 1];
+		const previous = (deduped[deduped.length - 1])!;
 		if (previous && JSON.stringify(previous) === JSON.stringify(part)) continue;
 		deduped.push(part);
 	}
@@ -39,7 +39,7 @@ function parseCommandImpl(command: string[]): ParsedShellCommand[] {
 
 	const powerShellScript = extractPowerShellCommand(command);
 	if (powerShellScript) {
-		return [{ kind: "unknown", command: powerShellScript[1] }];
+		return [{ kind: "unknown", command: powerShellScript[1]! }];
 	}
 
 	const normalized = normalizeTokens(command);
@@ -78,7 +78,7 @@ function parseCommandImpl(command: string[]): ParsedShellCommand[] {
 
 function singleUnknownForCommand(command: string[]): ParsedShellCommand {
 	const shell = extractShellCommand(command);
-	if (shell) return { kind: "unknown", command: shell[1] };
+	if (shell) return { kind: "unknown", command: shell[1]! };
 	return { kind: "unknown", command: joinCommandTokens(command) };
 }
 
@@ -88,13 +88,13 @@ function extractShellCommand(command: string[]): [shell: string, script: string]
 
 function extractPowerShellCommand(command: string[]): [shell: string, script: string] | undefined {
 	if (command.length < 3) return undefined;
-	const shell = command[0];
+	const shell = command[0]!;
 	const shellName = shell.replace(/\\/g, "/").split("/").pop()?.toLowerCase();
 	if (shellName !== "powershell" && shellName !== "powershell.exe" && shellName !== "pwsh" && shellName !== "pwsh.exe") {
 		return undefined;
 	}
 	for (let index = 1; index + 1 < command.length; index++) {
-		const flag = command[index]?.toLowerCase();
+		const flag = command[index]!?.toLowerCase();
 		if (flag !== "-nologo" && flag !== "-noprofile" && flag !== "-command" && flag !== "-c") {
 			return undefined;
 		}
@@ -181,8 +181,8 @@ function containsConnectors(tokens: string[]): boolean {
 function simplifyOnce(commands: ParsedShellCommand[]): ParsedShellCommand[] | undefined {
 	if (commands.length <= 1) return undefined;
 
-	if (commands[0]?.kind === "unknown") {
-		const tokens = shellSplit(commands[0].command);
+	if (commands[0]!?.kind === "unknown") {
+		const tokens = shellSplit(commands[0]!.command);
 		if (tokens[0] === "echo") return commands.slice(1);
 	}
 
@@ -210,7 +210,7 @@ function simplifyOnce(commands: ParsedShellCommand[]): ParsedShellCommand[] | un
 
 export function isSmallFormattingCommand(tokens: string[]): boolean {
 	if (tokens.length === 0) return false;
-	const command = tokens[0];
+	const command = tokens[0]!;
 	if (command === "wc" || command === "tr" || command === "cut" || command === "sort" || command === "uniq" || command === "tee" || command === "column" || command === "yes" || command === "printf") {
 		return true;
 	}
@@ -265,9 +265,9 @@ function summarizeMainTokens(mainCommand: string[]): ParsedShellCommand {
 		const candidates = skipFlagValues(args, ["-g", "--glob", "--iglob", "-t", "--type", "--type-add", "--type-not", "-m", "--max-count", "-A", "-B", "-C", "--context", "--max-depth"]);
 		const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 		if (hasFilesFlag) {
-			return { kind: "list", command: joinCommandTokens(mainCommand), path: nonFlags[0] ? shortDisplayPath(nonFlags[0]) : undefined };
+			return { kind: "list", command: joinCommandTokens(mainCommand), path: nonFlags[0]! ? shortDisplayPath(nonFlags[0]!) : undefined };
 		}
-		return { kind: "search", command: joinCommandTokens(mainCommand), query: nonFlags[0], path: nonFlags[1] ? shortDisplayPath(nonFlags[1]) : undefined };
+		return { kind: "search", command: joinCommandTokens(mainCommand), query: nonFlags[0]!, path: nonFlags[1]! ? shortDisplayPath(nonFlags[1]!) : undefined };
 	}
 	if (head === "git") {
 		const [subcommand, ...subtail] = tail;
@@ -291,7 +291,7 @@ function summarizeMainTokens(mainCommand: string[]): ParsedShellCommand {
 		const args = trimAtConnector(tail);
 		const candidates = skipFlagValues(args, ["-G", "-g", "--file-search-regex", "--ignore-dir", "--ignore-file", "--path-to-ignore"]);
 		const nonFlags = candidates.filter((token) => !token.startsWith("-"));
-		return { kind: "search", command: joinCommandTokens(mainCommand), query: nonFlags[0], path: nonFlags[1] ? shortDisplayPath(nonFlags[1]) : undefined };
+		return { kind: "search", command: joinCommandTokens(mainCommand), query: nonFlags[0]!, path: nonFlags[1]! ? shortDisplayPath(nonFlags[1]!) : undefined };
 	}
 	if (head === "cat") {
 		const path = singleNonFlagOperand(tail, []);
@@ -352,12 +352,12 @@ function parseGrepLike(mainCommand: string[], args: string[]): ParsedShellComman
 			continue;
 		}
 		if (arg === "-e" || arg === "--regexp") {
-			if (!pattern) pattern = trimmed[index + 1];
+			if (!pattern) pattern = (trimmed[index + 1])!;
 			index += 1;
 			continue;
 		}
 		if (arg === "-f" || arg === "--file") {
-			if (!pattern) pattern = trimmed[index + 1];
+			if (!pattern) pattern = (trimmed[index + 1])!;
 			index += 1;
 			continue;
 		}
@@ -369,9 +369,9 @@ function parseGrepLike(mainCommand: string[], args: string[]): ParsedShellComman
 		operands.push(arg);
 	}
 	const hasPattern = pattern !== undefined;
-	const query = pattern ?? operands[0];
+	const query = pattern ?? operands[0]!;
 	const pathIndex = hasPattern ? 0 : 1;
-	return { kind: "search", command: joinCommandTokens(mainCommand), query, path: operands[pathIndex] ? shortDisplayPath(operands[pathIndex]!) : undefined };
+	return { kind: "search", command: joinCommandTokens(mainCommand), query, path: operands[pathIndex]! ? shortDisplayPath(operands[pathIndex]!) : undefined };
 }
 
 function readCommand(mainCommand: string[], path: string): ParsedShellCommand {
@@ -436,12 +436,12 @@ function positionalOperands(args: string[], flagsWithValues: string[]): string[]
 }
 
 function firstNonFlagOperand(args: string[], flagsWithValues: string[]): string | undefined {
-	return positionalOperands(args, flagsWithValues)[0];
+	return (positionalOperands(args, flagsWithValues)[0])!;
 }
 
 function singleNonFlagOperand(args: string[], flagsWithValues: string[]): string | undefined {
 	const operands = positionalOperands(args, flagsWithValues);
-	return operands.length === 1 ? operands[0] : undefined;
+	return operands.length === 1 ? operands[0]! : undefined;
 }
 
 function awkDataFileOperand(args: string[]): string | undefined {
@@ -450,15 +450,15 @@ function awkDataFileOperand(args: string[]): string | undefined {
 	const hasScriptFile = trimmed.some((arg) => arg === "-f" || arg === "--file");
 	const candidates = skipFlagValues(trimmed, ["-F", "-v", "-f", "--field-separator", "--assign", "--file"]);
 	const nonFlags = candidates.filter((arg) => !arg.startsWith("-"));
-	if (hasScriptFile) return nonFlags[0];
-	return nonFlags.length >= 2 ? nonFlags[1] : undefined;
+	if (hasScriptFile) return nonFlags[0]!;
+	return nonFlags.length >= 2 ? nonFlags[1]! : undefined;
 }
 
 function pythonWalksFiles(args: string[]): boolean {
 	const trimmed = trimAtConnector(args);
 	for (let index = 0; index < trimmed.length; index++) {
 		if (trimmed[index] !== "-c") continue;
-		const script = trimmed[index + 1];
+		const script = (trimmed[index + 1])!;
 		if (!script) continue;
 		return script.includes("os.walk") || script.includes("os.listdir") || script.includes("os.scandir") || script.includes("glob.glob") || script.includes("glob.iglob") || script.includes("pathlib.Path") || script.includes(".rglob(");
 	}
@@ -474,7 +474,7 @@ function cdTarget(args: string[]): string | undefined {
 	let target: string | undefined;
 	for (let index = 0; index < args.length; index++) {
 		const arg = args[index]!;
-		if (arg === "--") return args[index + 1];
+		if (arg === "--") return (args[index + 1])!;
 		if (arg === "-L" || arg === "-P") continue;
 		if (arg.startsWith("-")) continue;
 		target = arg;
@@ -491,9 +491,9 @@ function parseFdQueryAndPath(args: string[]): [string | undefined, string | unde
 	const candidates = skipFlagValues(trimmed, ["-t", "--type", "-e", "--extension", "-E", "--exclude", "--search-path"]);
 	const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 	if (nonFlags.length === 1) {
-		return isPathish(nonFlags[0]!) ? [undefined, shortDisplayPath(nonFlags[0]!)] : [nonFlags[0], undefined];
+		return isPathish(nonFlags[0]!) ? [undefined, shortDisplayPath(nonFlags[0]!)] : [nonFlags[0]!, undefined];
 	}
-	if (nonFlags.length >= 2) return [nonFlags[0], shortDisplayPath(nonFlags[1]!)];
+	if (nonFlags.length >= 2) return [nonFlags[0]!, shortDisplayPath(nonFlags[1]!)];
 	return [undefined, undefined];
 }
 
@@ -510,7 +510,7 @@ function parseFindQueryAndPath(args: string[]): [string | undefined, string | un
 	for (let index = 0; index < trimmed.length; index++) {
 		const arg = trimmed[index]!;
 		if (arg === "-name" || arg === "-iname" || arg === "-path" || arg === "-regex") {
-			query = trimmed[index + 1];
+			query = (trimmed[index + 1])!;
 			break;
 		}
 	}
@@ -518,9 +518,9 @@ function parseFindQueryAndPath(args: string[]): [string | undefined, string | un
 }
 
 function readPathFromHeadTail(args: string[], tool: "head" | "tail"): string | undefined {
-	if (args.length === 1 && !args[0]!.startsWith("-")) return args[0];
+	if (args.length === 1 && !args[0]!.startsWith("-")) return args[0]!;
 	if (tool === "head") {
-		const hasValidN = args[0] === "-n" ? /^[0-9]+$/.test(args[1] ?? "") : (args[0]?.startsWith("-n") ?? false) && /^[0-9]+$/.test(args[0]!.slice(2));
+		const hasValidN = args[0] === "-n" ? /^[0-9]+$/.test(args[1] ?? "") : (args[0]!?.startsWith("-n") ?? false) && /^[0-9]+$/.test(args[0]!.slice(2));
 		if (hasValidN) {
 			const candidates: string[] = [];
 			for (let index = 0; index < args.length; index++) {
@@ -536,7 +536,7 @@ function readPathFromHeadTail(args: string[], tool: "head" | "tail"): string | u
 	}
 	const hasValidN = args[0] === "-n"
 		? /^\+?[0-9]+$/.test(args[1] ?? "")
-		: (args[0]?.startsWith("-n") ?? false) && /^\+?[0-9]+$/.test(args[0]!.slice(2));
+		: (args[0]!?.startsWith("-n") ?? false) && /^\+?[0-9]+$/.test(args[0]!.slice(2));
 	if (hasValidN) {
 		const candidates: string[] = [];
 		for (let index = 0; index < args.length; index++) {
@@ -564,7 +564,7 @@ function sedReadPath(args: string[]): string | undefined {
 	let hasRangeScript = false;
 	for (let index = 0; index < trimmed.length; index++) {
 		const token = trimmed[index]!;
-		if ((token === "-e" || token === "--expression") && isValidSedRange(trimmed[index + 1])) {
+		if ((token === "-e" || token === "--expression") && isValidSedRange((trimmed[index + 1])!)) {
 			hasRangeScript = true;
 		}
 		if (!token.startsWith("-") && isValidSedRange(token)) {
@@ -575,8 +575,8 @@ function sedReadPath(args: string[]): string | undefined {
 	const candidates = skipFlagValues(trimmed, ["-e", "-f", "--expression", "--file"]);
 	const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 	if (nonFlags.length === 0) return undefined;
-	if (isValidSedRange(nonFlags[0])) return nonFlags[1];
-	return nonFlags[0];
+	if (isValidSedRange(nonFlags[0]!)) return nonFlags[1]!;
+	return nonFlags[0]!;
 }
 
 function isMutatingXargsCommand(tokens: string[]): boolean {

--- a/packages/pi-codex-conversion/src/shell/parse.ts
+++ b/packages/pi-codex-conversion/src/shell/parse.ts
@@ -53,15 +53,15 @@ export function isSmallFormattingCommand(tokens: string[]): boolean {
 	}
 	if (head === "head") {
 		if (tail.length === 0) return true;
-		if (tail.length === 1) return tail[0].startsWith("-");
-		if (tail.length === 2 && (tail[0] === "-n" || tail[0] === "-c") && /^\d+$/.test(tail[1])) return true;
+		if (tail.length === 1) return tail[0]!.startsWith("-");
+		if (tail.length === 2 && (tail[0] === "-n" || tail[0] === "-c") && /^\d+$/.test(tail[1]!)) return true;
 		return false;
 	}
 	if (head === "tail") {
 		if (tail.length === 0) return true;
-		if (tail.length === 1) return tail[0].startsWith("-");
+		if (tail.length === 1) return tail[0]!.startsWith("-");
 		if (tail.length === 2 && (tail[0] === "-n" || tail[0] === "-c")) {
-			const value = tail[1]?.startsWith("+") ? tail[1].slice(1) : tail[1];
+			const value = tail[1]!?.startsWith("+") ? tail[1]!.slice(1) : tail[1]!;
 			if (value && /^\d+$/.test(value)) return true;
 		}
 		return false;
@@ -137,14 +137,14 @@ function parseMainTokens(tokens: string[]): ShellAction | null {
 		]);
 		const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 		if (hasFilesFlag) {
-			const path = nonFlags[0];
+			const path = nonFlags[0]!;
 			return { kind: "list", command, path: path ? shortDisplayPath(path) : undefined };
 		}
 		return {
 			kind: "search",
 			command,
-			query: nonFlags[0],
-			path: nonFlags[1] ? shortDisplayPath(nonFlags[1]) : undefined,
+			query: nonFlags[0]!,
+			path: nonFlags[1]! ? shortDisplayPath(nonFlags[1]!) : undefined,
 		};
 	}
 
@@ -184,8 +184,8 @@ function parseMainTokens(tokens: string[]): ShellAction | null {
 		return {
 			kind: "search",
 			command,
-			query: nonFlags[0],
-			path: nonFlags[1] ? shortDisplayPath(nonFlags[1]) : undefined,
+			query: nonFlags[0]!,
+			path: nonFlags[1]! ? shortDisplayPath(nonFlags[1]!) : undefined,
 		};
 	}
 
@@ -269,7 +269,7 @@ function parseGrepLike(command: string, tail: string[]): ShellAction {
 	let afterDoubleDash = false;
 
 	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
+		const arg = args[index]!;
 		if (afterDoubleDash) {
 			operands.push(arg);
 			continue;
@@ -279,12 +279,12 @@ function parseGrepLike(command: string, tail: string[]): ShellAction {
 			continue;
 		}
 		if (arg === "-e" || arg === "--regexp") {
-			if (!pattern) pattern = args[index + 1];
+			if (!pattern) pattern = (args[index + 1])!;
 			index += 1;
 			continue;
 		}
 		if (arg === "-f" || arg === "--file") {
-			if (!pattern) pattern = args[index + 1];
+			if (!pattern) pattern = (args[index + 1])!;
 			index += 1;
 			continue;
 		}
@@ -306,9 +306,9 @@ function parseGrepLike(command: string, tail: string[]): ShellAction {
 	}
 
 	const hasPattern = pattern !== undefined;
-	const query = pattern ?? operands[0];
+	const query = pattern ?? operands[0]!;
 	const pathIndex = hasPattern ? 0 : 1;
-	const path = operands[pathIndex] ? shortDisplayPath(operands[pathIndex]) : undefined;
+	const path = operands[pathIndex]! ? shortDisplayPath(operands[pathIndex]!) : undefined;
 
 	return { kind: "search", command, query, path };
 }
@@ -318,11 +318,11 @@ function parseFdQueryAndPath(tail: string[]): [string | undefined, string | unde
 	const candidates = skipFlagValues(args, ["-t", "--type", "-e", "--extension", "-E", "--exclude", "--search-path"]);
 	const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 	if (nonFlags.length === 1) {
-		if (isPathish(nonFlags[0])) return [undefined, shortDisplayPath(nonFlags[0])];
-		return [nonFlags[0], undefined];
+		if (isPathish(nonFlags[0]!)) return [undefined, shortDisplayPath(nonFlags[0]!)];
+		return [nonFlags[0]!, undefined];
 	}
 	if (nonFlags.length >= 2) {
-		return [nonFlags[0], shortDisplayPath(nonFlags[1])];
+		return [nonFlags[0]!, shortDisplayPath(nonFlags[1]!)];
 	}
 	return [undefined, undefined];
 }
@@ -339,9 +339,9 @@ function parseFindQueryAndPath(tail: string[]): [string | undefined, string | un
 
 	let query: string | undefined;
 	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
+		const arg = args[index]!;
 		if (arg === "-name" || arg === "-iname" || arg === "-path" || arg === "-regex") {
-			query = args[index + 1];
+			query = (args[index + 1])!;
 			break;
 		}
 	}
@@ -359,14 +359,14 @@ function readAction(command: string, path: string): ShellAction {
 }
 
 function readPathFromHeadTail(args: string[], tool: "head" | "tail"): string | undefined {
-	if (args.length === 1 && !args[0].startsWith("-")) {
-		return args[0];
+	if (args.length === 1 && !args[0]!.startsWith("-")) {
+		return args[0]!;
 	}
 
 	const tokens = trimAtConnector(args);
 	let index = 0;
 	while (index < tokens.length) {
-		const token = tokens[index];
+		const token = tokens[index]!;
 		if (!token) break;
 		if (!token.startsWith("-")) {
 			return token;
@@ -391,8 +391,8 @@ function sedReadPath(args: string[]): string | undefined {
 
 	let hasRangeScript = false;
 	for (let index = 0; index < tokens.length; index++) {
-		const token = tokens[index];
-		if ((token === "-e" || token === "--expression") && isValidSedRange(tokens[index + 1])) {
+		const token = tokens[index]!;
+		if ((token === "-e" || token === "--expression") && isValidSedRange((tokens[index + 1])!)) {
 			hasRangeScript = true;
 		}
 		if (!token.startsWith("-") && isValidSedRange(token)) {
@@ -404,8 +404,8 @@ function sedReadPath(args: string[]): string | undefined {
 	const candidates = skipFlagValues(tokens, ["-e", "-f", "--expression", "--file"]);
 	const nonFlags = candidates.filter((token) => !token.startsWith("-"));
 	if (nonFlags.length === 0) return undefined;
-	if (isValidSedRange(nonFlags[0])) return nonFlags[1];
-	return nonFlags[0];
+	if (isValidSedRange(nonFlags[0]!)) return nonFlags[1]!;
+	return nonFlags[0]!;
 }
 
 function isValidSedRange(value: string | undefined): boolean {
@@ -424,7 +424,7 @@ function skipFlagValues(args: string[], flagsWithValues: string[]): string[] {
 	const out: string[] = [];
 	let skipNext = false;
 	for (let index = 0; index < args.length; index++) {
-		const token = args[index];
+		const token = args[index]!;
 		if (skipNext) {
 			skipNext = false;
 			continue;
@@ -450,7 +450,7 @@ function positionalOperands(args: string[], flagsWithValues: string[]): string[]
 	let afterDoubleDash = false;
 	let skipNext = false;
 	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
+		const arg = args[index]!;
 		if (skipNext) {
 			skipNext = false;
 			continue;
@@ -477,12 +477,12 @@ function positionalOperands(args: string[], flagsWithValues: string[]): string[]
 }
 
 function firstNonFlagOperand(args: string[], flagsWithValues: string[]): string | undefined {
-	return positionalOperands(args, flagsWithValues)[0];
+	return (positionalOperands(args, flagsWithValues)[0])!;
 }
 
 function singleNonFlagOperand(args: string[], flagsWithValues: string[]): string | undefined {
 	const operands = positionalOperands(args, flagsWithValues);
-	return operands.length === 1 ? operands[0] : undefined;
+	return operands.length === 1 ? operands[0]! : undefined;
 }
 
 function awkDataFileOperand(args: string[]): string | undefined {
@@ -491,15 +491,15 @@ function awkDataFileOperand(args: string[]): string | undefined {
 	const hasScriptFile = tokens.some((arg) => arg === "-f" || arg === "--file");
 	const candidates = skipFlagValues(tokens, ["-F", "-v", "-f", "--field-separator", "--assign", "--file"]);
 	const nonFlags = candidates.filter((arg) => !arg.startsWith("-"));
-	if (hasScriptFile) return nonFlags[0];
-	return nonFlags.length >= 2 ? nonFlags[1] : undefined;
+	if (hasScriptFile) return nonFlags[0]!;
+	return nonFlags.length >= 2 ? nonFlags[1]! : undefined;
 }
 
 function pythonWalksFiles(args: string[]): boolean {
 	const tokens = trimAtConnector(args);
 	for (let index = 0; index < tokens.length; index++) {
 		if (tokens[index] !== "-c") continue;
-		const script = tokens[index + 1];
+		const script = (tokens[index + 1])!;
 		if (!script) continue;
 		return (
 			script.includes("os.walk") ||
@@ -541,7 +541,7 @@ function xargsIsMutatingSubcommand(tokens: string[]): boolean {
 function xargsSubcommand(tokens: string[]): string[] | undefined {
 	let index = 0;
 	while (index < tokens.length) {
-		const token = tokens[index];
+		const token = tokens[index]!;
 		if (token === "--") return tokens.slice(index + 1);
 		if (!token.startsWith("-")) return tokens.slice(index);
 		const takesValue = token === "-E" || token === "-e" || token === "-I" || token === "-L" || token === "-n" || token === "-P" || token === "-s";
@@ -558,8 +558,8 @@ function cdTarget(args: string[]): string | undefined {
 	if (args.length === 0) return undefined;
 	let target: string | undefined;
 	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
-		if (arg === "--") return args[index + 1];
+		const arg = args[index]!;
+		if (arg === "--") return (args[index + 1])!;
 		if (arg === "-L" || arg === "-P") continue;
 		if (arg.startsWith("-")) continue;
 		target = arg;

--- a/packages/pi-codex-conversion/src/shell/tokenize.ts
+++ b/packages/pi-codex-conversion/src/shell/tokenize.ts
@@ -14,8 +14,8 @@ export function shellSplit(input: string): string[] {
 	};
 
 	for (let index = 0; index < input.length; index++) {
-		const char = input[index];
-		const next = input[index + 1];
+		const char = input[index]!;
+		const next = (input[index + 1])!;
 
 		if (escaping) {
 			current += char;
@@ -109,13 +109,13 @@ export function normalizeTokens(tokens: string[]): string[] {
 	if (tokens.length >= 3 && (tokens[0] === "yes" || tokens[0] === "y" || tokens[0] === "no" || tokens[0] === "n") && tokens[1] === "|") {
 		return normalizeTokens(tokens.slice(2));
 	}
-	const shell = tokens[0]?.replace(/\\/g, "/").split("/").pop();
+	const shell = tokens[0]!?.replace(/\\/g, "/").split("/").pop();
 	if (
 		tokens.length === 3 &&
 		(shell === "bash" || shell === "zsh" || shell === "sh") &&
 		(tokens[1] === "-c" || tokens[1] === "-lc")
 	) {
-		return normalizeTokens(shellSplit(tokens[2]));
+		return normalizeTokens(shellSplit(tokens[2]!));
 	}
 	return tokens;
 }

--- a/packages/pi-codex-conversion/src/shell/types.ts
+++ b/packages/pi-codex-conversion/src/shell/types.ts
@@ -1,7 +1,7 @@
 export type ShellAction =
 	| { kind: "read"; command: string; name: string; path: string }
-	| { kind: "list"; command: string; path?: string }
-	| { kind: "search"; command: string; query?: string; path?: string }
+	| { kind: "list"; command: string; path?: string | undefined }
+	| { kind: "search"; command: string; query?: string | undefined; path?: string | undefined }
 	| { kind: "run"; command: string };
 
 export interface CommandSummary {

--- a/packages/pi-codex-conversion/src/tools/apply-patch-binary.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch-binary.ts
@@ -12,10 +12,10 @@ export function ensureBundledApplyPatchOnPath(env: NodeJS.ProcessEnv = process.e
 	if (!existsSync(wrapperPath)) {
 		return undefined;
 	}
-	const currentPath = env.PATH ?? "";
+	const currentPath = env["PATH"] ?? "";
 	const entries = currentPath.split(delimiter).filter(Boolean);
 	if (!entries.includes(binDir)) {
-		env.PATH = [binDir, ...entries].join(delimiter);
+		env["PATH"] = [binDir, ...entries].join(delimiter);
 	}
 	return binDir;
 }

--- a/packages/pi-codex-conversion/src/tools/apply-patch-rendering.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch-rendering.ts
@@ -13,7 +13,7 @@ interface PreviewLine {
 interface FilePreview {
 	verb: "Added" | "Deleted" | "Edited";
 	path: string;
-	movePath?: string;
+	movePath?: string | undefined;
 	added: number;
 	removed: number;
 	lines: PreviewLine[];
@@ -37,7 +37,7 @@ export function formatApplyPatchSummary(patchText: string, cwd = process.cwd()):
 	const lines: string[] = [];
 
 	if (files.length === 1) {
-		const [file] = files;
+		const file = files[0]!;
 		lines.push(`${bulletHeader(file.verb, formatPatchTarget(file.path, file.movePath, cwd))} ${renderCounts(file.added, file.removed)}`);
 		return lines.join("\n");
 	}
@@ -69,7 +69,7 @@ export function formatApplyPatchCall(patchText: string, cwd = process.cwd()): st
 	const lines: string[] = [];
 
 	if (files.length === 1) {
-		const [file] = files;
+		const file = files[0]!;
 		lines.push(`${bulletHeader(file.verb, formatPatchTarget(file.path, file.movePath, cwd))} ${renderCounts(file.added, file.removed)}`);
 		lines.push(...file.lines.map((line) => formatPreviewLine(line, file.lines)));
 		return lines.join("\n");
@@ -105,7 +105,7 @@ export function renderApplyPatchCall(patchText: string, cwd = process.cwd()): st
 	const lines: string[] = [];
 
 	if (files.length === 1) {
-		const [file] = files;
+		const file = files[0]!;
 		lines.push(`${bulletHeader(file.verb, formatPatchTarget(file.path, file.movePath, cwd))} ${renderCounts(file.added, file.removed)}`);
 		lines.push(...renderPreviewLines(file.lines));
 		return lines.join("\n");
@@ -171,7 +171,7 @@ function buildUpdatePreview(action: ParsedPatchAction, cwd: string): { added: nu
 	let index = 0;
 
 	while (index < action.lines.length) {
-		const line = action.lines[index];
+		const line = action.lines[index]!;
 		if (line === "*** End of File") {
 			break;
 		}
@@ -182,8 +182,8 @@ function buildUpdatePreview(action: ParsedPatchAction, cwd: string): { added: nu
 
 		index += 1;
 		const sectionLines: string[] = [];
-		while (index < action.lines.length && !action.lines[index].startsWith("@@") && action.lines[index] !== "*** End of File") {
-			sectionLines.push(action.lines[index]);
+		while (index < action.lines.length && !action.lines[index]!.startsWith("@@") && action.lines[index] !== "*** End of File") {
+			sectionLines.push(action.lines[index]!);
 			index += 1;
 		}
 
@@ -257,7 +257,7 @@ function renderPreviewLines(lines: PreviewLine[]): string[] {
 
 function normalizePatchLine(rawLine: string): PreviewLine {
 	const normalized = rawLine === "" ? " " : rawLine;
-	const marker = normalized[0];
+	const marker = normalized[0]!;
 	if (marker !== " " && marker !== "+" && marker !== "-") {
 		return { lineNumber: 0, marker: " ", text: rawLine };
 	}
@@ -291,7 +291,7 @@ function findSequence(lines: string[], context: string[], start: number, normali
 	for (let lineIndex = start; lineIndex <= lines.length - context.length; lineIndex += 1) {
 		let matches = true;
 		for (let contextIndex = 0; contextIndex < context.length; contextIndex += 1) {
-			if (normalize(lines[lineIndex + contextIndex]) !== normalize(context[contextIndex])) {
+			if (normalize((lines[lineIndex + contextIndex])!) !== normalize(context[contextIndex]!)) {
 				matches = false;
 				break;
 			}

--- a/packages/pi-codex-conversion/src/tools/apply-patch-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch-tool.ts
@@ -348,7 +348,7 @@ export function registerApplyPatchTool(pi: ExtensionAPI): void {
 			};
 		},
 		renderCall: renderApplyPatchCallWithOptionalContext,
-		renderResult(result, { isPartial, expanded }, theme) {
+		renderResult(result, { isPartial }, theme) {
 			if (isPartial) {
 				return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
 			}

--- a/packages/pi-codex-conversion/src/tools/apply-patch-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch-tool.ts
@@ -17,7 +17,7 @@ interface ApplyPatchRenderState {
 	collapsed: string;
 	expanded: string;
 	status: "pending" | "partial_failure" | "failed";
-	failedTargets?: string[];
+	failedTargets?: string[] | undefined;
 }
 
 interface ApplyPatchSuccessDetails {
@@ -29,7 +29,7 @@ interface ApplyPatchPartialFailureDetails {
 	status: "partial_failure";
 	result: ExecutePatchResult;
 	error: string;
-	failedTargets?: string[];
+	failedTargets?: string[] | undefined;
 	appliedFiles: string[];
 	failedFiles: string[];
 	recoveryInstructions: {
@@ -43,10 +43,10 @@ type ApplyPatchToolDetails = ApplyPatchSuccessDetails | ApplyPatchPartialFailure
 const applyPatchRenderStates = new Map<string, ApplyPatchRenderState>();
 
 interface ApplyPatchRenderContextLike {
-	toolCallId?: string;
-	cwd?: string;
-	expanded?: boolean;
-	argsComplete?: boolean;
+	toolCallId?: string | undefined;
+	cwd?: string | undefined;
+	expanded?: boolean | undefined;
+	argsComplete?: boolean | undefined;
 }
 
 function parseApplyPatchParams(params: unknown): { patchText: string } {
@@ -119,12 +119,12 @@ function renderPartialFailureCall(
 	if (lines.length === 0) {
 		return theme.fg("warning", "• Edit partially failed");
 	}
-	lines[0] = lines[0].replace(/^• (Added|Edited|Deleted)\b/, "• Edit partially failed");
+	lines[0] = lines[0]!.replace(/^• (Added|Edited|Deleted)\b/, "• Edit partially failed");
 	const failedLineIndexes = new Set<number>();
 	if (failedTargets) {
 		for (let i = 0; i < lines.length; i += 1) {
 			for (const failedTarget of failedTargets) {
-				const failedLine = markFailedTargetLine(lines[i], failedTarget);
+				const failedLine = markFailedTargetLine(lines[i]!, failedTarget);
 				if (failedLine) {
 					lines[i] = failedLine;
 					failedLineIndexes.add(i);
@@ -155,12 +155,12 @@ function renderFailedCall(
 	if (lines.length === 0) {
 		return theme.fg("error", "• Edit failed");
 	}
-	lines[0] = lines[0].replace(/^• (Added|Edited|Deleted)\b/, "• Edit failed");
+	lines[0] = lines[0]!.replace(/^• (Added|Edited|Deleted)\b/, "• Edit failed");
 	const failedLineIndexes = new Set<number>();
 	if (failedTargets) {
 		for (let i = 0; i < lines.length; i += 1) {
 			for (const failedTarget of failedTargets) {
-				const failedLine = markFailedTargetLine(lines[i], failedTarget);
+				const failedLine = markFailedTargetLine(lines[i]!, failedTarget);
 				if (failedLine) {
 					lines[i] = failedLine;
 					failedLineIndexes.add(i);
@@ -184,7 +184,7 @@ function markFailedTargetLine(line: string, failedTarget: string): string | unde
 	if (!suffixMatch) {
 		return undefined;
 	}
-	const suffix = suffixMatch[0];
+	const suffix = suffixMatch[0]!;
 	const prefixAndTarget = line.slice(0, -suffix.length);
 	const candidatePrefixes = ["• Edit partially failed ", "• Added ", "• Edited ", "• Deleted ", "  └ ", "    "];
 	for (const prefix of candidatePrefixes) {
@@ -244,7 +244,7 @@ export function clearApplyPatchRenderState(): void {
 }
 
 const renderApplyPatchCallWithOptionalContext: any = (
-	args: { input?: unknown },
+	args: { input?: unknown | undefined },
 	theme: { fg(role: string, text: string): string; bold(text: string): string },
 	context?: ApplyPatchRenderContextLike,
 ) => {

--- a/packages/pi-codex-conversion/src/tools/codex-rendering.ts
+++ b/packages/pi-codex-conversion/src/tools/codex-rendering.ts
@@ -105,14 +105,14 @@ function coalesceReadGroups(actionGroups: ShellAction[][]): ShellAction[] {
 	const flattened: ShellAction[] = [];
 
 	for (let index = 0; index < actionGroups.length; index += 1) {
-		const actions = actionGroups[index];
+		const actions = actionGroups[index]!;
 		if (actions.every((action) => action.kind === "read")) {
 			const reads: Extract<ShellAction, { kind: "read" }>[] = [];
 			const seenPaths = new Set<string>();
 			let lastRead: Extract<ShellAction, { kind: "read" }> | undefined;
 
 			for (let readIndex = index; readIndex < actionGroups.length; readIndex += 1) {
-				const readActions = actionGroups[readIndex];
+				const readActions = actionGroups[readIndex]!;
 				if (!readActions.every((action) => action.kind === "read")) {
 					break;
 				}

--- a/packages/pi-codex-conversion/src/tools/exec-command-state.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-command-state.ts
@@ -5,7 +5,7 @@ export type ExecCommandStatus = "running" | "done";
 export interface ExecCommandRenderInfo {
 	hidden: boolean;
 	status: ExecCommandStatus;
-	actionGroups?: ShellAction[][];
+	actionGroups?: ShellAction[][] | undefined;
 }
 
 interface ExecEntry {
@@ -14,8 +14,8 @@ interface ExecEntry {
 	summary: CommandSummary;
 	status: ExecCommandStatus;
 	hidden: boolean;
-	groupId?: number;
-	invalidate?: () => void;
+	groupId?: number | undefined;
+	invalidate?: () => void | undefined;
 }
 
 interface ExecGroup {

--- a/packages/pi-codex-conversion/src/tools/exec-command-state.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-command-state.ts
@@ -64,14 +64,6 @@ export function createExecCommandTracker(): ExecCommandTracker {
 		entriesByToolCallId.get(toolCallId)?.invalidate?.();
 	}
 
-	function findLatestEntryByCommand(command: string): ExecEntry | undefined {
-		let latest: ExecEntry | undefined;
-		for (const entry of entriesByToolCallId.values()) {
-			if (entry.command !== command) continue;
-			latest = entry;
-		}
-		return latest;
-	}
 
 	function getGroupForEntry(entry: ExecEntry | undefined): ExecGroup | undefined {
 		if (!entry?.groupId) return undefined;

--- a/packages/pi-codex-conversion/src/tools/exec-command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-command-tool.ts
@@ -22,12 +22,12 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 
 interface ExecCommandParams {
 	cmd: string;
-	workdir?: string;
-	shell?: string;
-	tty?: boolean;
-	yield_time_ms?: number;
-	max_output_tokens?: number;
-	login?: boolean;
+	workdir?: string | undefined;
+	shell?: string | undefined;
+	tty?: boolean | undefined;
+	yield_time_ms?: number | undefined;
+	max_output_tokens?: number | undefined;
+	login?: boolean | undefined;
 }
 
 function prepareExecCommandArguments(args: unknown): ExecCommandParams {
@@ -38,13 +38,13 @@ function prepareExecCommandArguments(args: unknown): ExecCommandParams {
 	const record = args as Record<string, unknown>;
 	const prepared: Record<string, unknown> = { ...record };
 	if (!("cmd" in prepared) && "command" in prepared) {
-		prepared.cmd = prepared.command;
+		prepared["cmd"] = prepared["command"]!;
 	}
 	if (!("workdir" in prepared)) {
 		if ("cwd" in prepared) {
-			prepared.workdir = prepared.cwd;
+			prepared["workdir"] = prepared["cwd"]!;
 		} else if ("working_directory" in prepared) {
-			prepared.workdir = prepared.working_directory;
+			prepared["workdir"] = prepared["working_directory"]!;
 		}
 	}
 	return prepared as unknown as ExecCommandParams;
@@ -81,12 +81,12 @@ function createEmptyResultComponent(): Container {
 }
 
 interface ExecCommandRenderContextLike {
-	toolCallId?: string;
-	invalidate?: () => void;
+	toolCallId?: string | undefined;
+	invalidate?: () => void | undefined;
 }
 
 const renderExecCommandCallWithOptionalContext: any = (
-	args: { cmd?: unknown },
+	args: { cmd?: unknown | undefined },
 	theme: { fg(role: string, text: string): string; bold(text: string): string },
 	context: ExecCommandRenderContextLike | undefined,
 	tracker: ExecCommandTracker,
@@ -104,7 +104,7 @@ const renderExecCommandCallWithOptionalContext: any = (
 };
 
 const renderExecCommandResultWithOptionalContext: any = (
-	result: { content: Array<{ type: string; text?: string }>; details?: unknown },
+	result: { content: Array<{ type: string; text?: string | undefined }>; details?: unknown | undefined },
 	options: { expanded: boolean; isPartial: boolean },
 	theme: { fg(role: string, text: string): string },
 	context: ExecCommandRenderContextLike | undefined,
@@ -139,7 +139,7 @@ export function registerExecCommandTool(pi: ExtensionAPI, tracker: ExecCommandTr
 		description: "Runs a shell command, returning output or a session ID for ongoing interaction.",
 		promptSnippet: "Run a command.",
 		parameters: EXEC_COMMAND_PARAMETERS,
-		prepareArguments: prepareExecCommandArguments,
+		prepareArguments: prepareExecCommandArguments as (args: unknown) => { cmd: string; workdir?: string; shell?: string; tty?: boolean; yield_time_ms?: number; max_output_tokens?: number; login?: boolean },
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			if (signal?.aborted) {
 				throw new Error("exec_command aborted");
@@ -158,10 +158,10 @@ export function registerExecCommandTool(pi: ExtensionAPI, tracker: ExecCommandTr
 				details: result,
 			};
 		},
-		renderCall: ((args: { cmd?: unknown }, theme: { fg(role: string, text: string): string; bold(text: string): string }, context?: ExecCommandRenderContextLike) =>
+		renderCall: ((args: { cmd?: unknown | undefined }, theme: { fg(role: string, text: string): string; bold(text: string): string }, context?: ExecCommandRenderContextLike) =>
 			renderExecCommandCallWithOptionalContext(args, theme, context, tracker)) as any,
 		renderResult: ((
-			result: { content: Array<{ type: string; text?: string }>; details?: unknown },
+			result: { content: Array<{ type: string; text?: string | undefined }>; details?: unknown | undefined },
 			options: { expanded: boolean; isPartial: boolean },
 			theme: { fg(role: string, text: string): string },
 			context?: ExecCommandRenderContextLike,

--- a/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
@@ -9,26 +9,26 @@ export interface UnifiedExecResult {
 	chunk_id: string;
 	wall_time_seconds: number;
 	output: string;
-	exit_code?: number;
-	session_id?: number;
-	original_token_count?: number;
+	exit_code?: number | undefined;
+	session_id?: number | undefined;
+	original_token_count?: number | undefined;
 }
 
 export interface ExecCommandInput {
 	cmd: string;
-	workdir?: string;
-	shell?: string;
-	tty?: boolean;
-	yield_time_ms?: number;
-	max_output_tokens?: number;
-	login?: boolean;
+	workdir?: string | undefined;
+	shell?: string | undefined;
+	tty?: boolean | undefined;
+	yield_time_ms?: number | undefined;
+	max_output_tokens?: number | undefined;
+	login?: boolean | undefined;
 }
 
 export interface WriteStdinInput {
 	session_id: number;
-	chars?: string;
-	yield_time_ms?: number;
-	max_output_tokens?: number;
+	chars?: string | undefined;
+	yield_time_ms?: number | undefined;
+	max_output_tokens?: number | undefined;
 }
 
 interface BaseExecSession {
@@ -68,11 +68,11 @@ export interface ExecSessionManager {
 }
 
 export interface ExecSessionManagerOptions {
-	defaultExecYieldTimeMs?: number;
-	defaultWriteYieldTimeMs?: number;
-	minNonInteractiveExecYieldTimeMs?: number;
-	minEmptyWriteYieldTimeMs?: number;
-	maxSessionBufferChars?: number;
+	defaultExecYieldTimeMs?: number | undefined;
+	defaultWriteYieldTimeMs?: number | undefined;
+	minNonInteractiveExecYieldTimeMs?: number | undefined;
+	minEmptyWriteYieldTimeMs?: number | undefined;
+	maxSessionBufferChars?: number | undefined;
 }
 
 const DEFAULT_EXEC_YIELD_TIME_MS = 10_000;
@@ -91,7 +91,7 @@ function resolveWorkdir(baseCwd: string, workdir?: string): string {
 }
 
 function resolveShell(shell?: string): string {
-	return getCodexRuntimeShell(shell || process.env["SHELL"]);
+	return getCodexRuntimeShell(shell || process.env["SHELL"]!);
 }
 
 const BASH_SYNC_ENV_KEYS = [
@@ -119,13 +119,13 @@ function shellEscape(value: string): string {
 }
 
 function shouldSyncBashEnv(requestedShell: string | undefined, effectiveShell: string): boolean {
-	return effectiveShell === CODEX_FALLBACK_SHELL && isFishShell(requestedShell || process.env["SHELL"]);
+	return effectiveShell === CODEX_FALLBACK_SHELL && isFishShell(requestedShell || process.env["SHELL"]!);
 }
 
 function buildSyncedBashCommand(command: string, env: NodeJS.ProcessEnv): string {
 	const assignments: string[] = [];
 	for (const key of BASH_SYNC_ENV_KEYS) {
-		const value = key === "SHELL" ? CODEX_FALLBACK_SHELL : env[key];
+		const value = key === "SHELL" ? CODEX_FALLBACK_SHELL : env[key]!;
 		if (typeof value !== "string") continue;
 		assignments.push(`export ${key}=${shellEscape(value)}`);
 	}
@@ -139,7 +139,7 @@ function resolveExecution(requestedShell: string | undefined, command: string): 
 	if (!shouldSyncBashEnv(requestedShell, shell)) {
 		return { shell, command, env };
 	}
-	env.SHELL = CODEX_FALLBACK_SHELL;
+	env["SHELL"] = CODEX_FALLBACK_SHELL;
 	return {
 		shell,
 		command: buildSyncedBashCommand(command, env),
@@ -240,7 +240,7 @@ function applyTerminalOutput(session: PtyExecSession, text: string): string {
 					break;
 				}
 				const params = sanitized.slice(index + 2, sequenceEnd);
-				const finalByte = sanitized[sequenceEnd];
+				const finalByte = sanitized[sequenceEnd]!;
 				if (finalByte === "K") {
 					const mode = Number(params || "0");
 					if (mode === 0) {
@@ -258,7 +258,7 @@ function applyTerminalOutput(session: PtyExecSession, text: string): string {
 				continue;
 			}
 
-			const next = sanitized[index + 1];
+			const next = (sanitized[index + 1])!;
 			if (next && /[()*+,\-./]/.test(next) && index + 2 < sanitized.length) {
 				index += 2;
 				continue;
@@ -313,7 +313,7 @@ function generateChunkId(): string {
 	return randomBytes(3).toString("hex");
 }
 
-function truncateOutput(text: string, maxOutputTokens?: number): { output: string; original_token_count?: number } {
+function truncateOutput(text: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
 	if (text.length === 0) {
 		return { output: "" };
 	}
@@ -330,20 +330,20 @@ function truncateOutput(text: string, maxOutputTokens?: number): { output: strin
 	};
 }
 
-function consumeOutput(session: ExecSession, maxOutputTokens?: number): { output: string; original_token_count?: number } {
+function consumeOutput(session: ExecSession, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
 	const text =
 		session.kind === "pty" ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
 	session.emittedBuffer = session.buffer;
 	return truncateOutput(text, maxOutputTokens);
 }
 
-function peekUnconsumedOutput(session: ExecSession, maxOutputTokens?: number): { output: string; original_token_count?: number } {
+function peekUnconsumedOutput(session: ExecSession, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
 	const text =
 		session.kind === "pty" ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
 	return truncateOutput(text, maxOutputTokens);
 }
 
-function peekOutputSince(session: ExecSession, baseline: string, maxOutputTokens?: number): { output: string; original_token_count?: number } {
+function peekOutputSince(session: ExecSession, baseline: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
 	const text = session.kind === "pty" ? computePtyDelta(baseline, session.buffer) : session.buffer.slice(baseline.length);
 	return truncateOutput(text, maxOutputTokens);
 }
@@ -492,7 +492,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 	function makeSnapshotFromOutput(
 		session: ExecSession,
 		waitMs: number,
-		snapshot: { output: string; original_token_count?: number },
+		snapshot: { output: string; original_token_count?: number | undefined },
 	): UnifiedExecResult {
 		const result: UnifiedExecResult = {
 			chunk_id: generateChunkId(),

--- a/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
@@ -91,7 +91,7 @@ function resolveWorkdir(baseCwd: string, workdir?: string): string {
 }
 
 function resolveShell(shell?: string): string {
-	return getCodexRuntimeShell(shell || process.env.SHELL);
+	return getCodexRuntimeShell(shell || process.env["SHELL"]);
 }
 
 const BASH_SYNC_ENV_KEYS = [
@@ -119,7 +119,7 @@ function shellEscape(value: string): string {
 }
 
 function shouldSyncBashEnv(requestedShell: string | undefined, effectiveShell: string): boolean {
-	return effectiveShell === CODEX_FALLBACK_SHELL && isFishShell(requestedShell || process.env.SHELL);
+	return effectiveShell === CODEX_FALLBACK_SHELL && isFishShell(requestedShell || process.env["SHELL"]);
 }
 
 function buildSyncedBashCommand(command: string, env: NodeJS.ProcessEnv): string {
@@ -564,7 +564,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		const child = pty.spawn(shell, shellArgs, {
 			cwd: workdir,
 			env: execution.env,
-			name: process.env.TERM || "xterm-256color",
+			name: process.env["TERM"] || "xterm-256color",
 			cols: 80,
 			rows: 24,
 		});

--- a/packages/pi-codex-conversion/src/tools/image-generation-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/image-generation-tool.ts
@@ -14,12 +14,12 @@ const IMAGE_GENERATION_PARAMETERS = Type.Unsafe<Record<string, never>>({
 });
 
 interface FunctionToolPayload {
-	type?: unknown;
-	name?: unknown;
+	type?: unknown | undefined;
+	name?: unknown | undefined;
 }
 
 interface ResponsesPayload {
-	tools?: unknown[];
+	tools?: unknown[] | undefined;
 	[key: string]: unknown;
 }
 

--- a/packages/pi-codex-conversion/src/tools/view-image-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/view-image-tool.ts
@@ -16,7 +16,7 @@ const DETAIL_DESCRIPTION =
 
 interface ViewImageParams {
 	path: string;
-	detail?: string;
+	detail?: string | undefined;
 }
 
 interface ViewImageReader {
@@ -29,7 +29,7 @@ interface ViewImageReaders {
 }
 
 interface CreateViewImageToolOptions {
-	allowOriginalDetail?: boolean;
+	allowOriginalDetail?: boolean | undefined;
 	createReaders?: (cwd: string) => ViewImageReaders;
 }
 
@@ -40,7 +40,7 @@ function createViewImageParameters(allowOriginalDetail: boolean) {
 		path: Type.String({ description: "Local image file path." }),
 	};
 	if (allowOriginalDetail) {
-		properties.detail = Type.Optional(Type.String({ description: DETAIL_DESCRIPTION }));
+		properties["detail"] = Type.Optional(Type.String({ description: DETAIL_DESCRIPTION }));
 	}
 	return Type.Object(properties);
 }
@@ -77,9 +77,9 @@ function prepareViewImageArguments(args: unknown): Record<string, unknown> {
 	const prepared: Record<string, unknown> = { ...record };
 	if (!("path" in prepared)) {
 		if ("file_path" in prepared) {
-			prepared.path = prepared.file_path;
+			prepared["path"] = prepared["file_path"]!;
 		} else if ("image_path" in prepared) {
-			prepared.path = prepared.image_path;
+			prepared["path"] = prepared["image_path"]!;
 		}
 	}
 	return prepared;
@@ -163,7 +163,7 @@ export function createViewImageTool(options: CreateViewImageToolOptions = {}): T
 		},
 		renderCall(args, theme) {
 			return new Text(
-				`${theme.fg("toolTitle", theme.bold("view_image"))} ${theme.fg("accent", typeof args.path === "string" ? args.path : "")}`,
+				`${theme.fg("toolTitle", theme.bold("view_image"))} ${theme.fg("accent", typeof args["path"]! === "string" ? args["path"]! : "")}`,
 				0,
 				0,
 			);

--- a/packages/pi-codex-conversion/src/tools/web-search-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/web-search-tool.ts
@@ -16,20 +16,20 @@ const WEB_SEARCH_PARAMETERS = Type.Unsafe<Record<string, never>>({
 });
 
 interface FunctionToolPayload {
-	type?: unknown;
-	name?: unknown;
+	type?: unknown | undefined;
+	name?: unknown | undefined;
 }
 
 interface ResponsesPayload {
-	include?: unknown;
-	tools?: unknown[];
+	include?: unknown | undefined;
+	tools?: unknown[] | undefined;
 	[key: string]: unknown;
 }
 
 interface ResponsesWebSearchTool {
 	type: "web_search";
 	external_web_access: true;
-	search_content_types?: string[];
+	search_content_types?: string[] | undefined;
 }
 
 export function supportsNativeWebSearch(model: ExtensionContext["model"]): boolean {

--- a/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
@@ -14,15 +14,15 @@ const WRITE_STDIN_PARAMETERS = Type.Object({
 
 interface WriteStdinParams {
 	session_id: number;
-	chars?: string;
-	yield_time_ms?: number;
-	max_output_tokens?: number;
+	chars?: string | undefined;
+	yield_time_ms?: number | undefined;
+	max_output_tokens?: number | undefined;
 }
 
 interface FormattedExecTranscript {
 	output: string;
-	sessionId?: number;
-	exitCode?: number;
+	sessionId?: number | undefined;
+	exitCode?: number | undefined;
 }
 
 function parseFormattedExecTranscript(text: string): FormattedExecTranscript {
@@ -33,8 +33,8 @@ function parseFormattedExecTranscript(text: string): FormattedExecTranscript {
 	const exitCodeMatch = text.match(/Process exited with code (-?\d+)/);
 	return {
 		output,
-		sessionId: sessionMatch ? Number(sessionMatch[1]) : undefined,
-		exitCode: exitCodeMatch ? Number(exitCodeMatch[1]) : undefined,
+		sessionId: sessionMatch ? Number(sessionMatch[1]!) : undefined,
+		exitCode: exitCodeMatch ? Number(exitCodeMatch[1]!) : undefined,
 	};
 }
 
@@ -69,7 +69,7 @@ function renderTerminalText(text: string): string {
 	return committed + line.join("");
 }
 
-function getResultState(result: { details?: unknown; content: Array<{ type: string; text?: string }> }): FormattedExecTranscript {
+function getResultState(result: { details?: unknown | undefined; content: Array<{ type: string; text?: string | undefined }> }): FormattedExecTranscript {
 	const details = isUnifiedExecResult(result.details) ? result.details : undefined;
 	const content = result.content.find((item) => item.type === "text");
 	if (details) {

--- a/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
@@ -136,7 +136,7 @@ export function registerWriteStdinTool(pi: ExtensionAPI, sessions: ExecSessionMa
 			const command = typeof sessionId === "number" ? sessions.getSessionCommand(sessionId) : undefined;
 			return new Text(renderWriteStdinCall(sessionId, input, command, theme), 0, 0);
 		},
-		renderResult(result, { expanded, isPartial }, theme) {
+		renderResult(result, { expanded }, theme) {
 			if (!expanded) return createEmptyResultComponent();
 			const state = getResultState(result);
 			const output = renderTerminalText(state.output);

--- a/packages/pi-codex-conversion/tests/apply-patch-core.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-core.test.ts
@@ -271,9 +271,9 @@ test("executePatch skips later actions that overlap a failed move", async () => 
 
 		assert.ok(error instanceof ExecutePatchError);
 		assert.equal(error.failures.length, 2);
-		assert.equal(error.failures[0]?.action.path, "a.txt");
-		assert.equal(error.failures[1]?.action.path, "b.txt");
-		assert.match(error.failures[1]?.message ?? "", /Skipped because an earlier failed action affected b\.txt/);
+		assert.equal(error.failures[0]!?.action.path, "a.txt");
+		assert.equal(error.failures[1]!?.action.path, "b.txt");
+		assert.match(error.failures[1]!?.message ?? "", /Skipped because an earlier failed action affected b\.txt/);
 		assert.deepEqual(error.result.changedFiles.sort(), ["b.txt", "c.txt"]);
 		assert.deepEqual(error.result.createdFiles.sort(), ["b.txt", "c.txt"]);
 		assert.equal(readFileSync(join(cwd, "a.txt"), "utf8"), "from\n");
@@ -325,9 +325,9 @@ test("executePatch blocks overlapping actions even when they use absolute and re
 
 		assert.ok(error instanceof ExecutePatchError);
 		assert.equal(error.failures.length, 2);
-		assert.equal(error.failures[0]?.action.path, sourcePath);
-		assert.equal(error.failures[1]?.action.path, "./source.txt");
-		assert.match(error.failures[1]?.message ?? "", /Skipped because an earlier failed action affected \.\/source\.txt/);
+		assert.equal(error.failures[0]!?.action.path, sourcePath);
+		assert.equal(error.failures[1]!?.action.path, "./source.txt");
+		assert.match(error.failures[1]!?.message ?? "", /Skipped because an earlier failed action affected \.\/source\.txt/);
 		assert.equal(readFileSync(sourcePath, "utf8"), "from\n");
 		assert.equal(readFileSync(movedPath, "utf8"), "to\n");
 		assert.equal(readFileSync(join(cwd, "later.txt"), "utf8"), "later\n");

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -185,11 +185,11 @@ test("apply_patch renderCall shows partial failure inline after some hunks alrea
 				recoveryInstructions?: { mustReadFiles?: string[]; mustNotReadFiles?: string[] };
 			};
 		};
-		assert.equal(result.content[0]?.type, "text");
-		assert.match(result.content[0]?.text ?? "", /partially failed/i);
-		assert.match(result.content[0]?.text ?? "", /MUST read missing\.txt before retrying\./);
-		assert.match(result.content[0]?.text ?? "", /Earlier file actions in this patch were already applied\./);
-		assert.match(result.content[0]?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it\./);
+		assert.equal(result.content[0]!?.type, "text");
+		assert.match(result.content[0]!?.text ?? "", /partially failed/i);
+		assert.match(result.content[0]!?.text ?? "", /MUST read missing\.txt before retrying\./);
+		assert.match(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied\./);
+		assert.match(result.content[0]!?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it\./);
 		assert.deepEqual(result.details?.failedFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.appliedFiles, ["created.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);
@@ -245,7 +245,7 @@ test("apply_patch keeps applying later files after one file fails", async () => 
 			};
 		};
 
-		assert.match(result.content[0]?.text ?? "", /partially failed/i);
+		assert.match(result.content[0]!?.text ?? "", /partially failed/i);
 		assert.deepEqual(result.details?.failedFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.appliedFiles?.sort(), ["created.txt", "later.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);
@@ -284,7 +284,7 @@ test("apply_patch renderCall marks failed absolute-path entries inline using dis
 		const result = (await execute("call-absolute-partial-failure", { input: patch }, undefined, undefined, { cwd })) as {
 			content: Array<{ type: string; text?: string }>;
 		};
-		assert.match(result.content[0]?.text ?? "", /while patching missing\.txt/);
+		assert.match(result.content[0]!?.text ?? "", /while patching missing\.txt/);
 
 		const collapsed = renderComponentText(
 			renderCall({ input: patch }, theme, { toolCallId: "call-absolute-partial-failure", expanded: false, cwd }),
@@ -414,10 +414,10 @@ test("apply_patch partial move failures report real paths and no prior-action wa
 			};
 		};
 
-		assert.match(result.content[0]?.text ?? "", /while patching source\.txt → moved\/source\.txt/i);
-		assert.match(result.content[0]?.text ?? "", /Failed files: source\.txt, moved\/source\.txt/i);
-		assert.match(result.content[0]?.text ?? "", /MUST read source\.txt, moved\/source\.txt before retrying\./i);
-		assert.doesNotMatch(result.content[0]?.text ?? "", /Earlier file actions in this patch were already applied\./i);
+		assert.match(result.content[0]!?.text ?? "", /while patching source\.txt → moved\/source\.txt/i);
+		assert.match(result.content[0]!?.text ?? "", /Failed files: source\.txt, moved\/source\.txt/i);
+		assert.match(result.content[0]!?.text ?? "", /MUST read source\.txt, moved\/source\.txt before retrying\./i);
+		assert.doesNotMatch(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied\./i);
 		assert.deepEqual(result.details?.failedFiles, ["source.txt", "moved/source.txt"]);
 		assert.deepEqual(result.details?.appliedFiles, []);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["source.txt", "moved/source.txt"]);

--- a/packages/pi-codex-conversion/tests/codex-context-budget.test.ts
+++ b/packages/pi-codex-conversion/tests/codex-context-budget.test.ts
@@ -127,16 +127,16 @@ test("refreshes cached raw windows when model metadata changes", () => {
 test("reads project compaction reserve over global reserve", () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-codex-budget-"));
 	const agentDir = mkdtempSync(join(tmpdir(), "pi-codex-agent-"));
-	const oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const oldAgentDir = process.env["PI_CODING_AGENT_DIR"];
 	try {
-		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env["PI_CODING_AGENT_DIR"] = agentDir;
 		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ compaction: { reserveTokens: 20_000 } }));
 		mkdirSync(join(cwd, ".pi"));
 		writeFileSync(join(cwd, ".pi", "settings.json"), JSON.stringify({ compaction: { reserveTokens: 30_000 } }));
 		assert.equal(readPiCompactionReserveTokens(cwd), 30_000);
 	} finally {
-		if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+		if (oldAgentDir === undefined) delete process.env["PI_CODING_AGENT_DIR"];
+		else process.env["PI_CODING_AGENT_DIR"] = oldAgentDir;
 		rmSync(cwd, { recursive: true, force: true });
 		rmSync(agentDir, { recursive: true, force: true });
 	}

--- a/packages/pi-codex-conversion/tests/codex-context-budget.test.ts
+++ b/packages/pi-codex-conversion/tests/codex-context-budget.test.ts
@@ -127,7 +127,7 @@ test("refreshes cached raw windows when model metadata changes", () => {
 test("reads project compaction reserve over global reserve", () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-codex-budget-"));
 	const agentDir = mkdtempSync(join(tmpdir(), "pi-codex-agent-"));
-	const oldAgentDir = process.env["PI_CODING_AGENT_DIR"];
+	const oldAgentDir = process.env["PI_CODING_AGENT_DIR"]!;
 	try {
 		process.env["PI_CODING_AGENT_DIR"] = agentDir;
 		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ compaction: { reserveTokens: 20_000 } }));

--- a/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
@@ -99,7 +99,7 @@ test("exec_command emits partial execution updates without consuming final outpu
 });
 
 test("exec session manager coerces fish defaults to bash", async () => {
-	const originalShell = process.env["SHELL"];
+	const originalShell = process.env["SHELL"]!;
 	process.env["SHELL"] = "/usr/bin/fish";
 	const sessions = createFastTestExecSessionManager();
 	try {
@@ -145,8 +145,8 @@ test("exec session manager coerces explicit fish shells to bash", async () => {
 });
 
 test("exec session manager preserves fish-derived PATH and SHELL when forcing bash", async () => {
-	const originalShell = process.env["SHELL"];
-	const originalPath = process.env["PATH"];
+	const originalShell = process.env["SHELL"]!;
+	const originalPath = process.env["PATH"]!;
 	process.env["SHELL"] = "/usr/bin/fish";
 	process.env["PATH"] = "/tmp/pi-codex-fish-path:/usr/bin:/bin";
 	const sessions = createFastTestExecSessionManager();

--- a/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
@@ -7,7 +7,7 @@ function createFastTestExecSessionManager() {
 }
 
 async function finishSession(
-	sessionId: number,
+	_sessionId: number,
 	write: (chars?: string) => Promise<UnifiedExecResult>,
 ): Promise<{ output: string; final: UnifiedExecResult }> {
 	let result = await write("hello\n");
@@ -99,8 +99,8 @@ test("exec_command emits partial execution updates without consuming final outpu
 });
 
 test("exec session manager coerces fish defaults to bash", async () => {
-	const originalShell = process.env.SHELL;
-	process.env.SHELL = "/usr/bin/fish";
+	const originalShell = process.env["SHELL"];
+	process.env["SHELL"] = "/usr/bin/fish";
 	const sessions = createFastTestExecSessionManager();
 	try {
 		const result = await sessions.exec(
@@ -117,9 +117,9 @@ test("exec session manager coerces fish defaults to bash", async () => {
 	} finally {
 		sessions.shutdown();
 		if (originalShell === undefined) {
-			delete process.env.SHELL;
+			delete process.env["SHELL"];
 		} else {
-			process.env.SHELL = originalShell;
+			process.env["SHELL"] = originalShell;
 		}
 	}
 });
@@ -145,10 +145,10 @@ test("exec session manager coerces explicit fish shells to bash", async () => {
 });
 
 test("exec session manager preserves fish-derived PATH and SHELL when forcing bash", async () => {
-	const originalShell = process.env.SHELL;
-	const originalPath = process.env.PATH;
-	process.env.SHELL = "/usr/bin/fish";
-	process.env.PATH = "/tmp/pi-codex-fish-path:/usr/bin:/bin";
+	const originalShell = process.env["SHELL"];
+	const originalPath = process.env["PATH"];
+	process.env["SHELL"] = "/usr/bin/fish";
+	process.env["PATH"] = "/tmp/pi-codex-fish-path:/usr/bin:/bin";
 	const sessions = createFastTestExecSessionManager();
 	try {
 		const result = await sessions.exec(
@@ -164,14 +164,14 @@ test("exec session manager preserves fish-derived PATH and SHELL when forcing ba
 	} finally {
 		sessions.shutdown();
 		if (originalShell === undefined) {
-			delete process.env.SHELL;
+			delete process.env["SHELL"];
 		} else {
-			process.env.SHELL = originalShell;
+			process.env["SHELL"] = originalShell;
 		}
 		if (originalPath === undefined) {
-			delete process.env.PATH;
+			delete process.env["PATH"];
 		} else {
-			process.env.PATH = originalPath;
+			process.env["PATH"] = originalPath;
 		}
 	}
 });

--- a/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
@@ -242,8 +242,8 @@ test("activity dispatcher defers display messages until an idle agent_end flush"
 
 	assert.equal(isStreaming, false);
 	assert.equal(sentMessages.length, 1);
-	assert.deepEqual(sentMessages[0]?.options, { triggerTurn: false });
-	assert.equal((sentMessages[0]?.message as { customType?: string }).customType, "codex-web-search-activity");
+	assert.deepEqual(sentMessages[0]!?.options, { triggerTurn: false });
+	assert.equal((sentMessages[0]!?.message as { customType?: string }).customType, "codex-web-search-activity");
 });
 
 test("activity dispatcher flushes queued display messages before shutdown clear", async () => {
@@ -269,8 +269,8 @@ test("activity dispatcher flushes queued display messages before shutdown clear"
 	await waitForTimers();
 
 	assert.equal(sentMessages.length, 1);
-	assert.deepEqual(sentMessages[0]?.options, { triggerTurn: false });
-	assert.equal((sentMessages[0]?.message as { customType?: string }).customType, "codex-web-search-activity");
+	assert.deepEqual(sentMessages[0]!?.options, { triggerTurn: false });
+	assert.equal((sentMessages[0]!?.message as { customType?: string }).customType, "codex-web-search-activity");
 });
 
 test("saveOpenAICodexGeneratedImage writes the decoded image bytes into the workspace-local cache", async () => {

--- a/packages/pi-codex-conversion/tests/payload-rewrite.test.ts
+++ b/packages/pi-codex-conversion/tests/payload-rewrite.test.ts
@@ -170,5 +170,5 @@ test("native replay preserves the previous native blob across a newer Pi fallbac
 	assert.equal(result.ok, true);
 	if (!result.ok) return;
 	assert.deepEqual(result.rewrittenPayload.input.map((item) => (item as { type?: string; role?: string }).type ?? (item as { role?: string }).role), ["compaction_summary", "user", "user"]);
-	assert.deepEqual((result.rewrittenPayload.input[0] as { encrypted_content?: string }).encrypted_content, "sealed");
+	assert.deepEqual((result.rewrittenPayload.input[0]! as { encrypted_content?: string }).encrypted_content, "sealed");
 });

--- a/packages/pi-codex-conversion/tests/view-image-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/view-image-tool.test.ts
@@ -80,7 +80,7 @@ test("createViewImageTool uses resized reader by default and strips text output"
 
 	assert.deepEqual(calls, ["resized"]);
 	assert.equal(result.content.length, 1);
-	assert.deepEqual(result.content[0], { type: "image", data: PNG_BASE64, mimeType: "image/png" });
+	assert.deepEqual(result.content[0]!, { type: "image", data: PNG_BASE64, mimeType: "image/png" });
 });
 
 test("createViewImageTool uses original reader when requested", async () => {
@@ -106,7 +106,7 @@ test("createViewImageTool uses original reader when requested", async () => {
 
 	assert.deepEqual(calls, ["original"]);
 	assert.equal(result.content.length, 1);
-	assert.equal(result.content[0]?.type, "image");
+	assert.equal(result.content[0]!?.type, "image");
 });
 
 test("createViewImageTool rejects missing paths and directories with codex-like errors", async () => {

--- a/packages/pi-codex-conversion/tsconfig.json
+++ b/packages/pi-codex-conversion/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false,
+    "exactOptionalPropertyTypes": false
   },
   "include": [
     "src/**/*.ts",

--- a/packages/pi-codex-conversion/tsconfig.json
+++ b/packages/pi-codex-conversion/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/pi-explore-subagents/package.json
+++ b/packages/pi-explore-subagents/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "@howaboua/pi-explore-subagents",
-  "version": "0.1.4",
-  "description": "Isolated discovery-only explore subagents for Pi.",
-  "type": "module",
-  "license": "MIT",
-  "author": "Igor Warzocha",
-  "files": [
-    "index.ts",
-    "src",
-    "config.json",
-    "shallow.prompt.md",
-    "deep.prompt.md",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0",
-    "@types/node": "^25.9.1",
-    "typebox": "^1.1.38",
-    "typescript": "^6.0.3",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0",
-    "typebox": "*"
-  },
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ]
-  },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-extension",
-    "subagent",
-    "codebase-discovery",
-    "reconnaissance"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-explore-subagents"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-explore-subagents#readme",
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  }
+	"name": "@howaboua/pi-explore-subagents",
+	"version": "0.1.4",
+	"description": "Isolated discovery-only explore subagents for Pi.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"files": [
+		"index.ts",
+		"src",
+		"config.json",
+		"shallow.prompt.md",
+		"deep.prompt.md",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0",
+		"@types/node": "^25.9.1",
+		"typebox": "^1.1.38",
+		"typescript": "^6.0.3",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0",
+		"typebox": "*"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-extension",
+		"subagent",
+		"codebase-discovery",
+		"reconnaissance"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-explore-subagents"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-explore-subagents#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	}
 }

--- a/packages/pi-explore-subagents/src/messages.ts
+++ b/packages/pi-explore-subagents/src/messages.ts
@@ -63,7 +63,8 @@ export function formatToolCall(
 ): string {
 	if (name === "read") {
 		const filePath = String(args["file_path"] ?? args["path"] ?? "?");
-		const offset = typeof args["offset"] === "number" ? args["offset"] : undefined;
+		const offset =
+			typeof args["offset"] === "number" ? args["offset"] : undefined;
 		const limit = typeof args["limit"] === "number" ? args["limit"] : undefined;
 		const range =
 			offset !== undefined || limit !== undefined

--- a/packages/pi-explore-subagents/src/messages.ts
+++ b/packages/pi-explore-subagents/src/messages.ts
@@ -13,9 +13,10 @@ export function getMode(value: unknown): ExploreMode | null {
 export function getFinalOutput(messages: Message[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i];
+		if (!message) continue;
 		if (message.role !== "assistant") continue;
 		for (const part of message.content) {
-			if (part.type === "text") return part.text;
+			if (typeof part === "object" && part.type === "text") return part.text;
 		}
 	}
 	return "";
@@ -28,7 +29,7 @@ export function getToolCalls(
 	for (const message of messages) {
 		if (message.role !== "assistant") continue;
 		for (const part of message.content) {
-			if (part.type === "toolCall")
+			if (typeof part === "object" && part.type === "toolCall")
 				calls.push({ name: part.name, args: part.arguments });
 		}
 	}
@@ -61,9 +62,9 @@ export function formatToolCall(
 	args: Record<string, unknown>,
 ): string {
 	if (name === "read") {
-		const filePath = String(args.file_path ?? args.path ?? "?");
-		const offset = typeof args.offset === "number" ? args.offset : undefined;
-		const limit = typeof args.limit === "number" ? args.limit : undefined;
+		const filePath = String(args["file_path"] ?? args["path"] ?? "?");
+		const offset = typeof args["offset"] === "number" ? args["offset"] : undefined;
+		const limit = typeof args["limit"] === "number" ? args["limit"] : undefined;
 		const range =
 			offset !== undefined || limit !== undefined
 				? `:${offset ?? 1}${limit !== undefined ? `-${(offset ?? 1) + limit - 1}` : ""}`
@@ -71,10 +72,10 @@ export function formatToolCall(
 		return `read ${filePath}${range}`;
 	}
 	if (name === "grep")
-		return `grep /${String(args.pattern ?? "")}/ in ${String(args.path ?? ".")}`;
+		return `grep /${String(args["pattern"] ?? "")}/ in ${String(args["path"] ?? ".")}`;
 	if (name === "find")
-		return `find ${String(args.pattern ?? "*")} in ${String(args.path ?? ".")}`;
-	if (name === "ls") return `ls ${String(args.path ?? ".")}`;
-	if (name === "bash") return `$ ${String(args.command ?? "")}`;
+		return `find ${String(args["pattern"] ?? "*")} in ${String(args["path"] ?? ".")}`;
+	if (name === "ls") return `ls ${String(args["path"] ?? ".")}`;
+	if (name === "bash") return `$ ${String(args["command"] ?? "")}`;
 	return `${name} ${JSON.stringify(args)}`;
 }

--- a/packages/pi-explore-subagents/src/render.ts
+++ b/packages/pi-explore-subagents/src/render.ts
@@ -3,7 +3,7 @@ import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { isSubagentFailure } from "./config.js";
 import { MODE_SPECS, TOOL_NAME } from "./constants.js";
 import { formatToolCall, formatUsage, getToolCalls } from "./messages.js";
-import type { ChildRunDetails, ExploreMode } from "./types.js";
+import type { ChildRunDetails } from "./types.js";
 
 function getSubagentCallPreview(
 	details: Pick<ChildRunDetails, "task" | "mode">,

--- a/packages/pi-explore-subagents/tsconfig.json
+++ b/packages/pi-explore-subagents/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "index.ts",
-    "src/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "src/**/*.ts"]
 }

--- a/packages/pi-markdown-workflows/AGENTS.md
+++ b/packages/pi-markdown-workflows/AGENTS.md
@@ -1,13 +1,14 @@
 # AGENTS.md
 
-## Repository Overview
+## Overview
 
 Pi extension that provides workflow tooling (`workflows`, `workflows_create`, `/workflow`) and embedded subdirectory `AGENTS.md` autoloading.
 
 ## Build & Verification
 
-- Typecheck: `npx tsc --noEmit`
-- Build: `npm run build`
+- Typecheck: `bun run typecheck`
+- Check: `bun run check`
+- Build: `bun run build`
 
 ## Notes
 

--- a/packages/pi-markdown-workflows/package.json
+++ b/packages/pi-markdown-workflows/package.json
@@ -1,80 +1,80 @@
 {
-  "name": "@howaboua/pi-markdown-workflows",
-  "version": "0.2.9",
-  "description": "Pi extension with workflows tools and embedded subdirectory AGENTS.md context loading",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-markdown-workflows"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-markdown-workflows#readme",
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "keywords": [
-    "pi",
-    "pi-coding-agent",
-    "extension",
-    "pi-extension",
-    "pi-package",
-    "agents",
-    "agents-md",
-    "skills",
-    "workflows",
-    "markdown",
-    "sop",
-    "subdir-context",
-    "automation"
-  ],
-  "license": "MIT",
-  "files": [
-    "AGENTS.md",
-    "dist",
-    "skills",
-    "LICENSE",
-    "README.md",
-    "index.ts",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "scripts": {
-    "build": "tsc",
-    "test": "node tests/subdir-context.test.mjs && node tests/skill-discovery.test.mjs",
-    "check": "bun run lint && bun run typecheck",
-    "clean": "rm -rf dist",
-    "lint": "biome check .",
-    "format": "biome check --write .",
-    "verify": "bun run check && bun run build && bun run test",
-    "publish:dry-run": "npm publish --dry-run",
-    "publish:dev": "npm publish --tag dev",
-    "release:dev": "npm version prerelease --preid dev && npm publish --tag dev",
-    "prepack": "bun run verify",
-    "prepublishOnly": "bun run verify",
-    "typecheck": "tsgo --noEmit"
-  },
-  "dependencies": {
-    "@howaboua/pi-howaboua-extensions-primitives-sdk": "^0.3.0",
-    "typebox": "^1.1.34"
-  },
-  "devDependencies": {
-    "@types/node": "^24.3.0",
-    "oxfmt": "^0.35.0",
-    "typescript": "^5.9.3",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.76.0"
-  },
-  "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ]
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@howaboua/pi-markdown-workflows",
+	"version": "0.2.9",
+	"description": "Pi extension with workflows tools and embedded subdirectory AGENTS.md context loading",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-markdown-workflows"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-markdown-workflows#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"keywords": [
+		"pi",
+		"pi-coding-agent",
+		"extension",
+		"pi-extension",
+		"pi-package",
+		"agents",
+		"agents-md",
+		"skills",
+		"workflows",
+		"markdown",
+		"sop",
+		"subdir-context",
+		"automation"
+	],
+	"license": "MIT",
+	"files": [
+		"AGENTS.md",
+		"dist",
+		"skills",
+		"LICENSE",
+		"README.md",
+		"index.ts",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"test": "node tests/subdir-context.test.mjs && node tests/skill-discovery.test.mjs",
+		"check": "bun run lint && bun run typecheck",
+		"clean": "rm -rf dist",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"verify": "bun run check && bun run build && bun run test",
+		"publish:dry-run": "npm publish --dry-run",
+		"publish:dev": "npm publish --tag dev",
+		"release:dev": "npm version prerelease --preid dev && npm publish --tag dev",
+		"prepack": "bun run verify",
+		"prepublishOnly": "bun run verify",
+		"typecheck": "tsgo --noEmit"
+	},
+	"dependencies": {
+		"@howaboua/pi-howaboua-extensions-primitives-sdk": "^0.3.0",
+		"typebox": "^1.1.34"
+	},
+	"devDependencies": {
+		"@types/node": "^24.3.0",
+		"oxfmt": "^0.35.0",
+		"typescript": "^5.9.3",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "^0.76.0"
+	},
+	"pi": {
+		"extensions": [
+			"./dist/index.js"
+		]
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/pi-markdown-workflows/src/core/frontmatter.ts
+++ b/packages/pi-markdown-workflows/src/core/frontmatter.ts
@@ -106,8 +106,8 @@ export function parseNameDescriptionFrontmatter(
 	const parsed = parseFrontmatter(content);
 	if (!parsed) return null;
 
-	const name = normalizePlainText(parsed.name ?? "");
-	const description = normalizePlainText(parsed.description ?? "");
+	const name = normalizePlainText(parsed["name"] ?? "");
+	const description = normalizePlainText(parsed["description"] ?? "");
 	if (!name || !description) return null;
 
 	return { name, description };

--- a/packages/pi-markdown-workflows/src/core/subdir.ts
+++ b/packages/pi-markdown-workflows/src/core/subdir.ts
@@ -127,17 +127,17 @@ function parsePersistedContextDetails(
 		SUBDIR_CONTEXT_DETAILS_KEY
 	];
 	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-	const files = (value as Record<string, unknown>).files;
+	const files = (value as Record<string, unknown>)["files"];
 	if (!Array.isArray(files)) return null;
 	const parsed = files
 		.filter((item): item is PersistedContextFile => {
 			if (!item || typeof item !== "object" || Array.isArray(item))
 				return false;
-			const pathValue = (item as Record<string, unknown>).path;
-			const contentValue = (item as Record<string, unknown>).content;
+			const pathValue = (item as Record<string, unknown>)["path"];
+			const contentValue = (item as Record<string, unknown>)["content"];
 			return typeof pathValue === "string" && typeof contentValue === "string";
 		})
-		.map((item) => ({ path: item.path, content: item.content }));
+		.map((item) => ({ path: item["path"], content: item["content"] }));
 	if (!parsed.length) return null;
 	return { files: parsed };
 }
@@ -201,14 +201,14 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 			const details = (message as { details?: unknown }).details;
 			const persisted = parsePersistedContextDetails(details);
 			if (!persisted) continue;
-			for (const file of persisted.files) {
-				const absolute = resolvePath(file.path, currentCwd);
+			for (const file of persisted["files"]) {
+				const absolute = resolvePath(file["path"], currentCwd);
 				if (
 					path.basename(absolute) !== "AGENTS.md" ||
 					absolute === cwdAgentsPath
 				)
 					continue;
-				out.set(absolute, file.content);
+				out.set(absolute, file["content"]);
 			}
 		}
 		return out;
@@ -283,10 +283,10 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 		const isRead = event.toolName === "read";
 		const isPathDiscoveryTool = ["grep", "find", "ls"].includes(event.toolName);
 		const shellInput =
-			typeof event.input.command === "string"
-				? event.input.command
-				: typeof event.input.cmd === "string"
-					? event.input.cmd
+			typeof event.input["command"] === "string"
+				? event.input["command"]
+				: typeof event.input["cmd"] === "string"
+					? event.input["cmd"]
 					: undefined;
 		const isShell =
 			event.toolName === "bash" ||
@@ -294,7 +294,7 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 			event.toolName === "exec_command" ||
 			event.toolName === "shell";
 		if (!isRead && !isShell && !isPathDiscoveryTool) return undefined;
-		const pathInput = event.input.path as string | undefined;
+		const pathInput = event.input["path"] as string | undefined;
 		const isDiscoveryShell =
 			isShell &&
 			typeof shellInput === "string" &&

--- a/packages/pi-markdown-workflows/src/core/workflow/ops.ts
+++ b/packages/pi-markdown-workflows/src/core/workflow/ops.ts
@@ -62,7 +62,7 @@ export async function injectWorkflowUse(
 }
 
 export async function promoteWorkflow(
-	cwd: string,
+	_cwd: string,
 	workflow: WorkflowDefinition,
 ): Promise<string> {
 	const slug = slugify(workflow.name) || "workflow";

--- a/packages/pi-markdown-workflows/tsconfig.json
+++ b/packages/pi-markdown-workflows/tsconfig.json
@@ -1,16 +1,11 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "."
-  },
-  "include": [
-    "index.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "./dist",
+		"rootDir": "."
+	},
+	"include": ["index.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/pi-memories/package.json
+++ b/packages/pi-memories/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "@howaboua/pi-memories",
-  "version": "0.0.0",
-  "type": "module",
-  "pi": {
-    "extensions": [
-      "./src/index.ts"
-    ]
-  },
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.16",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0",
-    "@types/node": "^25.9.1",
-    "typebox": "^1.1.38",
-    "typescript": "^5.9.3"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "src",
-    "README.md",
-    "tsconfig.json",
-    "biome.json",
-    "LICENSE"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-memories"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-memories#readme",
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "license": "MIT",
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-extension",
-    "memory"
-  ]
+	"name": "@howaboua/pi-memories",
+	"version": "0.0.0",
+	"type": "module",
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0",
+		"@types/node": "^25.9.1",
+		"typebox": "^1.1.38",
+		"typescript": "^5.9.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"src",
+		"README.md",
+		"tsconfig.json",
+		"biome.json",
+		"LICENSE"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-memories"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-memories#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"license": "MIT",
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-extension",
+		"memory"
+	]
 }

--- a/packages/pi-memories/src/index.ts
+++ b/packages/pi-memories/src/index.ts
@@ -317,7 +317,7 @@ export default function piMemories(pi: ExtensionAPI) {
 	loadConfig();
 
 	pi.on("session_shutdown", async (_event, ctx) => {
-		if (process.env.PI_MEMORIES_CHILD === "1") return;
+		if (process.env["PI_MEMORIES_CHILD"] === "1") return;
 		const config = loadConfig();
 		if (!config.enabled) return;
 		logDebug(config, `shutdown cwd=${ctx.cwd}`);
@@ -372,8 +372,8 @@ export default function piMemories(pi: ExtensionAPI) {
 				cwd: ctx.cwd,
 				config,
 				compactedWindow,
-				summaryText,
 				tailText,
+				...(summaryText ? { summaryText } : {}),
 			});
 			logDebug(config, `memory session completed chars=${result.length}`);
 			appendInbox(config, ctx, result);

--- a/packages/pi-memories/tsconfig.json
+++ b/packages/pi-memories/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/pi-semantic-grep/package.json
+++ b/packages/pi-semantic-grep/package.json
@@ -1,63 +1,63 @@
 {
-  "name": "@howaboua/pi-semantic-grep",
-  "version": "0.1.10",
-  "description": "Semantic code and docs search for pi, backed by OpenAI-compatible embeddings and repo-local SQLite indexes.",
-  "type": "module",
-  "license": "MIT",
-  "author": "Igor Warzocha",
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-semantic-grep#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-semantic-grep"
-  },
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "keywords": [
-    "pi",
-    "pi-extension",
-    "semantic-search",
-    "semantic-grep",
-    "embeddings",
-    "sqlite",
-    "rag",
-    "code-search"
-  ],
-  "files": [
-    "src",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "pi": {
-    "extensions": [
-      "./src/index.ts"
-    ]
-  },
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "dependencies": {
-    "better-sqlite3": "^12.10.0",
-    "typebox": "^1.0.55"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^24.0.0",
-    "typescript": "^5.8.3",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@howaboua/pi-semantic-grep",
+	"version": "0.1.10",
+	"description": "Semantic code and docs search for pi, backed by OpenAI-compatible embeddings and repo-local SQLite indexes.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-semantic-grep#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-semantic-grep"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"keywords": [
+		"pi",
+		"pi-extension",
+		"semantic-search",
+		"semantic-grep",
+		"embeddings",
+		"sqlite",
+		"rag",
+		"code-search"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"dependencies": {
+		"better-sqlite3": "^12.10.0",
+		"typebox": "^1.0.55"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/node": "^24.0.0",
+		"typescript": "^5.8.3",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/pi-semantic-grep/src/embeddings.ts
+++ b/packages/pi-semantic-grep/src/embeddings.ts
@@ -13,14 +13,15 @@ export async function embed(
 		"Content-Type": "application/json",
 	};
 	if (config.embeddings.apiKey)
-		headers.Authorization = `Bearer ${config.embeddings.apiKey}`;
+		headers["Authorization"] = `Bearer ${config.embeddings.apiKey}`;
 
-	const res = await fetch(config.embeddings.url, {
+	const init: RequestInit = {
 		method: "POST",
 		headers,
 		body: JSON.stringify({ model: config.embeddings.model, input }),
-		signal,
-	});
+	};
+	if (signal) init.signal = signal;
+	const res = await fetch(config.embeddings.url, init);
 	if (!res.ok)
 		throw new Error(`embedding endpoint ${res.status}: ${await res.text()}`);
 	const json = (await res.json()) as EmbeddingResponse;
@@ -36,9 +37,11 @@ export function cosine(a: number[], b: number[]): number {
 		bb = 0;
 	const n = Math.min(a.length, b.length);
 	for (let i = 0; i < n; i++) {
-		dot += a[i] * b[i];
-		aa += a[i] * a[i];
-		bb += b[i] * b[i];
+		const av = a[i] ?? 0;
+		const bv = b[i] ?? 0;
+		dot += av * bv;
+		aa += av * av;
+		bb += bv * bv;
 	}
 	return aa && bb ? dot / (Math.sqrt(aa) * Math.sqrt(bb)) : 0;
 }

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -117,6 +117,7 @@ export async function syncIndex(
 	for (let i = 0; i < files.length; i++) {
 		signal?.throwIfAborted();
 		const file = files[i];
+		if (!file) continue;
 		const snapshot = readFileSnapshot(root, file);
 		if (!snapshot) continue;
 		const old = known.get(file);

--- a/packages/pi-semantic-grep/tsconfig.json
+++ b/packages/pi-semantic-grep/tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["src/**/*.ts"]
 }

--- a/packages/pi-smart-btw/index.ts
+++ b/packages/pi-smart-btw/index.ts
@@ -14,7 +14,7 @@ const FALLBACK_INJECT_SHORTCUT = "alt+c";
 const FALLBACK_DISMISS_SHORTCUT = "alt+x";
 
 type State = {
-	child?: BtwChild;
+	child: BtwChild | undefined;
 	turns: BtwTurn[];
 	running: boolean;
 	queue: Promise<void>;
@@ -104,7 +104,7 @@ function sendResultMessage(pi: ExtensionAPI, turn: BtwTurn) {
 }
 
 export default function (pi: ExtensionAPI) {
-	if (process.env.PI_SMART_BTW_CHILD === "1") return;
+	if (process.env["PI_SMART_BTW_CHILD"] === "1") return;
 	ensureConfig();
 	pi.registerMessageRenderer(MESSAGE_TYPE, (message, _options, theme) => {
 		const details = message.details as
@@ -135,7 +135,12 @@ export default function (pi: ExtensionAPI) {
 			);
 		}),
 	}));
-	const state: State = { turns: [], running: false, queue: Promise.resolve() };
+	const state: State = {
+		child: undefined,
+		turns: [],
+		running: false,
+		queue: Promise.resolve(),
+	};
 
 	const dismiss = async () => {
 		await state.child?.stop();

--- a/packages/pi-smart-btw/package.json
+++ b/packages/pi-smart-btw/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "@howaboua/pi-smart-btw",
-  "version": "0.1.1",
-  "description": "Async side-session questions for Pi with explicit injection into the main chat.",
-  "type": "module",
-  "license": "MIT",
-  "files": [
-    "index.ts",
-    "src",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write .",
-    "pack:dry": "npm pack --dry-run"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0"
-  },
-  "devDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0",
-    "@types/node": "^24.10.0",
-    "typescript": "^5.9.3",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ]
-  },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-extension",
-    "side-session",
-    "btw",
-    "subagent",
-    "async"
-  ],
-  "author": "Igor Warzocha",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-smart-btw"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-smart-btw#readme",
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "engines": {
-    "node": ">=20.6.0"
-  }
+	"name": "@howaboua/pi-smart-btw",
+	"version": "0.1.1",
+	"description": "Async side-session questions for Pi with explicit injection into the main chat.",
+	"type": "module",
+	"license": "MIT",
+	"files": [
+		"index.ts",
+		"src",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0"
+	},
+	"devDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0",
+		"@types/node": "^24.10.0",
+		"typescript": "^5.9.3",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-extension",
+		"side-session",
+		"btw",
+		"subagent",
+		"async"
+	],
+	"author": "Igor Warzocha",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-smart-btw"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-smart-btw#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"engines": {
+		"node": ">=20.6.0"
+	}
 }

--- a/packages/pi-smart-btw/src/config.ts
+++ b/packages/pi-smart-btw/src/config.ts
@@ -23,7 +23,7 @@ const DEFAULT_CONFIG: Required<BtwConfig> = {
 
 function agentDir() {
 	return (
-		process.env.PI_CODING_AGENT_DIR?.trim() ||
+		process.env["PI_CODING_AGENT_DIR"]?.trim() ||
 		path.join(os.homedir(), ".pi", "agent")
 	);
 }

--- a/packages/pi-smart-btw/src/rpc-child.ts
+++ b/packages/pi-smart-btw/src/rpc-child.ts
@@ -36,11 +36,10 @@ export class BtwChild {
 	private agentEndCount = 0;
 	private closed = false;
 	private exitCode: number | undefined;
+	private readonly onUpdate: (() => void) | undefined;
 
-	constructor(
-		private cwd: string,
-		private onUpdate?: () => void,
-	) {
+	constructor(cwd: string, onUpdate?: () => void) {
+		this.onUpdate = onUpdate;
 		const cfg = readConfig();
 		const args = [
 			"--mode",
@@ -159,7 +158,7 @@ export class BtwChild {
 		return new Promise<T>((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.pending.delete(id);
-				reject(new Error(`Timed out waiting for ${String(command.type)}`));
+				reject(new Error(`Timed out waiting for ${String(command["type"])}`));
 			}, timeoutMs);
 			this.pending.set(id, {
 				resolve: (v) => resolve(v as T),

--- a/packages/pi-smart-btw/tsconfig.json
+++ b/packages/pi-smart-btw/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "index.ts",
-    "src/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "src/**/*.ts"]
 }

--- a/packages/pi-subagent-review/package.json
+++ b/packages/pi-subagent-review/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "@howaboua/pi-subagent-review",
-  "version": "0.1.52",
-  "description": "Pi extension that adds /review via an isolated review subagent.",
-  "license": "MIT",
-  "files": [
-    "index.ts",
-    "src",
-    "review.prompt.md",
-    "README.md",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-extension",
-    "review",
-    "code-review",
-    "subagent",
-    "agent"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-subagent-review"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-subagent-review#readme",
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ]
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0"
-  },
-  "type": "module",
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "devDependencies": {
-    "@earendil-works/pi-ai": "^0.76.0",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@types/node": "^24.10.0",
-    "typescript": "^5.9.3",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@howaboua/pi-subagent-review",
+	"version": "0.1.52",
+	"description": "Pi extension that adds /review via an isolated review subagent.",
+	"license": "MIT",
+	"files": [
+		"index.ts",
+		"src",
+		"review.prompt.md",
+		"README.md",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-extension",
+		"review",
+		"code-review",
+		"subagent",
+		"agent"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-subagent-review"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-subagent-review#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0"
+	},
+	"type": "module",
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"devDependencies": {
+		"@earendil-works/pi-ai": "^0.76.0",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@types/node": "^24.10.0",
+		"typescript": "^5.9.3",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/pi-subagent-review/src/constants.ts
+++ b/packages/pi-subagent-review/src/constants.ts
@@ -37,7 +37,7 @@ export const RPC_POLL_MS = 150;
 export const RPC_QUIESCENCE_MS = 500;
 
 export function getAgentDir(): string {
-	const configured = process.env.PI_CODING_AGENT_DIR?.trim();
+	const configured = process.env["PI_CODING_AGENT_DIR"]?.trim();
 	return configured || path.join(os.homedir(), ".pi", "agent");
 }
 

--- a/packages/pi-subagent-review/src/conversation-summary.ts
+++ b/packages/pi-subagent-review/src/conversation-summary.ts
@@ -116,6 +116,15 @@ export async function buildReviewConversationSummary(
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (!auth.ok) throw new Error(`Summary model unavailable: ${auth.error}`);
 
+	const options = {
+		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+		...(auth.headers ? { headers: auth.headers } : {}),
+		...(model.reasoning && config.summary.thinking !== "off"
+			? { reasoning: config.summary.thinking }
+			: {}),
+		...(ctx.signal ? { signal: ctx.signal } : {}),
+	};
+
 	const response = await completeSimple(
 		model,
 		{
@@ -127,15 +136,7 @@ export async function buildReviewConversationSummary(
 				},
 			],
 		},
-		{
-			apiKey: auth.apiKey,
-			headers: auth.headers,
-			reasoning:
-				model.reasoning && config.summary.thinking !== "off"
-					? config.summary.thinking
-					: undefined,
-			signal: ctx.signal,
-		},
+		options,
 	);
 
 	const summary = response.content

--- a/packages/pi-subagent-review/src/subagent.ts
+++ b/packages/pi-subagent-review/src/subagent.ts
@@ -103,7 +103,7 @@ export async function runReviewSubagent(
 				pendingRequests.delete(id);
 				reject(
 					new Error(
-						`Timed out waiting for RPC response to ${String(command.type)}.${details.stderr ? ` Stderr: ${details.stderr.trim()}` : ""}`,
+						`Timed out waiting for RPC response to ${String(command["type"])}.${details.stderr ? ` Stderr: ${details.stderr.trim()}` : ""}`,
 					),
 				);
 			}, timeoutMs);
@@ -124,7 +124,7 @@ export async function runReviewSubagent(
 
 	const handleEvent = (event: any) => {
 		lastEventAt = Date.now();
-		if (event.type === "message_end" && event.message) {
+		if (event["type"] === "message_end" && event.message) {
 			const message = event.message;
 			details.messages.push(message);
 			if (message.role === "assistant") {
@@ -144,7 +144,7 @@ export async function runReviewSubagent(
 			return;
 		}
 
-		if (event.type === "agent_end") agentEndCount++;
+		if (event["type"] === "agent_end") agentEndCount++;
 	};
 
 	const handleLine = (line: string) => {

--- a/packages/pi-subagent-review/tsconfig.json
+++ b/packages/pi-subagent-review/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "index.ts",
-    "src/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "src/**/*.ts"]
 }

--- a/packages/pi-vent/extensions/vent.ts
+++ b/packages/pi-vent/extensions/vent.ts
@@ -95,7 +95,7 @@ export default function ventExtension(pi: ExtensionAPI) {
 			});
 		},
 
-		renderCall(args, theme, context) {
+		renderCall(args, theme, _context) {
 			const trigger =
 				typeof args?.trigger === "string" && args.trigger.trim()
 					? ` ${args.trigger.trim()}`

--- a/packages/pi-vent/package.json
+++ b/packages/pi-vent/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "@howaboua/pi-vent",
-  "version": "0.2.4",
-  "description": "Pi extension for logging repeated workflow friction to VENT.md.",
-  "type": "module",
-  "license": "MIT",
-  "author": "Igor Warzocha",
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-vent#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-vent"
-  },
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "keywords": [
-    "pi-package",
-    "pi-extension",
-    "pi",
-    "agent",
-    "feedback",
-    "vent"
-  ],
-  "files": [
-    "extensions",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "scripts": {
-    "check": "bun run lint && bun run typecheck",
-    "prepack": "bun run check",
-    "typecheck": "tsgo --noEmit",
-    "lint": "biome check .",
-    "format": "biome check --write ."
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@types/node": "^24.10.0",
-    "typebox": "^1.0.55",
-    "typescript": "^5.9.3",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "peerDependencies": {
-    "typebox": "*",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@earendil-works/pi-tui": "^0.76.0"
-  },
-  "pi": {
-    "extensions": [
-      "./extensions/vent.ts"
-    ]
-  }
+	"name": "@howaboua/pi-vent",
+	"version": "0.2.4",
+	"description": "Pi extension for logging repeated workflow friction to VENT.md.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-vent#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-vent"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"agent",
+		"feedback",
+		"vent"
+	],
+	"files": [
+		"extensions",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@types/node": "^24.10.0",
+		"typebox": "^1.0.55",
+		"typescript": "^5.9.3",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"peerDependencies": {
+		"typebox": "*",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@earendil-works/pi-tui": "^0.76.0"
+	},
+	"pi": {
+		"extensions": [
+			"./extensions/vent.ts"
+		]
+	}
 }

--- a/packages/pi-vent/tsconfig.json
+++ b/packages/pi-vent/tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "extensions/**/*.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["extensions/**/*.ts"]
 }

--- a/scripts/add-aggregate-changesets.mjs
+++ b/scripts/add-aggregate-changesets.mjs
@@ -6,6 +6,7 @@ const root = process.cwd();
 const changesetDir = join(root, ".changeset");
 const packagesDir = join(root, "packages");
 const aggregateNames = new Set(["@howaboua/pi-stuff", "@howaboua/pi-extensions", "@howaboua/pi-skills"]);
+const aggregateExcludedNames = new Set(["@howaboua/pi-codex-conversion", "@howaboua/pi-skill-omarchy-help"]);
 const generatedPath = join(changesetDir, "aggregate-bundles.md");
 
 function readJson(path) {
@@ -36,7 +37,7 @@ let needsExtensions = false;
 let needsSkills = false;
 
 for (const { pkg } of packageInfos) {
-  if (!changedPackages.has(pkg.name) || aggregateNames.has(pkg.name)) continue;
+  if (!changedPackages.has(pkg.name) || aggregateNames.has(pkg.name) || aggregateExcludedNames.has(pkg.name)) continue;
   const hasExtensions = Array.isArray(pkg.pi?.extensions) && pkg.pi.extensions.length > 0;
   const hasSkills = Array.isArray(pkg.pi?.skills) && pkg.pi.skills.length > 0;
   if (hasExtensions || hasSkills) needsStuff = true;


### PR DESCRIPTION
## Summary
- set up release/changelog workflow for the monorepo
- fix strict workspace typechecking across extension packages, including pi-codex-conversion
- improve root README install instructions with copyable code blocks

## Validation
- `bun run check:changed`
- isolated tmux smoke test of local `pi-codex-conversion` + `pi-subagent-review`: exec, patch, image generation, image view, and web search passed
- `/review`: no actionable issues found

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-explore-subagents`, `@howaboua/pi-markdown-workflows`, `@howaboua/pi-memories`, `@howaboua/pi-semantic-grep`, `@howaboua/pi-smart-btw`, `@howaboua/pi-subagent-review`, `@howaboua/pi-vent`, plus initial skill packages
- Aggregates: auto-bumped by `bun run changeset:aggregates`

## Sponsor button
- present