### PR TITLE
Persist subagent config and show /end progress

### DIFF
--- a/.changeset/calm-explorers-config.md
+++ b/.changeset/calm-explorers-config.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-explore-subagents": patch
 ---
 
-Persist explore subagent config under the user agent directory.
+Persist explore subagent config under the user agent directory, migrating existing package-local config on first use.

--- a/.changeset/calm-explorers-config.md
+++ b/.changeset/calm-explorers-config.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-explore-subagents": patch
+---
+
+Persist explore subagent config under the user agent directory.

--- a/.changeset/fuzzy-gh-comments.md
+++ b/.changeset/fuzzy-gh-comments.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-skill-gh-issue-pr-flow": patch
+---
+
+Document file-based GitHub comment and PR body posting to avoid escaped newline formatting mistakes.

--- a/.changeset/neat-trees-end.md
+++ b/.changeset/neat-trees-end.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-auto-trees": patch
+---
+
+Show temporary UI feedback while `/end` summarizes back to the marker.

--- a/packages/pi-auto-trees/index.ts
+++ b/packages/pi-auto-trees/index.ts
@@ -24,6 +24,7 @@ import type {
 
 export const INCREMENTAL_WORKFLOW_STATE_ENTRY = "incremental-workflow-state";
 export const INCREMENTAL_WORKFLOW_MARKER_LABEL = "marker";
+export const INCREMENTAL_WORKFLOW_END_WIDGET = "auto-trees-end";
 export const INCREMENTAL_WORKFLOW_DEFAULT_END_PROMPT = [
 	"Treat this as a finished work increment that should become durable context for continuing the same repository session.",
 	"Focus on the final accepted outcome, not dead ends or step-by-step implementation noise.",
@@ -201,6 +202,13 @@ export default function (pi: ExtensionAPI) {
 		description:
 			"Roll up work since /marker into a summary and advance the marker",
 		handler: async (args, ctx) => {
+			const clearEndFeedback = () => {
+				if (ctx.hasUI) {
+					ctx.ui.setWidget(INCREMENTAL_WORKFLOW_END_WIDGET, undefined);
+				}
+				ctx.ui.setWorkingMessage();
+			};
+
 			await ctx.waitForIdle();
 
 			if (!markerId) {
@@ -225,6 +233,13 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.setWorkingMessage(
 				ctx.ui.theme.fg("dim", "Summarizing increment…"),
 			);
+			if (ctx.hasUI) {
+				ctx.ui.setWidget(
+					INCREMENTAL_WORKFLOW_END_WIDGET,
+					[ctx.ui.theme.fg("dim", "Summarising back to marker...")],
+					{ placement: "aboveEditor" },
+				);
+			}
 
 			let result: Awaited<ReturnType<typeof ctx.navigateTree>>;
 			try {
@@ -233,7 +248,7 @@ export default function (pi: ExtensionAPI) {
 					buildEndNavigationOptions(parseEndMode(args)),
 				);
 			} finally {
-				ctx.ui.setWorkingMessage();
+				clearEndFeedback();
 			}
 
 			if (result.cancelled) {

--- a/packages/pi-auto-trees/package.json
+++ b/packages/pi-auto-trees/package.json
@@ -1,62 +1,62 @@
 {
-  "name": "@howaboua/pi-auto-trees",
-  "version": "0.1.3",
-  "description": "A Pi package that adds /marker and /end commands for incremental long-running coding sessions.",
-  "type": "module",
-  "license": "MIT",
-  "author": "pi-auto-trees contributors",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
-    "directory": "packages/pi-auto-trees"
-  },
-  "bugs": {
-    "url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
-  },
-  "homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-auto-trees#readme",
-  "keywords": [
-    "pi-package",
-    "pi-extension",
-    "pi-coding-agent",
-    "coding-agent",
-    "slash-command",
-    "session-management"
-  ],
-  "engines": {
-    "node": ">=20.6.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "index.ts",
-    "README.md",
-    "LICENSE",
-    "tsconfig.json",
-    "biome.json"
-  ],
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ]
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.76.0"
-  },
-  "devDependencies": {
-    "typescript": "^5.7.3",
-    "@earendil-works/pi-coding-agent": "^0.76.0",
-    "@biomejs/biome": "^2.4.16"
-  },
-  "scripts": {
-    "typecheck": "tsgo --noEmit",
-    "prepublishOnly": "bun run typecheck && bun run pack:dry",
-    "check": "bun run lint && bun run typecheck",
-    "lint": "biome check .",
-    "format": "biome check --write .",
-    "pack:dry": "npm pack --dry-run"
-  },
-  "overrides": {
-    "uuid": "14.0.0"
-  }
+	"name": "@howaboua/pi-auto-trees",
+	"version": "0.1.3",
+	"description": "A Pi package that adds /marker and /end commands for incremental long-running coding sessions.",
+	"type": "module",
+	"license": "MIT",
+	"author": "pi-auto-trees contributors",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-auto-trees"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-auto-trees#readme",
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-coding-agent",
+		"coding-agent",
+		"slash-command",
+		"session-management"
+	],
+	"engines": {
+		"node": ">=20.6.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"index.ts",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "^0.76.0"
+	},
+	"devDependencies": {
+		"typescript": "^5.7.3",
+		"@earendil-works/pi-coding-agent": "^0.76.0",
+		"@biomejs/biome": "^2.4.16"
+	},
+	"scripts": {
+		"typecheck": "tsgo --noEmit",
+		"prepublishOnly": "bun run typecheck && bun run pack:dry",
+		"check": "bun run lint && bun run typecheck",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run"
+	},
+	"overrides": {
+		"uuid": "14.0.0"
+	}
 }

--- a/packages/pi-auto-trees/tsconfig.json
+++ b/packages/pi-auto-trees/tsconfig.json
@@ -1,6 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "include": [
-    "index.ts"
-  ]
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts"]
 }

--- a/packages/pi-explore-subagents/README.md
+++ b/packages/pi-explore-subagents/README.md
@@ -52,7 +52,7 @@ You can also clone the package and install your local copy if you want to tune t
 
 ## Configuration
 
-On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with separate model settings for each mode. A good starting point is to keep `shallow` fast and inexpensive, and reserve `deep` for longer work:
+On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with separate model settings for each mode. If an older local install already has a tuned package-local `config.json`, those settings are copied into the new user-local file first. A good starting point is to keep `shallow` fast and inexpensive, and reserve `deep` for longer work:
 
 ```json
 {

--- a/packages/pi-explore-subagents/README.md
+++ b/packages/pi-explore-subagents/README.md
@@ -48,11 +48,11 @@ Good for:
 pi install npm:@howaboua/pi-explore-subagents
 ```
 
-You can also clone the package and install your local copy if you want to tune the prompts, model choices, or mode behavior for your own workflow. That is often the best setup because every agent stack and codebase is a little different.
+You can also clone the package and install your local copy if you want to tune the prompts or mode behavior for your own workflow.
 
 ## Configuration
 
-The package includes a simple `config.json` with separate model settings for each mode. A good starting point is to keep `shallow` fast and inexpensive, and reserve `deep` for longer work:
+On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with separate model settings for each mode. A good starting point is to keep `shallow` fast and inexpensive, and reserve `deep` for longer work:
 
 ```json
 {
@@ -66,6 +66,8 @@ The package includes a simple `config.json` with separate model settings for eac
   }
 }
 ```
+
+Edit that user-local file to tune models or thinking levels. It lives outside the installed package, so reinstalls and updates will not wipe your changes.
 
 ## Usage
 

--- a/packages/pi-explore-subagents/src/config.ts
+++ b/packages/pi-explore-subagents/src/config.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import {
 	ALLOWED_THINKING,
-	CONFIG_PATH,
 	DEFAULT_CONFIG,
+	getAgentDir,
+	getConfigPath,
 	TOOL_NAME,
 } from "./constants.js";
 import type {
@@ -28,15 +29,28 @@ function normalizeConfig(
 	return { model, thinking };
 }
 
+export function ensureConfigFile(): string {
+	const agentDir = getAgentDir();
+	const configPath = getConfigPath();
+	fs.mkdirSync(agentDir, { recursive: true });
+	if (!fs.existsSync(configPath)) {
+		fs.writeFileSync(
+			configPath,
+			`${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,
+			"utf8",
+		);
+	}
+	return configPath;
+}
+
 export function readConfig(): Record<ExploreMode, Required<ExploreConfig>> {
 	let parsed: ExtensionConfig;
+	const configPath = ensureConfigFile();
 	try {
-		parsed = JSON.parse(
-			fs.readFileSync(CONFIG_PATH, "utf8"),
-		) as ExtensionConfig;
+		parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as ExtensionConfig;
 	} catch (error) {
 		throw new Error(
-			`Could not parse ${CONFIG_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+			`Could not parse ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 

--- a/packages/pi-explore-subagents/src/config.ts
+++ b/packages/pi-explore-subagents/src/config.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_CONFIG,
 	getAgentDir,
 	getConfigPath,
+	PACKAGE_CONFIG_PATH,
 	TOOL_NAME,
 } from "./constants.js";
 import type {
@@ -29,6 +30,22 @@ function normalizeConfig(
 	return { model, thinking };
 }
 
+function readPackageConfig(): Record<ExploreMode, Required<ExploreConfig>> {
+	let parsed: ExtensionConfig | undefined;
+	try {
+		parsed = JSON.parse(
+			fs.readFileSync(PACKAGE_CONFIG_PATH, "utf8"),
+		) as ExtensionConfig;
+	} catch {
+		parsed = undefined;
+	}
+
+	return {
+		shallow: normalizeConfig(parsed?.shallow, DEFAULT_CONFIG.shallow),
+		deep: normalizeConfig(parsed?.deep, DEFAULT_CONFIG.deep),
+	};
+}
+
 export function ensureConfigFile(): string {
 	const agentDir = getAgentDir();
 	const configPath = getConfigPath();
@@ -36,7 +53,7 @@ export function ensureConfigFile(): string {
 	if (!fs.existsSync(configPath)) {
 		fs.writeFileSync(
 			configPath,
-			`${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,
+			`${JSON.stringify(readPackageConfig(), null, 2)}\n`,
 			"utf8",
 		);
 	}

--- a/packages/pi-explore-subagents/src/constants.ts
+++ b/packages/pi-explore-subagents/src/constants.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, "..");
 
 export const CONFIG_FILENAME = "pi-explore-subagents.json";
+export const PACKAGE_CONFIG_PATH = path.join(ROOT_DIR, "config.json");
 export const CHILD_ENV = "PI_EXPLORE_SUBAGENT_CHILD";
 export const TOOL_NAME = "explore_subagent";
 export const TOOL_LABEL = "Explore Subagent";

--- a/packages/pi-explore-subagents/src/constants.ts
+++ b/packages/pi-explore-subagents/src/constants.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { StringEnum } from "@earendil-works/pi-ai";
@@ -7,7 +8,7 @@ import type { ExploreConfig, ExploreMode, ThinkingLevel } from "./types.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, "..");
 
-export const CONFIG_PATH = path.join(ROOT_DIR, "config.json");
+export const CONFIG_FILENAME = "pi-explore-subagents.json";
 export const CHILD_ENV = "PI_EXPLORE_SUBAGENT_CHILD";
 export const TOOL_NAME = "explore_subagent";
 export const TOOL_LABEL = "Explore Subagent";
@@ -52,6 +53,15 @@ export const ALLOWED_THINKING = new Set<ThinkingLevel>([
 ]);
 export const RPC_POLL_MS = 150;
 export const RPC_QUIESCENCE_MS = 500;
+
+export function getAgentDir(): string {
+	const configured = process.env["PI_CODING_AGENT_DIR"]?.trim();
+	return configured || path.join(os.homedir(), ".pi", "agent");
+}
+
+export function getConfigPath(): string {
+	return path.join(getAgentDir(), CONFIG_FILENAME);
+}
 
 export const ExploreModeSchema = StringEnum(["shallow", "deep"] as const, {
 	description: "shallow | deep",

--- a/packages/pi-skill-gh-issue-pr-flow/skills/gh-issue-pr-flow/SKILL.md
+++ b/packages/pi-skill-gh-issue-pr-flow/skills/gh-issue-pr-flow/SKILL.md
@@ -20,6 +20,7 @@ This is intentionally generic. Do not assume repo-specific labels, projects, mil
 - Do not push, force-push, open a PR, comment on a PR, or request review unless the user asked for that side effect or it is clearly part of the requested workflow.
 - Ask before destructive or high-blast-radius git operations. `git reset --hard`, branch deletion, rebases over shared work, and force pushes require extra care.
 - Use auto-closing keywords like `Closes #123` only when the PR fully resolves the issue. Use `Refs #123` for partial or related work.
+- For multi-line GitHub issue, PR, and comment bodies, write the body to a temp markdown file and use `--body-file`. Do not pass shell strings with `\n`; GitHub will render literal backslash-n garbage.
 - Do not run expensive or repo-forbidden validations blindly. Read local instructions first and choose lightweight validation that matches the task.
 - For npm packages, include version and changelog handling in PR prep when the change is intended to ship. Do not use an `Unreleased` section unless the repo explicitly requires one.
 
@@ -151,6 +152,15 @@ Useful command:
 
 ```bash
 gh pr comment <pr-number-or-url> --body-file <review-request-file>
+```
+
+For issue comments, use the same file-based pattern:
+
+```bash
+cat > /tmp/issue-comment.md <<'EOF'
+Human-readable markdown here.
+EOF
+gh issue comment <issue-number-or-url> --body-file /tmp/issue-comment.md
 ```
 
 ### 9. Triage review feedback


### PR DESCRIPTION
## Summary
- Persist pi-explore-subagents config in the user agent directory instead of the installed package directory
- Show temporary auto-trees /end progress feedback above the editor while summarizing back to the marker
- Document file-based GitHub body posting in gh-issue-pr-flow to avoid escaped newline comments

## Issues
- Closes #9
- Refs #10 — reviewed the old footer marker PR and closed it as not planned

## Validation
- `bun run check:changed`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-explore-subagents`, `@howaboua/pi-auto-trees`, `@howaboua/pi-skill-gh-issue-pr-flow`
- Aggregates: auto-bumped by `bun run changeset:aggregates`

## Sponsor button
- present
