### PR TITLE
Improve release note generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-auto-trees — 0.1.4
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Show temporary UI feedback while `/end` summarizes back to the marker.
 
@@ -39,7 +39,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-codex-conversion — 1.5.17
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -47,7 +47,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-explore-subagents — 0.1.6
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Persist explore subagent config under the user agent directory, migrating existing package-local config on first use.
 
@@ -55,19 +55,21 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-extensions — 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-explore-subagents` now stores configuration in the user agent directory and migrates existing package-local config on first use.
+- `@howaboua/pi-auto-trees` now shows temporary `/end` progress feedback while summarising back to the marker.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-explore-subagents@0.1.6
-  - @howaboua/pi-auto-trees@0.1.4
+### Updated bundled packages
+
+- `@howaboua/pi-explore-subagents@0.1.6`
+- `@howaboua/pi-auto-trees@0.1.4`
 
 [Full changelog](./packages/pi-extensions/CHANGELOG.md)
 
 ### @howaboua/pi-markdown-workflows — 0.2.10
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -77,11 +79,11 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-memories — 0.1.0
 
-### Minor Changes
+### Changes
 
 - [`3c8c222`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/3c8c2222bb8d907a85517dd2155f8ea77d2441fb) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public release from the Howaboua Pi Stuff monorepo.
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -89,7 +91,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-semantic-grep — 0.1.11
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -97,7 +99,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-agent-native-hardening — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -105,7 +107,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-anti-ai-copy — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -113,7 +115,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-chrome-cdp — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -121,7 +123,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-gh-issue-pr-flow — 0.0.2
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Document file-based GitHub comment and PR body posting to avoid escaped newline formatting mistakes.
 
@@ -129,7 +131,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-omarchy-help — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -137,7 +139,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-project-reference-research — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -145,7 +147,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skill-skill-creator — 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.
 
@@ -153,18 +155,19 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-skills — 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-skill-gh-issue-pr-flow` now documents safer file-based GitHub issue, PR, and comment body posting.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-skill-gh-issue-pr-flow@0.0.2
+### Updated bundled packages
+
+- `@howaboua/pi-skill-gh-issue-pr-flow@0.0.2`
 
 [Full changelog](./packages/pi-skills/CHANGELOG.md)
 
 ### @howaboua/pi-smart-btw — 0.1.2
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -172,20 +175,23 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-stuff — 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-explore-subagents` now stores configuration in the user agent directory and migrates existing package-local config on first use.
+- `@howaboua/pi-auto-trees` now shows temporary `/end` progress feedback while summarising back to the marker.
+- `@howaboua/pi-skill-gh-issue-pr-flow` now documents safer file-based GitHub issue, PR, and comment body posting.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-explore-subagents@0.1.6
-  - @howaboua/pi-skill-gh-issue-pr-flow@0.0.2
-  - @howaboua/pi-auto-trees@0.1.4
+### Updated bundled packages
+
+- `@howaboua/pi-explore-subagents@0.1.6`
+- `@howaboua/pi-auto-trees@0.1.4`
+- `@howaboua/pi-skill-gh-issue-pr-flow@0.0.2`
 
 [Full changelog](./packages/pi-stuff/CHANGELOG.md)
 
 ### @howaboua/pi-subagent-review — 0.1.53
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 
@@ -193,7 +199,7 @@ Going forward, package-level changelogs remain the source of truth for each pack
 
 ### @howaboua/pi-vent — 0.2.5
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "test": "bun run scripts/workspaces.mjs test",
     "pack:dry": "bun run scripts/workspaces.mjs pack:dry",
     "changeset": "changeset",
-    "version-packages": "changeset version && bun run aggregate:sync && bun run changelog:sync",
+    "version-packages": "changeset version && bun run changelog:polish && bun run aggregate:sync && bun run changelog:sync",
     "release": "changeset publish",
     "check:changed": "bun run scripts/check-changed.mjs",
     "changeset:aggregates": "bun run scripts/add-aggregate-changesets.mjs",
     "hooks:install": "git config core.hooksPath .githooks",
     "changeset:check": "bun run scripts/require-changeset.mjs origin/main",
     "changelog:sync": "bun run scripts/sync-monorepo-changelog.mjs",
-    "aggregate:sync": "bun run scripts/sync-aggregate-packages.mjs"
+    "aggregate:sync": "bun run scripts/sync-aggregate-packages.mjs",
+    "changelog:polish": "bun run scripts/polish-changelogs.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/pi-auto-trees/CHANGELOG.md
+++ b/packages/pi-auto-trees/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.1.4
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Show temporary UI feedback while `/end` summarizes back to the marker.

--- a/packages/pi-codex-conversion/CHANGELOG.md
+++ b/packages/pi-codex-conversion/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.17
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 

--- a/packages/pi-explore-subagents/CHANGELOG.md
+++ b/packages/pi-explore-subagents/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.1.6
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Persist explore subagent config under the user agent directory, migrating existing package-local config on first use.
 
 ## 0.1.5
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/packages/pi-extensions/CHANGELOG.md
+++ b/packages/pi-extensions/CHANGELOG.md
@@ -2,23 +2,25 @@
 
 ## 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-explore-subagents` now stores configuration in the user agent directory and migrates existing package-local config on first use.
