### PR TITLE
Fix aggregate package publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@howaboua/pi-stuff-monorepo",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.0",
+  "packageManager": "bun@1.3.14",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -23,17 +23,6 @@
 		"@howaboua/pi-subagent-review": "0.1.53",
 		"@howaboua/pi-vent": "0.2.5"
 	},
-	"bundledDependencies": [
-		"@howaboua/pi-auto-reasoning-tool",
-		"@howaboua/pi-auto-trees",
-		"@howaboua/pi-explore-subagents",
-		"@howaboua/pi-markdown-workflows",
-		"@howaboua/pi-memories",
-		"@howaboua/pi-semantic-grep",
-		"@howaboua/pi-smart-btw",
-		"@howaboua/pi-subagent-review",
-		"@howaboua/pi-vent"
-	],
 	"files": [
 		"README.md",
 		"LICENSE"

--- a/packages/pi-skills/package.json
+++ b/packages/pi-skills/package.json
@@ -20,14 +20,6 @@
 		"@howaboua/pi-skill-project-reference-research": "0.0.1",
 		"@howaboua/pi-skill-skill-creator": "0.0.1"
 	},
-	"bundledDependencies": [
-		"@howaboua/pi-skill-agent-native-hardening",
-		"@howaboua/pi-skill-anti-ai-copy",
-		"@howaboua/pi-skill-chrome-cdp",
-		"@howaboua/pi-skill-gh-issue-pr-flow",
-		"@howaboua/pi-skill-project-reference-research",
-		"@howaboua/pi-skill-skill-creator"
-	],
 	"files": [
 		"README.md",
 		"LICENSE"

--- a/packages/pi-stuff/package.json
+++ b/packages/pi-stuff/package.json
@@ -29,23 +29,6 @@
 		"@howaboua/pi-subagent-review": "0.1.53",
 		"@howaboua/pi-vent": "0.2.5"
 	},
-	"bundledDependencies": [
-		"@howaboua/pi-auto-reasoning-tool",
-		"@howaboua/pi-auto-trees",
-		"@howaboua/pi-explore-subagents",
-		"@howaboua/pi-markdown-workflows",
-		"@howaboua/pi-memories",
-		"@howaboua/pi-semantic-grep",
-		"@howaboua/pi-skill-agent-native-hardening",
-		"@howaboua/pi-skill-anti-ai-copy",
-		"@howaboua/pi-skill-chrome-cdp",
-		"@howaboua/pi-skill-gh-issue-pr-flow",
-		"@howaboua/pi-skill-project-reference-research",
-		"@howaboua/pi-skill-skill-creator",
-		"@howaboua/pi-smart-btw",
-		"@howaboua/pi-subagent-review",
-		"@howaboua/pi-vent"
-	],
 	"files": [
 		"README.md",
 		"LICENSE"

--- a/scripts/sync-aggregate-packages.mjs
+++ b/scripts/sync-aggregate-packages.mjs
@@ -40,7 +40,7 @@ function updateAggregate(dir, filter, includeExtensions, includeSkills) {
   const file = join(packagesDir, dir, "package.json");
   const pkg = JSON.parse(readFileSync(file, "utf8"));
   pkg.dependencies = dependencyMap(filter);
-  pkg.bundledDependencies = bundled(filter);
+  delete pkg.bundledDependencies;
   pkg.files = Array.from(new Set([...(pkg.files ?? []), "README.md", "LICENSE"]));
   pkg.pi = {};
   if (includeExtensions) pkg.pi.extensions = piPaths("extensions", filter);


### PR DESCRIPTION
## Summary
- remove `bundledDependencies` from generated aggregate packages
- keep aggregate packages as dependency/meta packages so npm does not try to pack workspace symlink internals

## Validation
- `bun run aggregate:sync`
- `npm pack --dry-run --ignore-scripts` in `packages/pi-stuff`
- `npm pack --dry-run --ignore-scripts` in `packages/pi-extensions`

## Release
- Changeset: no; this fixes publishing of already-versioned aggregate packages
- Packages: `@howaboua/pi-stuff`, `@howaboua/pi-extensions`; generator also updates `@howaboua/pi-skills` for future packages
- Aggregates: n/a

## Sponsor button
- present