### PR TITLE
Fix aggregate package resource paths

### DIFF
--- a/.changeset/fix-aggregate-extension-paths.md
+++ b/.changeset/fix-aggregate-extension-paths.md
@@ -1,0 +1,7 @@
+---
+"@howaboua/pi-extensions": patch
+"@howaboua/pi-skills": patch
+"@howaboua/pi-stuff": patch
+---
+
+Fix aggregate package resource paths so Pi can load installed dependency extensions and skills.

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -29,15 +29,15 @@
 	],
 	"pi": {
 		"extensions": [
-			"node_modules/@howaboua/pi-auto-reasoning-tool/src/index.ts",
-			"node_modules/@howaboua/pi-auto-trees/index.ts",
-			"node_modules/@howaboua/pi-explore-subagents/index.ts",
-			"node_modules/@howaboua/pi-markdown-workflows/dist/index.js",
-			"node_modules/@howaboua/pi-memories/src/index.ts",
-			"node_modules/@howaboua/pi-semantic-grep/src/index.ts",
-			"node_modules/@howaboua/pi-smart-btw/index.ts",
-			"node_modules/@howaboua/pi-subagent-review/index.ts",
-			"node_modules/@howaboua/pi-vent/extensions/vent.ts"
+			"../pi-auto-reasoning-tool/src/index.ts",
+			"../pi-auto-trees/index.ts",
+			"../pi-explore-subagents/index.ts",
+			"../pi-markdown-workflows/dist/index.js",
+			"../pi-memories/src/index.ts",
+			"../pi-semantic-grep/src/index.ts",
+			"../pi-smart-btw/index.ts",
+			"../pi-subagent-review/index.ts",
+			"../pi-vent/extensions/vent.ts"
 		]
 	},
 	"repository": {

--- a/packages/pi-skills/package.json
+++ b/packages/pi-skills/package.json
@@ -26,12 +26,12 @@
 	],
 	"pi": {
 		"skills": [
-			"node_modules/@howaboua/pi-skill-agent-native-hardening/skills",
-			"node_modules/@howaboua/pi-skill-anti-ai-copy/skills",
-			"node_modules/@howaboua/pi-skill-chrome-cdp/skills",
-			"node_modules/@howaboua/pi-skill-gh-issue-pr-flow/skills",
-			"node_modules/@howaboua/pi-skill-project-reference-research/skills",
-			"node_modules/@howaboua/pi-skill-skill-creator/skills"
+			"../pi-skill-agent-native-hardening/skills",
+			"../pi-skill-anti-ai-copy/skills",
+			"../pi-skill-chrome-cdp/skills",
+			"../pi-skill-gh-issue-pr-flow/skills",
+			"../pi-skill-project-reference-research/skills",
+			"../pi-skill-skill-creator/skills"
 		]
 	},
 	"repository": {

--- a/packages/pi-stuff/package.json
+++ b/packages/pi-stuff/package.json
@@ -35,23 +35,23 @@
 	],
 	"pi": {
 		"extensions": [
-			"node_modules/@howaboua/pi-auto-reasoning-tool/src/index.ts",
-			"node_modules/@howaboua/pi-auto-trees/index.ts",
-			"node_modules/@howaboua/pi-explore-subagents/index.ts",
-			"node_modules/@howaboua/pi-markdown-workflows/dist/index.js",
-			"node_modules/@howaboua/pi-memories/src/index.ts",
-			"node_modules/@howaboua/pi-semantic-grep/src/index.ts",
-			"node_modules/@howaboua/pi-smart-btw/index.ts",
-			"node_modules/@howaboua/pi-subagent-review/index.ts",
-			"node_modules/@howaboua/pi-vent/extensions/vent.ts"
+			"../pi-auto-reasoning-tool/src/index.ts",
+			"../pi-auto-trees/index.ts",
+			"../pi-explore-subagents/index.ts",
+			"../pi-markdown-workflows/dist/index.js",
+			"../pi-memories/src/index.ts",
+			"../pi-semantic-grep/src/index.ts",
+			"../pi-smart-btw/index.ts",
+			"../pi-subagent-review/index.ts",
+			"../pi-vent/extensions/vent.ts"
 		],
 		"skills": [
-			"node_modules/@howaboua/pi-skill-agent-native-hardening/skills",
-			"node_modules/@howaboua/pi-skill-anti-ai-copy/skills",
-			"node_modules/@howaboua/pi-skill-chrome-cdp/skills",
-			"node_modules/@howaboua/pi-skill-gh-issue-pr-flow/skills",
-			"node_modules/@howaboua/pi-skill-project-reference-research/skills",
-			"node_modules/@howaboua/pi-skill-skill-creator/skills"
+			"../pi-skill-agent-native-hardening/skills",
+			"../pi-skill-anti-ai-copy/skills",
+			"../pi-skill-chrome-cdp/skills",
+			"../pi-skill-gh-issue-pr-flow/skills",
+			"../pi-skill-project-reference-research/skills",
+			"../pi-skill-skill-creator/skills"
 		]
 	},
 	"repository": {

--- a/scripts/sync-aggregate-packages.mjs
+++ b/scripts/sync-aggregate-packages.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 
 const root = process.cwd();
 const packagesDir = join(root, "packages");
@@ -22,15 +22,22 @@ function dependencyMap(filter) {
   return out;
 }
 
-function bundled(filter) {
-  return packages.filter(filter).map((entry) => entry.pkg.name);
+function packageInstallPath(packageName) {
+  return packageName.startsWith("@") ? packageName : packageName;
 }
 
-function piPaths(kind, filter) {
+function relativeDependencyResourcePath(aggregateName, dependencyName, resource) {
+  const fromDir = packageInstallPath(aggregateName);
+  const toDir = packageInstallPath(dependencyName);
+  const cleanedResource = resource.replace(/^\.\//, "");
+  return posix.join(posix.relative(fromDir, toDir), cleanedResource);
+}
+
+function piPaths(aggregateName, kind, filter) {
   const paths = [];
   for (const entry of packages.filter(filter)) {
     for (const resource of entry.pkg.pi?.[kind] ?? []) {
-      paths.push(`node_modules/${entry.pkg.name}/${resource.replace(/^\.\//, "")}`);
+      paths.push(relativeDependencyResourcePath(aggregateName, entry.pkg.name, resource));
     }
   }
   return paths;
@@ -43,8 +50,8 @@ function updateAggregate(dir, filter, includeExtensions, includeSkills) {
   delete pkg.bundledDependencies;
   pkg.files = Array.from(new Set([...(pkg.files ?? []), "README.md", "LICENSE"]));
   pkg.pi = {};
-  if (includeExtensions) pkg.pi.extensions = piPaths("extensions", filter);
-  if (includeSkills) pkg.pi.skills = piPaths("skills", filter);
+  if (includeExtensions) pkg.pi.extensions = piPaths(pkg.name, "extensions", filter);
+  if (includeSkills) pkg.pi.skills = piPaths(pkg.name, "skills", filter);
   writeFileSync(file, JSON.stringify(pkg, null, "\t") + "\n");
 }
 


### PR DESCRIPTION
## Summary
- fix aggregate package Pi resource paths so dependency extensions/skills resolve from npm installs
- update the aggregate sync script to keep sibling-relative dependency paths
- add patch changesets for aggregate packages

## Validation
- aggregate resource path resolver smoke
- `bun run check:changed`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-extensions`, `@howaboua/pi-skills`, `@howaboua/pi-stuff`
- Aggregates: directly fixed

## Sponsor button
- present