+- `@howaboua/pi-auto-trees` now shows temporary `/end` progress feedback while summarising back to the marker.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-explore-subagents@0.1.6
-  - @howaboua/pi-auto-trees@0.1.4
+### Updated bundled packages
+
+- `@howaboua/pi-explore-subagents@0.1.6`
+- `@howaboua/pi-auto-trees@0.1.4`
 
 ## 0.0.2
 
-### Patch Changes
+### Changes
 
 - [#6](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/6) [`e793612`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/e793612fb32a4f7e418f5d28772e6de75a5c26ad) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix aggregate package resource paths so Pi can load installed dependency extensions and skills.
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [`3c8c222`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/3c8c2222bb8d907a85517dd2155f8ea77d2441fb) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public release from the Howaboua Pi Stuff monorepo.
 

--- a/packages/pi-markdown-workflows/CHANGELOG.md
+++ b/packages/pi-markdown-workflows/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.10
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.
 

--- a/packages/pi-memories/CHANGELOG.md
+++ b/packages/pi-memories/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 0.1.0
 
-### Minor Changes
+### Changes
 
 - [`3c8c222`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/3c8c2222bb8d907a85517dd2155f8ea77d2441fb) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public release from the Howaboua Pi Stuff monorepo.
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/packages/pi-semantic-grep/CHANGELOG.md
+++ b/packages/pi-semantic-grep/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.1.11
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/packages/pi-skill-agent-native-hardening/CHANGELOG.md
+++ b/packages/pi-skill-agent-native-hardening/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-anti-ai-copy/CHANGELOG.md
+++ b/packages/pi-skill-anti-ai-copy/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-chrome-cdp/CHANGELOG.md
+++ b/packages/pi-skill-chrome-cdp/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-gh-issue-pr-flow/CHANGELOG.md
+++ b/packages/pi-skill-gh-issue-pr-flow/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.0.2
 
-### Patch Changes
+### Changes
 
 - [#11](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/11) [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Document file-based GitHub comment and PR body posting to avoid escaped newline formatting mistakes.
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-gh-issue-pr-flow/skills/gh-issue-pr-flow/SKILL.md
+++ b/packages/pi-skill-gh-issue-pr-flow/skills/gh-issue-pr-flow/SKILL.md
@@ -136,7 +136,7 @@ Only do this when requested or clearly implied.
    - validation performed
    - linked issue with `Closes` or `Refs` as appropriate
    - risks or follow-ups if useful
-   - sponsor-check status, if checked
+   - sponsor-check status only when funding/repo hygiene was part of the task
 4. If updating an existing PR, push commits and edit the body if the scope changed.
 
 ### 8. Ask Codex for review
@@ -180,7 +180,7 @@ Before final response, check:
 - pushed/PR/comment side effects match what the user asked for
 - issue/PR links are returned when created or updated
 - validation results or skipped-validation reason are reported
-- sponsor button status was reported if it was checked
+- sponsor button status was reported only when funding/repo hygiene was part of the task
 - no unrelated local changes were included
 
 ## Error handling

--- a/packages/pi-skill-omarchy-help/CHANGELOG.md
+++ b/packages/pi-skill-omarchy-help/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-project-reference-research/CHANGELOG.md
+++ b/packages/pi-skill-project-reference-research/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skill-skill-creator/CHANGELOG.md
+++ b/packages/pi-skill-skill-creator/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`f252da3`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/f252da342444236f06c6da3f7d92cbdab420d770) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public skill packages from the Howaboua Pi Stuff monorepo.

--- a/packages/pi-skills/CHANGELOG.md
+++ b/packages/pi-skills/CHANGELOG.md
@@ -2,22 +2,23 @@
 
 ## 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-skill-gh-issue-pr-flow` now documents safer file-based GitHub issue, PR, and comment body posting.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-skill-gh-issue-pr-flow@0.0.2
+### Updated bundled packages
+
+- `@howaboua/pi-skill-gh-issue-pr-flow@0.0.2`
 
 ## 0.0.2
 
-### Patch Changes
+### Changes
 
 - [#6](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/6) [`e793612`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/e793612fb32a4f7e418f5d28772e6de75a5c26ad) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix aggregate package resource paths so Pi can load installed dependency extensions and skills.
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [`3c8c222`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/3c8c2222bb8d907a85517dd2155f8ea77d2441fb) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public release from the Howaboua Pi Stuff monorepo.
 

--- a/packages/pi-smart-btw/CHANGELOG.md
+++ b/packages/pi-smart-btw/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.1.2
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/packages/pi-stuff/CHANGELOG.md
+++ b/packages/pi-stuff/CHANGELOG.md
@@ -2,24 +2,27 @@
 
 ## 0.0.3
 
-### Patch Changes
+### Changes
 
-- Bump aggregate Pi packages to include updated bundled packages.
+- `@howaboua/pi-explore-subagents` now stores configuration in the user agent directory and migrates existing package-local config on first use.
+- `@howaboua/pi-auto-trees` now shows temporary `/end` progress feedback while summarising back to the marker.
+- `@howaboua/pi-skill-gh-issue-pr-flow` now documents safer file-based GitHub issue, PR, and comment body posting.
 
-- Updated dependencies [[`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be), [`78ac21f`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/78ac21f443f2e14e00e0252b423b09182c31f0be)]:
-  - @howaboua/pi-explore-subagents@0.1.6
-  - @howaboua/pi-skill-gh-issue-pr-flow@0.0.2
-  - @howaboua/pi-auto-trees@0.1.4
+### Updated bundled packages
+
+- `@howaboua/pi-explore-subagents@0.1.6`
+- `@howaboua/pi-auto-trees@0.1.4`
+- `@howaboua/pi-skill-gh-issue-pr-flow@0.0.2`
 
 ## 0.0.2
 
-### Patch Changes
+### Changes
 
 - [#6](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/6) [`e793612`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/e793612fb32a4f7e418f5d28772e6de75a5c26ad) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix aggregate package resource paths so Pi can load installed dependency extensions and skills.
 
 ## 0.0.1
 
-### Patch Changes
+### Changes
 
 - [`3c8c222`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/3c8c2222bb8d907a85517dd2155f8ea77d2441fb) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Initial public release from the Howaboua Pi Stuff monorepo.
 

--- a/packages/pi-subagent-review/CHANGELOG.md
+++ b/packages/pi-subagent-review/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.1.53
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/packages/pi-vent/CHANGELOG.md
+++ b/packages/pi-vent/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## 0.2.5
 
-### Patch Changes
+### Changes
 
 - [#1](https://github.com/IgorWarzocha/howaboua-pi-stuff/pull/1) [`d57f0cb`](https://github.com/IgorWarzocha/howaboua-pi-stuff/commit/d57f0cbb5b92ce5cb7cf4736b6012c5ff0bebaae) Thanks [@IgorWarzocha](https://github.com/IgorWarzocha)! - Fix TypeScript errors under the shared workspace typecheck settings.

--- a/scripts/add-aggregate-changesets.mjs
+++ b/scripts/add-aggregate-changesets.mjs
@@ -1,62 +1,140 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 const root = process.cwd();
 const changesetDir = join(root, ".changeset");
 const packagesDir = join(root, "packages");
-const aggregateNames = new Set(["@howaboua/pi-stuff", "@howaboua/pi-extensions", "@howaboua/pi-skills"]);
-const aggregateExcludedNames = new Set(["@howaboua/pi-codex-conversion", "@howaboua/pi-skill-omarchy-help"]);
-const generatedPath = join(changesetDir, "aggregate-bundles.md");
+const aggregateNames = new Set([
+	"@howaboua/pi-stuff",
+	"@howaboua/pi-extensions",
+	"@howaboua/pi-skills",
+]);
+const aggregateExcludedNames = new Set([
+	"@howaboua/pi-codex-conversion",
+	"@howaboua/pi-skill-omarchy-help",
+]);
+const generatedFiles = [
+	"aggregate-bundles.md",
+	"aggregate-stuff.md",
+	"aggregate-extensions.md",
+	"aggregate-skills.md",
+];
 
 function readJson(path) {
-  return JSON.parse(readFileSync(path, "utf8"));
+	return JSON.parse(readFileSync(path, "utf8"));
 }
 
-function parseChangesetPackages(text) {
-  const match = text.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return [];
-  return [...match[1].matchAll(/^['"]?([^'":\n]+)['"]?:\s*(patch|minor|major)$/gm)].map((m) => m[1].trim());
+function parseChangeset(text) {
+	const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+	if (!match) return { packages: [], body: "" };
+	const packages = [
+		...match[1].matchAll(/^["']?([^'":\n]+)["']?:\s*(patch|minor|major)$/gm),
+	].map((m) => m[1].trim());
+	return { packages, body: match[2].trim() };
+}
+
+function cleanBody(body) {
+	return body
+		.replace(/^#+\s+/gm, "")
+		.replace(/\s+/g, " ")
+		.trim()
+		.replace(/\.$/, "");
+}
+
+function writeAggregateChangeset(filename, packages, includedChanges) {
+	const frontmatter = packages.map((name) => `"${name}": patch`).join("\n");
+	const bullets = includedChanges
+		.map(
+			({ name, body }) =>
+				`- ${name}: ${cleanBody(body) || "Updated bundled package"}.`,
+		)
+		.join("\n");
+	const content = `---\n${frontmatter}\n---\n\nInclude bundled package updates:\n\n${bullets}\n`;
+	writeFileSync(join(changesetDir, filename), content);
+	console.log(`Wrote ${filename} for ${packages.join(", ")}.`);
 }
 
 if (!existsSync(changesetDir)) process.exit(0);
 
-const changedPackages = new Set();
+for (const file of generatedFiles) {
+	const path = join(changesetDir, file);
+	if (existsSync(path)) rmSync(path);
+}
+
+const changesByPackage = new Map();
 for (const file of readdirSync(changesetDir)) {
-  if (!file.endsWith(".md") || file === "README.md" || file === "aggregate-bundles.md") continue;
-  const text = readFileSync(join(changesetDir, file), "utf8");
-  for (const pkg of parseChangesetPackages(text)) changedPackages.add(pkg);
+	if (
+		!file.endsWith(".md") ||
+		file === "README.md" ||
+		generatedFiles.includes(file)
+	)
+		continue;
+	const text = readFileSync(join(changesetDir, file), "utf8");
+	const changeset = parseChangeset(text);
+	for (const pkg of changeset.packages)
+		changesByPackage.set(pkg, changeset.body);
 }
 
 const packageInfos = readdirSync(packagesDir)
-  .filter((dir) => existsSync(join(packagesDir, dir, "package.json")))
-  .map((dir) => ({ dir, pkg: readJson(join(packagesDir, dir, "package.json")) }));
+	.filter((dir) => existsSync(join(packagesDir, dir, "package.json")))
+	.map((dir) => ({
+		dir,
+		pkg: readJson(join(packagesDir, dir, "package.json")),
+	}));
 
-let needsStuff = false;
-let needsExtensions = false;
-let needsSkills = false;
+const changedExtensions = [];
+const changedSkills = [];
 
 for (const { pkg } of packageInfos) {
-  if (!changedPackages.has(pkg.name) || aggregateNames.has(pkg.name) || aggregateExcludedNames.has(pkg.name)) continue;
-  const hasExtensions = Array.isArray(pkg.pi?.extensions) && pkg.pi.extensions.length > 0;
-  const hasSkills = Array.isArray(pkg.pi?.skills) && pkg.pi.skills.length > 0;
-  if (hasExtensions || hasSkills) needsStuff = true;
-  if (hasExtensions) needsExtensions = true;
-  if (hasSkills) needsSkills = true;
+	if (
+		!changesByPackage.has(pkg.name) ||
+		aggregateNames.has(pkg.name) ||
+		aggregateExcludedNames.has(pkg.name)
+	)
+		continue;
+	const hasExtensions =
+		Array.isArray(pkg.pi?.extensions) && pkg.pi.extensions.length > 0;
+	const hasSkills = Array.isArray(pkg.pi?.skills) && pkg.pi.skills.length > 0;
+	const entry = { name: pkg.name, body: changesByPackage.get(pkg.name) };
+	if (hasExtensions) changedExtensions.push(entry);
+	if (hasSkills) changedSkills.push(entry);
 }
 
-const aggregateBumps = [];
-if (needsStuff && !changedPackages.has("@howaboua/pi-stuff")) aggregateBumps.push("@howaboua/pi-stuff");
-if (needsExtensions && !changedPackages.has("@howaboua/pi-extensions")) aggregateBumps.push("@howaboua/pi-extensions");
-if (needsSkills && !changedPackages.has("@howaboua/pi-skills")) aggregateBumps.push("@howaboua/pi-skills");
-
-if (aggregateBumps.length === 0) {
-  if (existsSync(generatedPath)) writeFileSync(generatedPath, "");
-  console.log("No aggregate package changeset needed.");
-  process.exit(0);
+const changedStuff = [...changedExtensions, ...changedSkills];
+let wrote = false;
+if (changedStuff.length > 0 && !changesByPackage.has("@howaboua/pi-stuff")) {
+	writeAggregateChangeset(
+		"aggregate-stuff.md",
+		["@howaboua/pi-stuff"],
+		changedStuff,
+	);
+	wrote = true;
+}
+if (
+	changedExtensions.length > 0 &&
+	!changesByPackage.has("@howaboua/pi-extensions")
+) {
+	writeAggregateChangeset(
+		"aggregate-extensions.md",
+		["@howaboua/pi-extensions"],
+		changedExtensions,
+	);
+	wrote = true;
+}
+if (changedSkills.length > 0 && !changesByPackage.has("@howaboua/pi-skills")) {
+	writeAggregateChangeset(
+		"aggregate-skills.md",
+		["@howaboua/pi-skills"],
+		changedSkills,
+	);
+	wrote = true;
 }
 
-const frontmatter = aggregateBumps.map((name) => `"${name}": patch`).join("\n");
-const body = `---\n${frontmatter}\n---\n\nBump aggregate Pi packages to include updated bundled packages.\n`;
-writeFileSync(generatedPath, body);
-console.log(`Wrote ${generatedPath} for ${aggregateBumps.join(", ")}.`);
+if (!wrote) console.log("No aggregate package changeset needed.");

--- a/scripts/polish-changelogs.mjs
+++ b/scripts/polish-changelogs.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const packageDirs = readdirSync(join(root, "packages"));
+
+for (const dir of packageDirs) {
+	const changelogPath = join(root, "packages", dir, "CHANGELOG.md");
+	if (!existsSync(changelogPath)) continue;
+	const before = readFileSync(changelogPath, "utf8");
+	const after = before
+		.replace(/^### Major Changes$/gm, "### Breaking changes")
+		.replace(/^### Minor Changes$/gm, "### Changes")
+		.replace(/^### Patch Changes$/gm, "### Changes");
+	if (after !== before) writeFileSync(changelogPath, after);
+}
+
+console.log("Polished package changelog headings.");


### PR DESCRIPTION
## Summary
- Rewrite the latest generated changelog entries so release notes describe the actual user-facing changes
- Generate aggregate package changesets from the underlying package changes instead of generic bundle-bump text
- Polish Changesets headings from `Patch Changes` to user-facing `Changes`

## Validation
- `bun run changeset:aggregates`
- `bun run changelog:polish`
- `bun run changelog:sync`
- `bun run check:changed`

## Release
- Changeset: no, release workflow/docs only
- Aggregates: unchanged
