### PR TITLE
Harden agent guidance and add review loop

### DIFF
--- a/.changeset/language-agnostic-hardening.md
+++ b/.changeset/language-agnostic-hardening.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-skill-agent-native-hardening": patch
+---
+
+Makes the agent native hardening skill language-agnostic and adds JavaScript/TypeScript-, Python-, Rust-, and Go-specific reference guidance.

--- a/.changeset/review-loop-marker.md
+++ b/.changeset/review-loop-marker.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subagent-review": minor
+---
+
+Add `/review loop` markers that summarize completed review-fix increments before the next review pass.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .pi/*
 !.pi/skills/
 !.pi/skills/**
+!.pi/prompts/
+!.pi/prompts/**

--- a/.pi/prompts/pr-ready.md
+++ b/.pi/prompts/pr-ready.md
@@ -1,0 +1,18 @@
+---
+description: Produce a concise PR-ready handoff summary for the parent agent
+---
+
+Produce a concise PR-ready handoff summary for the parent agent using the current session context.
+
+Do not inspect changed files unless something is unclear.
+Do not run full validation unless explicitly asked.
+Do not create commits, branches, issues, or PRs.
+
+Final response should be copy-pasteable and include:
+- what changed
+- validation already run, if known
+- changed files, if known from context
+- changeset info, if known
+- remaining risks or follow-up, if any
+
+Keep it short and PR-oriented.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/SKILL.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/SKILL.md
@@ -1,25 +1,27 @@
 ---
 name: agent-native-hardening
-description: "Hardens TypeScript/JavaScript codebases for agent-native maintainability. Use when asked to audit, score, refactor, or plan cleanup for architecture, godfiles, godfunctions, feature folders, DRY, type safety, traversability, feedback loops, worktrees, or subagent-friendly structure."
+description: "Hardens codebases for agent-native maintainability across languages. Use when asked to audit, score, refactor, or plan cleanup for architecture, godfiles, godfunctions, feature folders, duplication, type/contract safety, traversability, feedback loops, worktrees, or subagent-friendly structure."
 ---
 
 # Agent Native Hardening
 
-Use this skill when the user asks to review and improve a codebase for agent-native maintainability, especially requests like:
-- "score this repo"
-- "make this codebase agent-friendly"
-- "improve code quality / maintainability"
-- "clean up the architecture"
-- "refactor with swarm/worktrees"
-- "improve quality loops and structure"
+## Purpose
+
+Harden a codebase so humans and agents can change it safely: clear ownership, small focused modules, explicit contracts, deterministic checks, and low reread cost.
 
 ## Must-Read References
 
-Read these supporting files before applying the skill, not after improvising the workflow:
+Read supporting files before applying the relevant part of the workflow:
 - `references/scoring-rubric.md` before any scorecard, findings list, or severity ranking.
 - `references/swarm-lanes.md` before planning discovery lanes, implementation lanes, worktrees, or subagent splits.
+- `references/js-ts.md` when the target repo uses JavaScript, TypeScript, Node package scripts, or JS/TS tooling.
+- `references/python.md` when the target repo uses Python, Python packaging, Python type checkers, or Python test/lint tooling.
+- `references/rust.md` when the target repo uses Rust, Cargo workspaces, Rust async runtimes, FFI, or Rust lint/test tooling.
+- `references/go.md` when the target repo uses Go, Go modules/workspaces, goroutines/channels, or Go lint/test/security tooling.
 
 If a reference file is missing or unreadable, say so and continue with the closest fallback, but do not silently skip it.
+
+If the repo uses a language, framework, or ecosystem that has no bundled reference, or if a bundled reference does not fit the repo, infer best practices from the general rules in this skill and the repo's own tooling/docs. Do not force an irrelevant language reference onto the repo.
 
 ## Core Principles
 
@@ -28,7 +30,7 @@ If a reference file is missing or unreadable, say so and continue with the close
 3. Keep tests light and deterministic; avoid flaky integration tests unless requested.
 4. Use lanes to separate evidence gathering and implementation. A lane can be a read-only exploration task, a direct coding pass, a subagent task, or a worktree branch depending on scope and risk.
 5. Keep each lane focused, low-overlap, and easy to verify.
-6. Prefer feature folders over catch-all files; godfiles and godfunctions must be extracted into clear feature-owned modules and small typed flows.
+6. Prefer feature-owned modules over catch-all files; godfiles and godfunctions must be extracted into clear feature-owned modules and small contract-driven flows.
 7. Push toward DRY and separation of concerns; remove copy-paste and mixed-responsibility modules without replacing them with new junk drawers.
 8. Treat feature velocity as a risk signal: cheap-feeling additions still spend finite complexity budget. Prefer explicit scope boundaries and reject bloat that does not serve the product's core job.
 9. Make the shortest agent path the correct path by writing concrete architecture invariants before adding features: ownership rules, extension points, message/event contracts, state-transition rules, and forbidden shortcuts.
@@ -37,7 +39,7 @@ If a reference file is missing or unreadable, say so and continue with the close
 
 Always score these categories from 0-10 and explain evidence with file references:
 1. `agent_native`
-2. `fully_typed`
+2. `contract_safety`
 3. `traversable`
 4. `test_coverage`
 5. `feedback_loops`
@@ -46,42 +48,42 @@ Always score these categories from 0-10 and explain evidence with file reference
 Use rubric: `references/scoring-rubric.md`. Read it fully before assigning scores.
 Always call out godfiles, godfunctions, mixed-concern modules, duplication hotspots, and feature-boundary violations in the evidence.
 
-## Type Safety Policy
+## Contract Safety Policy
 
-1. Make impossible states unrepresentable: prefer discriminated unions over boolean flag bags and optional-field state objects.
-2. Use branded/domain types for validated primitives when values are easy to mix up, such as IDs, emails, paths, slugs, and external references.
-3. Validate at IO boundaries, then pass trusted domain types internally.
-4. Derive types from the source of truth instead of restating shapes by hand.
-5. Preserve types across DB, server, client, and event/queue boundaries when project tooling supports it.
-6. Prefer object parameters over positional arguments for functions with multiple ambiguous arguments.
-7. Penalize pervasive `any`, unsafe casts, manually duplicated DTOs, and type drift between layers.
-8. Penalize positional data models: arrays/tuples/string lists where field identity is implied by index, magic column numbers, parallel arrays, or flattened display rows passed through domain logic. Keep typed domain objects until the render/serialization boundary.
+1. Make impossible states unrepresentable: prefer explicit variants/state models over boolean flag bags and optional-field state objects.
+2. Use domain-specific value types or validators for primitives that are easy to mix up, such as IDs, emails, paths, slugs, amounts, units, and external references.
+3. Validate at IO boundaries, then pass trusted domain values internally.
+4. Derive contracts from the source of truth instead of restating shapes by hand.
+5. Preserve contracts across storage, server, client, process, and event/queue boundaries when project tooling supports it.
+6. Prefer named fields or object-like parameters over positional arguments for calls with multiple ambiguous values.
+7. Penalize unchecked dynamic values, unsafe conversions, manually duplicated data shapes, and drift between layers.
+8. Penalize positional data models: arrays/tuples/string lists where field identity is implied by index, magic column numbers, parallel arrays, or flattened display rows passed through domain logic. Keep named domain objects until the render/serialization boundary.
 
 ## State + Control-Flow Ownership Policy
 
 1. Application/root objects should route, compose, and own only truly global lifecycle state; feature/view-specific state belongs to feature/view-owned modules.
-2. Avoid global dispatch functions that accumulate per-feature conditionals. Prefer polymorphic handlers, feature-local keymaps/actions, reducers, or command registries with typed contracts.
+2. Avoid global dispatch functions that accumulate per-feature conditionals. Prefer polymorphic handlers, feature-local keymaps/actions, reducers/state machines, command registries, or message handlers with explicit contracts.
 3. Adding a feature should usually mean adding a feature-owned file/folder, not adding branches to central handlers. If central changes are required, they should be small registration or routing changes.
-4. State transitions should be explicit and typed. Background/async work produces typed messages/events/results; one owner applies mutations in a predictable place.
+4. State transitions should be explicit and modeled. Background/async work produces messages/events/results with clear shapes; one owner applies mutations in a predictable place.
 5. Render/view functions should be pure where the framework allows it: no I/O, channel operations, hidden mutation, or background task coordination.
-6. Watch for manual cleanup/reset patterns (`= null`, `= undefined`, `= []`, `= nil`) scattered across handlers; they often indicate missing state isolation or unmodeled lifecycle transitions.
+6. Watch for manual cleanup/reset patterns (`= null`, `= none`, `= nil`, `= undefined`, `= []`, empty string sentinels) scattered across handlers; they often indicate missing state isolation or unmodeled lifecycle transitions.
 
 ## Godfile, Godfunction + Boundary Policy
 
 1. Treat a file or folder as a godfile hotspot when it acts as a catch-all for unrelated responsibilities, mixes layers, or keeps absorbing unrelated edits.
-2. Godfiles must be broken apart into feature folders with clear ownership and small entrypoints.
-3. Treat a function as a godfunction when it handles unrelated responsibilities, mixes orchestration/domain logic/IO/rendering/mutation, grows feature-specific branches, or requires large local context to change safely.
-4. Godfunctions must be split into named steps with owned responsibilities: feature-local handlers, pure domain transforms, typed command/event boundaries, IO adapters, and small orchestration functions.
-5. Extract by feature first, then by concern inside the feature: keep orchestration, domain logic, IO, schemas/types, UI, and tests separated when the codebase shape allows it.
+2. Godfiles must be broken apart into feature folders/modules with clear ownership and small entrypoints.
+3. Treat a function/method/procedure as a godfunction when it handles unrelated responsibilities, mixes orchestration/domain logic/IO/rendering/mutation, grows feature-specific branches, or requires large local context to change safely.
+4. Godfunctions must be split into named steps with owned responsibilities: feature-local handlers, pure domain transforms, explicit command/event boundaries, IO adapters, and small orchestration functions.
+5. Extract by feature first, then by concern inside the feature: keep orchestration, domain logic, IO, schemas/contracts, UI, and tests separated when the codebase shape allows it.
 6. Enforce DRY by pulling repeated logic into the nearest stable shared boundary with a clear owner.
-7. Do not "fix" duplication by creating a generic `utils` or `helpers` dumping ground; shared code still needs an explicit domain or platform owner.
+7. Do not fix duplication by creating a generic `utils`, `helpers`, `common`, or `misc` dumping ground; shared code still needs an explicit domain or platform owner.
 8. Penalize codebases that retain godfiles, godfunctions, mixed-responsibility modules, or broad cross-feature coupling even if tests still pass.
 
 ## Execution Workflow
 
 1. Baseline
 - Confirm clean git state.
-- Identify active check commands (`lint`, `typecheck`, `test`, `format:check`).
+- Identify active check commands: format, lint/static analysis, contract/type/schema checks, tests, build, and any repo-specific verification command.
 
 2. Evidence Sweep
 - For non-trivial repos, use read-only discovery lanes first. These may be explore-style subagents or your own direct inspection.
@@ -95,11 +97,13 @@ Always call out godfiles, godfunctions, mixed-concern modules, duplication hotsp
 - Choose the lightest lane mechanism that fits: direct edit, explore subagent, coding subagent, worktree, or integration branch.
 - Worktrees and commits are recommended for parallel/high-risk implementation, not mandatory for every lane.
 - Each implementation lane has one atomic objective and a clear validation command.
+- During recommendations, include optional modernization lanes when evidence supports them, such as stricter lint/static-analysis structure, stronger formatting gates, newer compiler/runtime versions, or updated contract-check tooling. Present these as suggestions only; do not perform toolchain upgrades or stricter rule adoption unless the user accepts.
 
 4. Implement or Coordinate
 - Use subagents when they reduce context load or parallelize cleanly; otherwise implement directly.
 - Require each implementation lane to run only relevant checks.
 - Track exact changed files. If using worker agents or worktrees, require a commit message or merge summary.
+- If the user accepts a modernization lane, implement it honestly. Do not make checks pass by hiding errors, weakening rules, broad-ignore patterns, suppressing diagnostics, adding obscure exemptions, or avoiding needed refactors. Keep repo principles intact and fix the real incompatibilities the upgrade reveals.
 
 5. Merge + Stabilize
 - If worktrees/branches were used, merge lane branches into an integration branch.
@@ -108,7 +112,7 @@ Always call out godfiles, godfunctions, mixed-concern modules, duplication hotsp
 - Fix only real breakages introduced by the hardening pass or lane merges.
 
 6. Final Report
-- Report findings first (by severity).
+- Report findings first by severity.
 - Provide updated scorecard.
 - Provide concise change log and remaining risks.
 
@@ -124,13 +128,13 @@ Avoid comments that restate obvious code.
 
 ## Structural Refactor Policy
 
-1. Default repo shape should favor feature folders over layerless file piles.
+1. Default repo shape should favor feature folders/modules over layerless file piles.
 2. When a file or function mixes multiple concerns, split it before adding more behavior.
 3. When duplication appears across features, first check whether the behavior is truly shared and stable; if yes, extract it into an owned shared module, otherwise keep it feature-local.
-4. Prefer small, composable modules with obvious ownership over giant "central" files.
+4. Prefer small, composable modules with obvious ownership over giant central files.
 5. In findings and final scoring, explicitly say whether the repo is moving toward or away from DRY and separation of concerns.
 6. Before implementing net-new features during hardening, identify the product/core-user scope boundary. Defer features that widen scope without strengthening architecture or the core workflow.
-7. Replace “special-case in the central path” changes with owned extension points: feature registration, typed messages, local handlers, or strategy objects.
+7. Replace “special-case in the central path” changes with owned extension points: feature registration, message contracts, local handlers, or strategy objects.
 
 ## Minimal Documentation Policy
 
@@ -141,13 +145,46 @@ Avoid comments that restate obvious code.
 
 ## Test Policy
 
-1. Add tests only for deterministic units:
+1. First inspect the existing test package, test style, fixture complexity, runtime cost, and how much behavior the repo already protects. Derive the repo's testing complexity intent from evidence instead of assuming more tests are always better.
+2. Add tests only where they matter: high-risk behavior, recently extracted logic, bug-prone state transitions, contract boundaries, or deterministic core units that would otherwise be easy to regress.
+3. Prefer matching the existing test complexity and conventions over introducing a heavier testing style. Do not dismiss an established test suite as insufficient just because it is small, integration-light, or intentionally pragmatic.
+4. Do not grow the test suite by default during a hardening pass. Avoid broad coverage campaigns, snapshot sprawl, fixture factories, mocks, or E2E scaffolding unless the user explicitly asks or the evidence clearly warrants it.
+5. Good candidates are deterministic units:
 - pure transforms
-- reducers/state machines
-- schema validation
+- state machines/reducers
+- schema/contract validation
 - handler guards
-2. Skip flaky E2E unless explicitly requested.
-3. Wire tests into existing check pipeline.
+6. Skip flaky E2E unless explicitly requested.
+7. Wire any added tests into the existing check pipeline, using the repo's current test runner and style unless there is a strong reason to suggest a separate opt-in modernization lane.
+
+## Modernization Recommendation Policy
+
+1. After inspection, recommend lint/static-analysis hardening, formatter gates, compiler/runtime upgrades, dependency modernization, or stricter contract checks only when there is evidence they would improve safety or feedback loops.
+2. Keep these as opt-in recommendations. Do not upgrade toolchains, add stricter rules, or rewrite configs unless the user accepts that lane.
+3. When a user accepts a modernization lane, follow the current best-practice path for the ecosystem instead of preserving weak legacy behavior for agent convenience.
+4. Never use “agent-friendly” as an excuse for hacks: no blanket ignores, no broad suppression comments, no watered-down rules, no fake green checks, and no avoiding a real refactor because the stricter tool exposed it.
+
+## Dependency Safety Policy
+
+1. Never bulk-update dependencies, runtimes, lockfiles, generated dependency metadata, or package-manager configs automatically. No “update everything to latest” behavior unless the user explicitly asks for that exact lane and accepts the risk.
+2. Treat dependency changes as opt-in modernization lanes. Recommend them with scope, reason, and risk; wait for user acceptance before changing package manifests or lockfiles.
+3. Prefer minimal, targeted updates that serve the accepted lane. Keep dependency and lockfile diffs reviewable, and avoid unrelated transitive churn when the package manager allows it.
+4. Prefer deterministic installs and validation commands that respect lockfiles or equivalent resolver state. Do not delete, regenerate, or normalize lockfiles casually.
+5. Treat install/build/lifecycle hooks, package-manager plugins, code generators, native binaries, and newly introduced CLIs as code execution surfaces. Do not run untrusted package code, global installers, generators, or post-install hooks just to inspect a repo.
+6. Before adding a new dependency, check for typosquatting/name confusion, surprising install scripts, opaque binaries, abandoned or suddenly revived packages, unexpected maintainers, suspicious repository/source links, and whether the dependency is actually necessary.
+7. Security scanners and audits are useful signals, not proof of safety. Do not claim a dependency is safe only because an audit passes; known-vulnerability tools often miss fresh supply-chain malware.
+8. If a package ecosystem has current guidance for script blocking, provenance, signatures, checksums, vendoring, sandboxed installs, or private mirrors, suggest those as optional hardening lanes instead of silently changing the workflow.
+9. Treat signed/provenance-attested packages as stronger signals, not automatic trust. A compromised maintainer account or CI pipeline can still publish malicious artifacts with apparently valid provenance.
+10. Treat dependency installs in developer machines and CI as possible credential-theft events. Avoid running new dependency code in environments with broad secrets, cloud credentials, publish tokens, SSH keys, or production access.
+11. For worm-like package campaigns, assume blast radius matters: one compromised package or maintainer can republish across many packages quickly. Prefer staged updates, review windows, and narrow allowlists over fresh-release chasing.
+
+## Missing or Incorrect Language Guidance
+
+1. If no bundled reference exists for the repo's language/ecosystem, proceed from the language-agnostic policies in this skill and adapt to the repo's discovered tools, conventions, and official docs when current external confirmation is needed.
+2. If a bundled reference conflicts with the repo's reality, prefer the repo evidence and general hardening principles over the stale or mismatched reference.
+3. In the final report, briefly mention that language-specific guidance was missing or mismatched when it affected recommendations.
+4. Suggest that the user may submit missing or incorrect language guidance at `https://github.com/IgorWarzocha/howaboua-pi-stuff/issues`.
+5. Do not open that issues link or browse it unless the user explicitly asks you to.
 
 ## Deliverable Format
 

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/go.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/go.md
@@ -1,0 +1,108 @@
+# Go Notes
+
+Use this reference when applying agent-native hardening to Go repos, including single-module apps, multi-module workspaces, CLIs, services, libraries, and concurrent systems.
+
+## Source anchors
+
+These notes are based on current official Go documentation and maintained Go tooling docs:
+- Go Modules Reference: modules, `go.mod`, `go.work`, and workspace behavior: https://go.dev/ref/mod
+- Go command docs: `go fmt`, `go vet`, coverage, and command tooling: https://go.dev/doc/cmd
+- Go vulnerability management and `govulncheck`: https://go.dev/doc/security/vuln/
+- Go fuzzing: https://go.dev/doc/security/fuzz/
+- Go race detector: https://go.dev/doc/articles/race_detector.html
+- `context` package docs: cancellation, deadlines, and request-scoped values: https://pkg.go.dev/context
+- `errors` package docs: wrapping, `Is`, `As`, and `Join`: https://pkg.go.dev/errors
+- `testing` package docs: subtests, `Cleanup`, `TempDir`, fuzz targets, and test helpers: https://pkg.go.dev/testing
+- Staticcheck docs for optional third-party linting: https://staticcheck.dev/docs/
+
+If recommending a Go version/toolchain upgrade, verify the current stable release from official Go sources before making the recommendation concrete.
+
+## Scorecard naming
+
+Use the main skill's `contract_safety` category. In Go, this is usually about explicit data models, narrow interfaces, error contracts, context/cancellation contracts, package boundaries, and avoiding unstructured `any`/map-shaped data.
+
+## Go baseline discovery
+
+Inspect:
+- `go.mod`, `go.sum`, and any `go.work` / `go.work.sum`
+- `cmd/`, `internal/`, `pkg/`, package directories, generated-code locations, and service entrypoints
+- `Makefile`, `Taskfile.yml`, `magefile.go`, CI configs, Dockerfiles, and scripts wrapping Go commands
+- lint/security configs such as Staticcheck, golangci-lint, `govulncheck`, or custom vet tooling
+- generated files marked with `// Code generated ... DO NOT EDIT.`; confirm they are generated before scoring them as hotspots
+
+Common checks:
+- `go test ./...`
+- `go test -race ./...` for concurrency-sensitive packages when runtime cost is acceptable
+- `go test -cover ./...` or package-specific coverage commands
+- `go vet ./...`
+- `go fmt ./...` / `gofmt` checks
+- `staticcheck ./...` when installed or already used
+- `govulncheck ./...` when security/dependency checking is in scope
+- `go mod tidy` as a consistency check, but do not casually rewrite module files without user approval or a clear lane
+
+## Common Go risk signals
+
+Penalize these strongly when they appear in central paths or public contracts:
+- godpackages with mixed HTTP, persistence, domain logic, configuration, and background worker code
+- large `main.go`, `server.go`, `service.go`, or `handler.go` files that accumulate unrelated feature branches
+- catch-all `util`, `utils`, `common`, `shared`, or `pkg` folders without a domain/platform owner
+- broad interfaces defined by consumers before a real boundary exists, or interfaces with many unrelated methods
+- interface{} / `any`, `map[string]any`, raw JSON maps, or loose `context.Value` plumbing used as domain models
+- positional slices/arrays used as domain data, magic indexes, and parallel slices
+- ignored errors, overwritten errors, `panic` in request/library paths, or logs without returning/handling the failure
+- error wrapping that hides sentinel/type contracts, or exported wrapped errors that accidentally become API commitments
+- goroutines started without ownership, cancellation, backpressure, bounded lifetime, or test visibility
+- channels used as hidden global control flow instead of clear ownership/message contracts
+- context stored on structs, passed as optional state, or used for required dependencies instead of cancellation/deadlines/request-scoped values
+- package import cycles, package names that hide ownership, or cross-feature imports through central dumping grounds
+- tests that depend on sleep timing, real network services, shared global state, or package execution order
+
+## Strong Go patterns
+
+Prefer these when hardening Go code:
+- small packages with clear names and ownership; use `internal/` to enforce private boundaries when helpful
+- command entrypoints in `cmd/<name>` that delegate to owned packages instead of containing product logic
+- explicit structs for request/response/domain data instead of loose maps
+- narrow interfaces at real boundaries, usually close to the consumer, with only the methods needed
+- explicit error contracts: wrap with context where useful, preserve inspectable errors when callers depend on them, and document exported error behavior
+- `context.Context` as the first parameter for operations that need cancellation/deadlines; propagate cancellation and always call cancel functions where required
+- owned goroutine lifecycle: clear start/stop ownership, cancellation path, wait/join behavior, and bounded channels/queues
+- table-driven tests for deterministic logic, with subtests for scenario names
+- `t.Cleanup`, `t.TempDir`, and local test fixtures instead of manual global cleanup
+- fuzz tests for parsers, encoders/decoders, protocol handlers, and validation logic with compact stable seeds
+- race-detector lanes for concurrent code, especially worker pools, caches, maps, and shared mutable state
+
+## Go package and boundary guidance
+
+- Split by product/domain ownership before splitting by technical layer. A feature package with HTTP adapter, domain logic, and persistence adapter subfiles is often more traversable than global `handlers`, `services`, and `repositories` piles.
+- Avoid `pkg/` as a default dumping ground. Use it only when the repo intentionally exposes reusable packages; otherwise prefer domain names or `internal/`.
+- Keep generated code separate and clearly marked. Do not refactor generated output directly unless generation is broken or absent.
+- Avoid package-level mutable state for configuration, clients, caches, or test toggles. Prefer explicit constructors and dependency injection at composition boundaries.
+- Avoid circular dependency workarounds that create abstract `common` packages. Break cycles by clarifying ownership and moving contracts to the smallest stable boundary.
+
+## Error handling guidance
+
+- Do not ignore returned errors unless the ignored case is intentional and documented locally.
+- Add context while preserving inspectability when callers need `errors.Is` or `errors.As`.
+- Do not convert every error into strings at package boundaries; keep structured/sentinel/type information where callers need decisions.
+- Avoid `panic` for ordinary runtime failures in libraries, handlers, workers, and request paths. Reserve it for impossible programmer errors or startup failures where crashing is the intended policy.
+- Keep logging ownership clear: either handle/log at an edge or return the error upward, but avoid duplicated noisy logs at every layer.
+
+## Concurrency and lifecycle guidance
+
+- Every goroutine should have an owner, a cancellation/stop path, and a way to observe completion or failure when correctness depends on it.
+- Prefer `context.Context` for cancellation/deadlines across API boundaries; do not use context values as a service locator or required argument bag.
+- Avoid unbounded goroutine spawning, unbounded queues, and sends that can block forever during shutdown.
+- Treat shared maps/caches/state as ownership hotspots. Use explicit synchronization or single-owner message loops, and test meaningful paths with `-race` when practical.
+- Replace sleep-based tests with synchronization primitives, fake clocks, controllable channels, or injected dependencies.
+
+## Go modernization suggestions
+
+After inspection, suggest these only as optional lanes unless the user already asked for upgrades:
+- update the Go toolchain and `go` directive to the current stable version after checking official Go sources
+- add or strengthen `go vet`, `go fmt`/format checks, Staticcheck, `govulncheck`, race-detector lanes, or coverage/fuzzing where they fit the repo
+- simplify module/workspace setup with clear `go.mod` / `go.work` ownership when multi-module development is genuinely needed
+- add package-boundary rules through `internal/`, import linting, or CI checks when cross-feature imports are causing drift
+- add deterministic CI commands that run the repo's chosen format, vet/lint, test, race/security, and build checks without hiding failures
+
+If the user accepts one of these lanes, do the upgrade cleanly. Do not make Go checks pass by weakening lint rules, deleting useful tests, adding broad excludes, ignoring errors, replacing typed data with `any`, hiding concurrency bugs, or preserving a bad package boundary because it avoids refactoring.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/js-ts.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/js-ts.md
@@ -1,0 +1,63 @@
+# JavaScript / TypeScript Notes
+
+Use this reference when applying agent-native hardening to JavaScript, TypeScript, Node, or web app repos.
+
+## Scorecard naming
+
+The main skill uses `contract_safety` as the language-neutral category. For JS/TS reports, it is acceptable to label the same category `fully_typed` when that matches the user's framing or an existing report, but score it with the contract-safety rubric.
+
+## Common JS/TS risk signals
+
+Penalize these strongly when they appear in central paths or public contracts:
+- pervasive `any`, `unknown` immediately cast away, broad `Record<string, unknown>` plumbing, or untyped external data
+- unsafe casts with `as`, non-null assertions, double casts, or unchecked JSON parsing
+- manually duplicated DTOs between API, server, client, DB, queue, and UI layers
+- type drift between schemas, database models, API handlers, client contracts, and tests
+- flag-bag React/component state with many booleans or optional fields instead of discriminated unions
+- positional tuples, string arrays, parallel arrays, magic column indexes, or table rows passed through domain logic
+- catch-all `utils.ts`, `helpers.ts`, `lib.ts`, `types.ts`, or barrel files that absorb unrelated ownership
+- root app files, route handlers, reducers, stores, or command dispatchers that keep gaining feature-specific branches
+
+## Strong JS/TS patterns
+
+Prefer these when hardening JS/TS code:
+- strict TypeScript settings where practical: `strict`, `noImplicitAny`, `noUncheckedIndexedAccess`, and `exactOptionalPropertyTypes`
+- discriminated unions for lifecycle, async, command, and UI state
+- branded/domain types for IDs, slugs, paths, emails, external refs, and validated primitives
+- runtime schemas at IO boundaries with inferred static types from the schema source of truth
+- typed API/client contracts instead of duplicated request/response interfaces
+- object parameters for functions with multiple same-shaped primitives
+- feature folders that keep route/view, domain logic, schemas/contracts, IO adapters, and tests near their owner
+- deterministic unit tests for pure transforms, reducers/state machines, schema parsing, and handler guards
+
+## JS/TS baseline commands
+
+During baseline discovery, inspect:
+- root and package `package.json` scripts
+- workspace files such as `pnpm-workspace.yaml`, `bunfig.toml`, `turbo.json`, `nx.json`, or package manager lockfiles
+- `tsconfig*.json`, lint configs, formatter configs, test runner configs, and build configs
+- generated `dist/`, `build/`, or `.next/` output only to confirm it is generated; do not treat generated code as source hotspots unless the repo edits it by hand
+
+Common active checks:
+- `npm|pnpm|yarn|bun run lint`
+- `npm|pnpm|yarn|bun run typecheck`
+- `npm|pnpm|yarn|bun test` or test-runner-specific scripts
+- `npm|pnpm|yarn|bun run build`
+- project-specific aggregate checks such as `check`, `check:changed`, or CI scripts
+
+## JS/TS implementation cautions
+
+- Do not silence errors by adding casts, `// @ts-ignore`, `// eslint-disable`, or weaker compiler settings unless the user explicitly asks and the tradeoff is documented.
+- Do not create new broad `utils` or `types` dumping grounds. Shared JS/TS modules still need an owner such as `platform/fs`, `domain/user`, `ui/forms`, or `contracts/api`.
+- Avoid refactors that move generated files, framework conventions, or build outputs unless the framework requires it.
+- When splitting React/UI code, keep render components mostly pure and move effects, IO, state transitions, and data shaping into owned hooks/modules where that improves clarity.
+
+## JS/TS modernization suggestions
+
+After inspection, suggest these only as optional lanes unless the user already asked for upgrades:
+- update TypeScript to the current stable version after verifying the latest version from an official package source
+- enable stricter compiler options where they improve real safety, especially `strict`, `noImplicitAny`, `noUncheckedIndexedAccess`, and `exactOptionalPropertyTypes`
+- strengthen linting with maintained rulesets and repo-appropriate boundaries, such as import ownership, no floating promises, no unsafe assignment/member access, and no broad suppressions
+- make `check`/CI run lint, typecheck, tests, and build in the smallest reliable aggregate command the repo supports
+
+If the user accepts one of these lanes, do the upgrade cleanly. Do not make TypeScript or lint pass by downgrading the target, relaxing strictness, scattering disable comments, adding broad ignore globs, converting failures to casts, or leaving exposed problems behind because they are inconvenient.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/python.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/python.md
@@ -1,0 +1,107 @@
+# Python Notes
+
+Use this reference when applying agent-native hardening to Python repos, including libraries, CLIs, services, data/ML projects, and web apps.
+
+## Common Python risk signals
+
+Penalize these strongly when they appear in central paths or public contracts:
+- untyped dictionaries, loosely shaped JSON, broad `dict`/`list` plumbing, or values passed through the system without validation
+- unchecked `Any`, `object`, dynamic attribute access, monkeypatching, reflection, or stringly typed dispatch in domain code
+- import side effects, mutable module-level state, hidden singleton clients, or configuration loaded at import time
+- broad `except Exception`, silent fallback defaults, swallowed subprocess/network errors, or logging instead of failing in validation paths
+- god modules such as large `utils.py`, `helpers.py`, `common.py`, `models.py`, `services.py`, or `views.py` that absorb unrelated ownership
+- framework godfiles: fat Django views/models, Flask/FastAPI route files mixing validation/business logic/database calls, or Celery task modules mixing orchestration and domain rules
+- test suites that rely on local import path accidents, real network/services, shared mutable fixtures, or order-dependent state
+- configuration sprawl across `setup.py`, `setup.cfg`, `requirements*.txt`, `tox.ini`, `pytest.ini`, `.flake8`, `mypy.ini`, and `pyproject.toml` without a clear source of truth
+
+## Strong Python patterns
+
+Prefer these when hardening Python code:
+- clear package ownership, usually with a `src/` layout for publishable libraries and CLIs when migration cost is acceptable
+- `pyproject.toml` as the visible home for project metadata and tool configuration when the repo already uses modern packaging
+- Ruff or equivalent lint/format checks wired into the repo’s normal check command
+- mypy, Pyright, or equivalent type checking for stable application/library boundaries, with strictness increased incrementally by owned module rather than random file comments
+- Pydantic, attrs, dataclasses, TypedDict, Protocol, NewType, enums, or small domain objects where they make contracts explicit
+- validation at IO boundaries: CLI args, env/config, HTTP requests, files, queues, database rows, notebooks, and third-party API responses
+- pure functions for transforms and decision logic, with IO behind adapters that are easy to fake in deterministic tests
+- pytest tests for pure transforms, schema/contract validation, failure paths, CLI guards, and framework handlers without real external services
+
+## Python baseline discovery
+
+During baseline discovery, inspect:
+- `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements*.txt`, `constraints*.txt`, `Pipfile`, `poetry.lock`, `uv.lock`, `tox.ini`, `noxfile.py`, `pytest.ini`, `.flake8`, `mypy.ini`, `pyrightconfig.json`
+- package layout: `src/`, top-level import packages, `tests/`, scripts, notebooks, migrations, generated code, and framework entrypoints
+- active check commands in README, CI, Makefile/Justfile, tox/nox sessions, package manager scripts, or task runners
+- runtime version declarations such as `requires-python`, `.python-version`, Docker images, CI Python matrix, or Pyright/mypy Python version settings
+- generated, vendored, migration, or notebook output; do not treat it as a source hotspot unless humans edit it directly
+
+Common active checks:
+- `ruff check .` and `ruff format --check .`
+- `pytest`
+- `mypy <package>` or `pyright`
+- `python -m build`, framework-specific test commands, or repo-specific aggregate commands such as `make check`, `tox`, `nox`, `uv run ...`, or `poetry run ...`
+
+## Python contract-safety guidance
+
+- Do not “fix” type checker errors by sprinkling `# type: ignore`, `cast(...)`, `Any`, or weaker config. Use those only for narrow, documented boundary cases.
+- Replace loose dict pipelines with named domain objects, TypedDicts, dataclasses/attrs models, Pydantic models, or framework schemas when the shape matters past the boundary.
+- Prefer Protocols for structural interfaces when behavior matters more than inheritance.
+- Keep domain functions independent of framework request/response objects, ORM sessions, environment reads, and global clients.
+- Use explicit result/error shapes for operations with expected failure modes instead of returning `None`, `{}`, `False`, or magic strings.
+- Keep imports boring: avoid path mutation, import-time connection setup, and side effects that make tests or agents depend on execution order.
+
+## Async Python guidance
+
+Watch async code for hidden lifecycle and ownership problems:
+- event loop management scattered across modules, nested `asyncio.run(...)`, or sync wrappers that secretly create loops
+- long-lived HTTP/database/queue clients created at import time instead of owned by an app lifespan, worker, fixture, or explicit context manager
+- background tasks launched without tracked ownership, cancellation, timeout, shutdown, or error propagation
+- swallowed `CancelledError`, broad exception handlers around task groups, or cleanup code that prevents cooperative cancellation
+- fire-and-forget tasks that mutate shared state or rely on process exit for cleanup
+- mixed sync/async APIs where blocking calls run inside the event loop without an executor or async-native adapter
+
+Prefer:
+- one clear owner for event loop/app lifespan setup
+- explicit async context managers for clients and resources
+- structured concurrency when available, such as `asyncio.TaskGroup` on supported Python versions, with cancellation and failure behavior tested
+- top-level async entrypoints that use high-level runners once, instead of libraries or nested helpers calling `asyncio.run(...)` inside an already running loop
+- typed message/result shapes between background work and state mutation owners
+- deterministic tests for timeout, cancellation, retry, and shutdown paths using fakes instead of real services
+
+## Typing migration strategy for large older repos
+
+For large legacy Python repos, recommend an incremental typing lane instead of a repo-wide flag day:
+- start with boundary modules: config loading, request/response schemas, CLI args, file parsing, queue messages, public library APIs, and core domain transforms
+- define a small number of owned strictness zones and expand them by package/module as errors are fixed
+- standardize one type-check invocation and run it consistently in CI before widening the checked surface
+- prefer `TypedDict`, dataclasses/attrs, Pydantic models, enums, NewType, and Protocols to document real shapes and behavior before chasing local annotations everywhere
+- replace repeated dict/string contracts with named objects at stable boundaries first; leave unstable internal code alone until ownership is clearer
+- use per-module config only as a temporary migration map, not a graveyard for permanent ignores
+- prefer narrow missing-import or third-party-stub exceptions over global ignore settings that hide future errors
+- track remaining untyped or weakly typed areas as explicit lanes with owners, not scattered TODO comments
+- avoid mass annotation churn that preserves bad architecture; split godmodules and clarify boundaries before forcing annotations through them
+
+## Python modernization suggestions
+
+After inspection, suggest these only as optional lanes unless the user already asked for upgrades:
+- consolidate tool configuration toward `pyproject.toml` where that reduces sprawl and matches the selected tools
+- suggest moving to `uv` for project/dependency/environment management when the repo has slow, fragmented, or unreproducible dependency workflows; keep it opt-in and verify the current uv docs before changing lockfiles or install commands
+- add or strengthen Ruff lint/format gates, with repo-appropriate rules rather than broad ignores
+- add or strengthen mypy/Pyright checking on owned modules and stable boundaries
+- update the supported Python version, package manager, lockfile workflow, or build backend after verifying current project constraints and official tool docs
+- move toward `src/` layout for publishable packages when import-path correctness matters and the migration can be validated
+- make the main check command run lint, format check, type/contract checks, tests, and build/package checks when relevant
+- for large older repos, propose an incremental typing migration plan before enabling strict checks globally
+
+If the user accepts one of these lanes, do the upgrade cleanly. Do not make Python checks pass by weakening strictness, adding blanket ignores, hiding import errors, abusing `Any`, skipping problem files, or preserving a godmodule because the stricter tool exposed too much work.
+
+## Source notes
+
+This reference was drafted from current official docs for Python packaging/`pyproject.toml`, Ruff configuration/formatter, mypy configuration, Pyright configuration, pytest configuration, uv project sync/layout, Python typing specs for TypedDict/Protocol/dataclass-related typing, and Python `asyncio` runner/task documentation.
+
+Useful source anchors:
+- Python `asyncio.run(...)` manages the loop and cannot run inside another event loop in the same thread: https://docs.python.org/3/library/asyncio-runner.html
+- Python task cancellation recommends `try/finally`, propagating `CancelledError`, and warns that swallowing cancellation can break structured concurrency: https://docs.python.org/3/library/asyncio-task.html#task-cancellation
+- Python `TaskGroup` waits for owned tasks and cancels siblings on non-cancellation failure: https://docs.python.org/3/library/asyncio-task.html#task-groups
+- mypy’s existing-code guide recommends starting small, standardizing the invocation, running in CI, and avoiding broad missing-import ignores where possible: https://mypy.readthedocs.io/en/stable/existing_code.html
+- Pyright supports `off`, `basic`, `standard`, and `strict` type-checking modes plus finer diagnostic overrides: https://github.com/microsoft/pyright/blob/main/docs/configuration.md

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/rust.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/rust.md
@@ -1,0 +1,123 @@
+# Rust Notes
+
+Use this reference when applying agent-native hardening to Rust crates, Cargo workspaces, Rust CLIs/services, or repos with Rust FFI/native components.
+
+Sources checked before writing this reference:
+- Cargo Book: `cargo fmt`, `cargo check`, workspaces, resolver behavior
+- Rustfmt project docs
+- Rust Reference: undefined behavior and unsafe responsibilities
+- Rust `core::error` docs
+- Rust API Guidelines documentation section
+- Asynchronous Programming in Rust guide
+
+## Rust baseline discovery
+
+Inspect before scoring or recommending lanes:
+- `Cargo.toml` at root and member crates
+- `[workspace]`, `members`, `default-members`, `resolver`, `[workspace.dependencies]`, `[workspace.lints]`, and feature flags
+- `Cargo.lock` for apps/workspaces; do not delete or regenerate it casually
+- `rust-toolchain.toml`, `rustfmt.toml`, `.rustfmt.toml`, `clippy.toml`, `.cargo/config.toml`, CI configs, and `Makefile`/`justfile`/`xtask` commands
+- crate layout: `src/lib.rs`, `src/main.rs`, `src/bin/*`, `crates/*`, `examples/*`, `tests/*`, `benches/*`, `build.rs`
+- generated code, bindings, or macros; confirm whether they are edited by hand before treating them as source hotspots
+
+Common checks to identify or suggest:
+- `cargo fmt -- --check`
+- `cargo check --workspace --all-targets`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-targets`
+- `cargo doc --workspace --no-deps` when public API docs matter
+
+Adjust flags to the repo's actual workspace/features. Do not blindly run `--all-features` if features are mutually exclusive or intentionally platform-specific.
+
+## Rust risk signals
+
+Penalize these when they appear in core paths:
+- giant `lib.rs`, `main.rs`, `mod.rs`, `error.rs`, `state.rs`, `util.rs`, or `prelude.rs` files that absorb unrelated concerns
+- root modules that own routing, IO, domain rules, state mutation, async task orchestration, and rendering/serialization at once
+- broad traits used as abstraction theater instead of stable extension points
+- error types that erase actionable failure modes too early in library/public boundaries
+- `unwrap`, `expect`, `panic`, or `todo!` in recoverable runtime paths
+- `Option` used where a failure reason should be modeled as `Result`
+- primitive soup: repeated `String`, `PathBuf`, `usize`, IDs, units, or raw bytes with no domain wrapper or validator where values can be mixed up
+- feature flags that create untested build combinations or hide cross-crate coupling
+- `unsafe` blocks without local safety comments/invariants and safe wrappers that do not enforce the unsafe contract
+- async tasks spawned without ownership, cancellation, shutdown, or error propagation paths
+- blocking IO or CPU-heavy work inside async tasks without an explicit blocking boundary
+
+## Strong Rust patterns
+
+Prefer these when hardening Rust code:
+- small crates/modules with `lib.rs` as a map and thin public entrypoint, not a dumping ground
+- domain modules that keep types, parsing/validation, pure transforms, and tests near the owned behavior
+- explicit enums for state machines and lifecycle transitions
+- newtypes for IDs, paths, units, validated strings, external references, and ambiguous numeric values
+- `Result` with meaningful error variants at boundaries where callers can react
+- app/CLI binaries that delegate to library modules so logic is testable without process spawning
+- integration tests for public behavior and unit tests for pure transforms, parsers, state machines, and error mapping
+- narrow trait boundaries introduced for real polymorphism, test seams, or external adapters, not preemptive genericity
+- documented `unsafe` invariants and safe APIs that prevent callers from violating them
+
+## Error handling guidance
+
+Rust's standard docs distinguish anticipated runtime failures from bugs: use `Result` and error types for expected failures; reserve panic paths for bugs or impossible states.
+
+Hardening recommendations:
+- keep rich domain errors inside libraries and public boundaries
+- convert to user-facing reports near CLI/service edges
+- avoid erasing errors too early if downstream code needs to branch on them
+- prefer `?` and small conversion helpers over large nested `match` blocks when it improves readability
+- document public failure behavior, panics, and safety notes where relevant
+
+Do not force one error crate across a repo unless the user accepts that modernization lane. Respect existing conventions unless they are causing drift, unreadable boundaries, or poor diagnostics.
+
+## Async Rust guidance
+
+Async Rust needs explicit lifecycle ownership. During inspection, look for:
+- `tokio::spawn` or runtime-specific spawn calls whose handles are dropped or ignored
+- channels with unclear close/shutdown behavior
+- background tasks that log errors but never report failure to the owner
+- cancellation paths that leave partial writes, locks, temp files, or external resources in unclear states
+- blocking calls inside async tasks
+
+Hardening patterns:
+- one owner for task startup, shutdown, and error collection
+- explicit cancellation/shutdown messages or tokens where the runtime/ecosystem supports them
+- structured task groups or owned join handles rather than fire-and-forget tasks
+- deterministic async tests with controlled time/resources when possible
+- small async orchestration functions that delegate pure transforms to synchronous code
+
+## Unsafe and FFI guidance
+
+`unsafe` means the compiler cannot verify the memory-safety contract; it does not make undefined behavior acceptable. Treat unsafe and FFI as high-signal inspection areas.
+
+For each unsafe hotspot, check:
+- is the unsafe block/module isolated from business logic?
+- are safety invariants written next to the unsafe operation or public unsafe API?
+- does the safe wrapper enforce the required preconditions?
+- are lifetimes, aliasing, ownership, thread-safety, and panic/drop behavior considered?
+- are generated bindings or external C APIs clearly separated from domain logic?
+
+Recommend `forbid(unsafe_code)` or narrower unsafe isolation only as an opt-in modernization lane unless the repo already follows that policy.
+
+## Rust modernization suggestions
+
+After inspection, suggest these only as optional lanes unless the user already asked for upgrades:
+- update to the current stable Rust toolchain after checking official Rust release/toolchain sources
+- adopt the latest appropriate Rust edition and Cargo resolver for the repo's MSRV/product constraints
+- centralize workspace dependencies/lints where it reduces drift
+- strengthen `clippy` and `rustfmt` gates in CI/check scripts
+- add `cargo deny`, audit tooling, or MSRV checks when supply-chain or compatibility risk matters
+
+If the user accepts a modernization lane, do it cleanly. Do not make Rust checks pass by weakening lints, adding broad `allow` attributes, hiding warnings, downgrading editions/toolchains, scattering `unwrap`/casts, or avoiding the refactor that stricter checks exposed.
+
+## Source anchors
+
+- Cargo fmt command: https://doc.rust-lang.org/cargo/commands/cargo-fmt.html
+- Rustfmt usage/configuration: https://github.com/rust-lang/rustfmt
+- Cargo check command: https://doc.rust-lang.org/cargo/commands/cargo-check.html
+- Cargo workspaces: https://doc.rust-lang.org/cargo/reference/workspaces.html
+- Cargo dependency resolver: https://doc.rust-lang.org/cargo/reference/resolver.html
+- Rust error handling docs: https://doc.rust-lang.org/core/error/index.html
+- Rust API Guidelines documentation: https://rust-lang.github.io/api-guidelines/documentation.html
+- Rust Reference undefined behavior: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+- Async Rust guide: https://rust-lang.github.io/async-book/part-guide/more-async-await.html

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/scoring-rubric.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/scoring-rubric.md
@@ -8,11 +8,11 @@ Apply an explicit godfile/godfunction penalty during scoring. A repo with unreso
 6-8: clear feature modules, low duplication, boundaries enforced by scripts/lint
 9-10: lane-safe architecture, deterministic extension points, feature ownership is obvious and DRY
 
-## 2) fully_typed
-0-2: mostly untyped / pervasive `any`
-3-5: TS enabled but weak strictness, unsafe casts, duplicated DTOs, or flag-bag states
-6-8: strict configs in major lanes, limited unsafe edges, types mostly derived from source of truth
-9-10: strict everywhere, clean request/event/domain typing, invalid states modeled out, end-to-end type flow preserved where tooling supports it
+## 2) contract_safety
+0-2: contracts are mostly implicit, unchecked dynamic data is pervasive, or validation is absent
+3-5: some contracts exist, but weak enforcement, unsafe conversions, duplicated data shapes, or flag-bag states remain
+6-8: contracts are enforced in major lanes, unsafe edges are limited, shapes are mostly derived from a source of truth
+9-10: contracts are strict across boundaries, invalid states are modeled out, and end-to-end data flow is preserved where tooling supports it
 
 ## 3) traversable
 0-2: hard to locate ownership and flows, godfiles/godfunctions dominate navigation
@@ -22,14 +22,16 @@ Apply an explicit godfile/godfunction penalty during scoring. A repo with unreso
 
 ## 4) test_coverage
 0-2: no tests
-3-5: minimal deterministic tests for core transforms
-6-8: broad deterministic unit coverage across lanes
-9-10: robust unit + integration + failure-path coverage
+3-5: some deterministic tests exist, but risky core behavior or contract boundaries are unprotected
+6-8: fit-for-purpose deterministic tests protect important behavior and match the repo's established test complexity
+9-10: lightweight, high-signal coverage protects critical deterministic behavior, failure paths, and contracts without flaky tests or coverage theater
+
+Score test coverage by fitness, not volume. A small pragmatic suite can score 9-10 when it protects the codebase's real risk surface and matches the repo's testing intent. Do not penalize lightweight tests just because they are few. Penalize missing tests for risky core logic, flaky/slow tests, unmaintainable fixture or mock complexity, snapshot sprawl, and tests added mainly to raise a number.
 
 ## 5) feedback_loops
 0-2: no consistent checks
-3-5: lint/typecheck only in one lane
-6-8: repo-wide lint/typecheck/test wired into `check`
+3-5: lint/static analysis or contract checks only in one lane
+6-8: repo-wide lint/static analysis/contract checks/tests wired into one command
 9-10: fast, reliable, enforced CI-style local gates
 
 ## 6) self_documenting
@@ -49,19 +51,19 @@ Treat these as strong negative signals:
 - godfunctions that mix unrelated responsibilities, such as validation, orchestration, IO, mutation, rendering, and error handling in one long flow
 - central handlers or lifecycle methods that keep absorbing feature-specific branches instead of delegating to feature-owned code
 - root app/controller objects owning feature-local state, input handling, async task coordination, and rendering decisions
-- global dispatch functions that grow with every feature instead of delegating to feature-owned handlers or typed commands
+- global dispatch functions that grow with every feature instead of delegating to feature-owned handlers or explicit commands
 - positional data flowing through domain logic: magic indexes, parallel arrays, tuple rows, or string lists whose meaning depends on order
 - scattered manual reset/cleanup patterns that reveal unmodeled state transitions or lifecycle ownership
 
 Treat these as strong positive signals:
 - godfiles decomposed into feature folders with clear ownership
-- godfunctions decomposed into small named steps with clear ownership and typed inputs/outputs
+- godfunctions decomposed into small named steps with clear ownership and explicit inputs/outputs
 - feature-local modules separated by concern where needed (`index`/entrypoint, domain logic, IO, types/schema, tests)
 - shared abstractions extracted only when genuinely cross-feature and stable
-- discriminated unions, domain/branded types, and derived types replace ambiguous primitives or manually duplicated shapes
+- explicit state variants, domain-specific value types, validators, and derived contracts replace ambiguous primitives or manually duplicated shapes
 - lower fan-in/fan-out per module and fewer unrelated edits per lane
-- central paths are small routers/registries; feature behavior lives behind explicit, typed extension points
-- async/background work communicates through typed messages/events/results, with one clear state mutation owner
+- central paths are small routers/registries; feature behavior lives behind explicit, contracted extension points
+- async/background work communicates through explicit messages/events/results, with one clear state mutation owner
 - domain data keeps named fields until render/serialization boundaries
 
 Suggested score caps:

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/swarm-lanes.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/swarm-lanes.md
@@ -21,14 +21,14 @@ Choose the lightest mechanism that keeps the work safe and comprehensible. Prefe
 - Output: hotspot list with why each one hurts traversability or ownership
 
 ### Discovery C: Duplication + Boundary Drift
-- Scope: repeated logic, duplicated DTOs/types, broad utils/helpers, cross-feature imports
+- Scope: repeated logic, duplicated data shapes/contracts, broad utils/helpers/common folders, cross-feature imports
 - Goal: identify DRY and separation-of-concerns problems without inventing premature abstractions
 - Output: duplicate patterns, proposed owner boundary, avoid/extract recommendation
 
-### Discovery D: Type Safety Drift
-- Scope: `any`, unsafe casts, flag bags, optional-field state objects, manual type copies, primitive soup
-- Goal: find places where invalid states are representable or types drift across layers
-- Output: candidate fixes using derived types, discriminated unions, or domain/branded types
+### Discovery D: Contract Safety Drift
+- Scope: unchecked dynamic values, unsafe conversions, flag bags, optional-field state objects, manual contract copies, primitive soup
+- Goal: find places where invalid states are representable or contracts drift across layers
+- Output: candidate fixes using derived contracts, explicit state variants, validators, or domain-specific value types
 
 ### Discovery E: Scope + Centralization Pressure
 - Scope: recent feature growth, root app/controller size, global dispatch handlers, route/action registries, async/background task wiring, feature flags/config bloat
@@ -38,7 +38,7 @@ Choose the lightest mechanism that keeps the work safe and comprehensible. Prefe
 ### Discovery F: Positional Data + Lifecycle Drift
 - Scope: arrays/tuples/parallel arrays used as domain data, magic indexes, flattened rows, scattered state resets, nullable lifecycle flags
 - Goal: identify implicit contracts and unmodeled transitions that confuse agents and invite off-by-one or stale-state bugs
-- Output: candidates for named domain objects, discriminated lifecycle states, typed messages/events, or owned reducers
+- Output: candidates for named domain objects, explicit lifecycle states, shaped messages/events, or owned state machines/reducers
 
 ## Implementation Lane Templates
 
@@ -67,14 +67,14 @@ Choose the lightest mechanism that keeps the work safe and comprehensible. Prefe
 - Goal: reduce reread cost for agents
 - Rule: one doc max unless user requests more
 
-### Lane F: Type/Contract Hardening
-- Scope: domain types, schemas, API/client contracts, event payloads, ambiguous function signatures
-- Goal: reduce invalid states, duplicated types, unsafe casts, ambiguous positional args, and boundary drift
+### Lane F: Contract Hardening
+- Scope: domain value types, schemas/validators, API/client contracts, event payloads, ambiguous function signatures
+- Goal: reduce invalid states, duplicated contracts, unsafe conversions, ambiguous positional args, and boundary drift
 - Typical files: schemas, DB models, API handlers, client contracts, domain types
 
 ### Lane G: State Ownership + Extension Points
 - Scope: root app/controller dispatch, input/action handlers, async task messages, render/view boundaries
-- Goal: move feature-specific branches and state into feature-owned modules while keeping central paths as typed routers/registries
+- Goal: move feature-specific branches and state into feature-owned modules while keeping central paths as contracted routers/registries
 - Typical files: app/router/controller entrypoints, feature action modules, reducers/state machines, message/event types
 
 ### Lane H: Scope Guardrails

--- a/packages/pi-subagent-review/README.md
+++ b/packages/pi-subagent-review/README.md
@@ -3,6 +3,7 @@
 `@howaboua/pi-subagent-review` is a Pi extension that adds one slash command:
 
 - `/review`
+- `/review loop`
 
 It runs an isolated review subagent against your current repo, optionally prepares a compact conversation-context summary first, injects the findings back into the session as a user message, and asks the main agent to triage those advisory findings before deciding what to address. It is modelled after Codex CLI's /review command.
 
@@ -12,11 +13,21 @@ It runs an isolated review subagent against your current repo, optionally prepar
 - detects the current git repo
 - chooses a base branch automatically
 - computes the merge base with `HEAD`
+- if no usable base branch or merge base exists, reviews the current checkout as-is
+- if the checkout is clean and has no diff against the selected base, reviews the latest commit instead of stopping early
 - inspects committed and dirty worktree changes
 - summarizes the current Pi session branch as review context, when enabled
 - runs an isolated review subagent
 - sends the findings back into the current Pi session as a user message
 - makes clear that the findings are advisory, not direct user instructions, so the main agent should triage them against prior context before editing
+
+`/review loop` starts a review loop. It sets a review-specific marker at the current conversation point, strips the `loop` word from the review guidance, and then runs the normal review.
+
+The first `/review` in a session branch also adds a visible advisory preface without starting an agent turn. The preface reminds the main agent that review findings are advisory and should be triaged against the current task, prior conversation, architectural decisions, and accepted tradeoffs before coding.
+
+After that, plain `/review` detects the active review marker, summarizes the work since that marker back into a compact review-fix increment, advances the review marker, and then runs the next isolated review pass from the compacted point. If the stored marker is gone, `/review` simply behaves like a normal review.
+
+The review marker is separate from `@howaboua/pi-auto-trees`' generic `/marker`, so both extensions can be used in the same session.
 
 While `/review` is running, the extension shows a small review widget above the editor with one of two states:
 
@@ -40,10 +51,14 @@ This means you usually never need to specify the diff base manually.
 
 Anything after `/review` is treated as extra review guidance.
 
+If the first word is `loop` in any casing, it starts review-loop mode and that word is removed from the review guidance.
+
 Examples:
 
 ```text
 /review
+/review loop
+/review LoOp focus extra attention on migrations and tests
 /review focus extra attention on migrations and tests
 /review assess whether we introduced new UI elements instead of reusing established components and existing CSS patterns
 ```

--- a/packages/pi-subagent-review/src/messages.ts
+++ b/packages/pi-subagent-review/src/messages.ts
@@ -1,0 +1,74 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import { REVIEW_COMMAND } from "./constants.js";
+import type { ReviewContext } from "./types.js";
+
+export const REVIEW_LOOP_PREFACE_MESSAGE_TYPE = "subagent-review-preface";
+
+export const REVIEW_LOOP_PREFACE_MESSAGE = [
+	"Review advisory note.",
+	"",
+	"A review subagent is about to inspect the repository in isolation. Treat its findings as advisory review input, not direct implementation instructions.",
+	"",
+	"When findings come back, triage before coding. Check each item against the current task, prior conversation, accepted architectural decisions, and any intentional tradeoffs from this session.",
+	"",
+	"Act directly only on clearly worthwhile issues: correctness bugs, security risks, data loss, broken builds, or serious regressions. For context-dependent, stylistic, architectural, low-impact, or preference-based findings, discuss the tradeoff first and say whether you would address, defer, or skip it.",
+].join("\n");
+
+function hasReviewPrefaceMessage(ctx: ExtensionCommandContext): boolean {
+	return ctx.sessionManager.getBranch().some((entry) => {
+		return (
+			entry.type === "custom_message" &&
+			entry.customType === REVIEW_LOOP_PREFACE_MESSAGE_TYPE
+		);
+	});
+}
+
+export function sendReviewPrefaceOnce(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	details: { markerId?: string } = {},
+): void {
+	if (hasReviewPrefaceMessage(ctx)) return;
+
+	pi.sendMessage(
+		{
+			customType: REVIEW_LOOP_PREFACE_MESSAGE_TYPE,
+			content: REVIEW_LOOP_PREFACE_MESSAGE,
+			display: true,
+			details,
+		},
+		{ triggerTurn: false },
+	);
+}
+
+export function buildReviewScopeText(review: ReviewContext): string {
+	if (review.scope === "latest-commit") {
+		return `for latest commit \`${review.latestCommit ?? "HEAD"}\` in \`${review.repoRoot}\` because no changes were found against the selected base`;
+	}
+
+	if (review.baseBranch && review.mergeBase) {
+		return `against local base branch \`${review.baseBranch}\` in \`${review.repoRoot}\` (merge base \`${review.mergeBase.slice(0, 12)}\`)`;
+	}
+
+	return `for current repository state in \`${review.repoRoot}\` with no usable base branch or merge base`;
+}
+
+export function buildReviewUserMessage(
+	review: ReviewContext,
+	findings: string,
+): string {
+	return [
+		`Review findings from /${REVIEW_COMMAND} ${buildReviewScopeText(review)}:`,
+		"",
+		findings.trim() || "No actionable issues found.",
+		"",
+		"These findings are advisory output from an isolated review subagent.",
+		"",
+		"Triage before coding. Weigh each item against the current task, prior conversation, accepted architectural decisions, and intentional tradeoffs from this session.",
+		"",
+		"If you address, skip, or defer findings, briefly say why.",
+	].join("\n");
+}

--- a/packages/pi-subagent-review/src/review-command.ts
+++ b/packages/pi-subagent-review/src/review-command.ts
@@ -6,11 +6,15 @@ import {
 } from "./config.js";
 import { REVIEW_COMMAND } from "./constants.js";
 import { buildReviewConversationSummary } from "./conversation-summary.js";
+import { buildReviewUserMessage, sendReviewPrefaceOnce } from "./messages.js";
+import { buildReviewTask, detectReviewContext } from "./review.js";
 import {
-	buildReviewTask,
-	buildReviewUserMessage,
-	detectReviewContext,
-} from "./review.js";
+	applyReviewLoopMarker,
+	getSemanticLeafId,
+	parseReviewArgs,
+	readReviewLoopState,
+	summarizeReviewLoopIncrement,
+} from "./review-loop.js";
 import { getFinalOutput, runReviewSubagent } from "./subagent.js";
 
 export function registerReviewCommand(pi: ExtensionAPI) {
@@ -18,6 +22,8 @@ export function registerReviewCommand(pi: ExtensionAPI) {
 		description:
 			"Run an isolated code-review subagent against the current repo and send the findings back as a user message",
 		handler: async (args, ctx) => {
+			const parsedArgs = parseReviewArgs(args);
+			const reviewPrefaceDetails: { markerId?: string } = {};
 			const setReviewWidget = (message?: string) => {
 				ctx.ui.setWidget(
 					REVIEW_COMMAND,
@@ -40,6 +46,21 @@ export function registerReviewCommand(pi: ExtensionAPI) {
 				await ctx.waitForIdle();
 			}
 
+			if (!parsedArgs.startLoop) {
+				const markerId = readReviewLoopState(ctx)?.markerId;
+				if (markerId) {
+					const loopResult = await summarizeReviewLoopIncrement(
+						pi,
+						ctx,
+						markerId,
+					);
+					if (loopResult === "cancelled") {
+						ctx.ui.notify("/review cancelled", "warning");
+						return;
+					}
+				}
+			}
+
 			let review;
 			try {
 				review = await detectReviewContext(pi, ctx.cwd);
@@ -50,6 +71,21 @@ export function registerReviewCommand(pi: ExtensionAPI) {
 				);
 				return;
 			}
+
+			if (parsedArgs.startLoop) {
+				const targetId = getSemanticLeafId(ctx);
+				if (targetId) {
+					reviewPrefaceDetails.markerId = targetId;
+					applyReviewLoopMarker(
+						pi,
+						ctx,
+						targetId,
+						readReviewLoopState(ctx)?.markerId,
+					);
+					ctx.ui.notify("Review loop marker set", "info");
+				}
+			}
+			sendReviewPrefaceOnce(pi, ctx, reviewPrefaceDetails);
 
 			if (!review.hasAnyChanges) {
 				pi.sendUserMessage(
@@ -90,7 +126,11 @@ export function registerReviewCommand(pi: ExtensionAPI) {
 					);
 				}
 
-				const task = buildReviewTask(review, args, conversationSummary);
+				const task = buildReviewTask(
+					review,
+					parsedArgs.focus,
+					conversationSummary,
+				);
 				details = createChildRunDetails(task, review.repoRoot, reviewConfig);
 				if (reviewConfig.source === "current") {
 					ctx.ui.notify(

--- a/packages/pi-subagent-review/src/review-loop.ts
+++ b/packages/pi-subagent-review/src/review-loop.ts
@@ -1,0 +1,152 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+
+export const REVIEW_LOOP_STATE_ENTRY = "subagent-review-loop-state";
+export const REVIEW_LOOP_MARKER_LABEL = "review";
+export const REVIEW_LOOP_WIDGET = "subagent-review-loop";
+export const REVIEW_LOOP_SUMMARY_PROMPT = [
+	"Treat this as a completed review-fix increment that should become durable context before the next isolated review pass.",
+	"Focus on the final accepted outcome, not dead ends or step-by-step implementation noise.",
+	"Capture which review findings were addressed, which were intentionally skipped or deferred, concrete files changed, key decisions, tests/checks run, and any remaining risks that matter for the next review.",
+	"Mention relevant commands, commits, PR outcomes, or review feedback only when they change future work.",
+	"Omit temporary debugging details, abandoned attempts, incidental churn, and repetitive review transcript noise.",
+	"Write the summary so the main agent can continue from this compacted review-loop point and immediately run the next review pass.",
+].join("\n");
+
+interface ReviewLoopState {
+	version: 1;
+	markerId: string;
+}
+
+export interface ParsedReviewArgs {
+	startLoop: boolean;
+	focus: string;
+}
+
+function isReviewLoopState(value: unknown): value is ReviewLoopState {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as { version?: unknown; markerId?: unknown };
+	return candidate.version === 1 && typeof candidate.markerId === "string";
+}
+
+export function parseReviewArgs(args: string): ParsedReviewArgs {
+	const trimmed = args.trim();
+	if (!trimmed) return { startLoop: false, focus: "" };
+
+	const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(trimmed);
+	const firstWord = match?.[1] ?? "";
+	if (firstWord.toLowerCase() !== "loop") {
+		return { startLoop: false, focus: trimmed };
+	}
+
+	return { startLoop: true, focus: (match?.[2] ?? "").trim() };
+}
+
+export function readReviewLoopState(
+	ctx: ExtensionCommandContext,
+): ReviewLoopState | undefined {
+	let state: ReviewLoopState | undefined;
+
+	for (const entry of ctx.sessionManager.getBranch()) {
+		if (entry.type !== "custom" || entry.customType !== REVIEW_LOOP_STATE_ENTRY)
+			continue;
+		if (isReviewLoopState(entry.data)) state = entry.data;
+	}
+
+	return state;
+}
+
+export function getSemanticLeafId(
+	ctx: ExtensionCommandContext,
+): string | undefined {
+	let currentId = ctx.sessionManager.getLeafId();
+
+	while (currentId) {
+		const entry = ctx.sessionManager.getEntry(currentId);
+		if (!entry) return undefined;
+
+		if (entry.type === "custom" || entry.type === "label") {
+			currentId = entry.parentId;
+			continue;
+		}
+
+		return currentId;
+	}
+
+	return undefined;
+}
+
+export function applyReviewLoopMarker(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	nextMarkerId: string,
+	previousMarkerId?: string,
+): void {
+	if (
+		previousMarkerId &&
+		previousMarkerId !== nextMarkerId &&
+		ctx.sessionManager.getLabel(previousMarkerId) === REVIEW_LOOP_MARKER_LABEL
+	) {
+		pi.setLabel(previousMarkerId, undefined);
+	}
+
+	const existingLabel = ctx.sessionManager.getLabel(nextMarkerId);
+	if (
+		existingLabel === undefined ||
+		existingLabel === REVIEW_LOOP_MARKER_LABEL
+	) {
+		pi.setLabel(nextMarkerId, REVIEW_LOOP_MARKER_LABEL);
+	}
+
+	pi.appendEntry(REVIEW_LOOP_STATE_ENTRY, {
+		version: 1,
+		markerId: nextMarkerId,
+	} satisfies ReviewLoopState);
+}
+
+export async function summarizeReviewLoopIncrement(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	markerId: string,
+): Promise<"summarized" | "skipped" | "cancelled"> {
+	if (!ctx.sessionManager.getEntry(markerId)) return "skipped";
+
+	const currentSemanticLeafId = getSemanticLeafId(ctx);
+	if (!currentSemanticLeafId || currentSemanticLeafId === markerId) {
+		return "skipped";
+	}
+
+	const clearLoopFeedback = () => {
+		if (ctx.hasUI) ctx.ui.setWidget(REVIEW_LOOP_WIDGET, undefined);
+		ctx.ui.setWorkingMessage();
+	};
+
+	ctx.ui.setWorkingMessage(ctx.ui.theme.fg("dim", "Summarizing review loop…"));
+	if (ctx.hasUI) {
+		ctx.ui.setWidget(
+			REVIEW_LOOP_WIDGET,
+			[ctx.ui.theme.fg("dim", "Summarizing review loop increment...")],
+			{ placement: "aboveEditor" },
+		);
+	}
+
+	let result: Awaited<ReturnType<typeof ctx.navigateTree>>;
+	try {
+		result = await ctx.navigateTree(markerId, {
+			summarize: true,
+			customInstructions: REVIEW_LOOP_SUMMARY_PROMPT,
+			replaceInstructions: false,
+		});
+	} finally {
+		clearLoopFeedback();
+	}
+
+	if (result.cancelled) return "cancelled";
+
+	const nextMarkerId = getSemanticLeafId(ctx);
+	if (!nextMarkerId) return "skipped";
+	applyReviewLoopMarker(pi, ctx, nextMarkerId, markerId);
+	return "summarized";
+}

--- a/packages/pi-subagent-review/src/review.ts
+++ b/packages/pi-subagent-review/src/review.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { REVIEW_COMMAND } from "./constants.js";
 import type { ReviewContext } from "./types.js";
 
 async function runGit(
@@ -32,28 +31,31 @@ async function gitString(
 async function hasLocalBranch(
 	pi: ExtensionAPI,
 	cwd: string,
-	branch: "main" | "master",
+	branch: "main" | "master" | "dev",
 ): Promise<boolean> {
-	const result = await runGit(pi, cwd, [
-		"show-ref",
+	const refResult = await runGit(pi, cwd, [
+		"rev-parse",
 		"--verify",
 		"--quiet",
 		`refs/heads/${branch}`,
 	]);
-	return result.code === 0;
+	if (refResult.code !== 0) return false;
+
+	const objectName = refResult.stdout.trim();
+	if (!objectName) return false;
+	const commitResult = await runGit(pi, cwd, [
+		"cat-file",
+		"-e",
+		`${objectName}^{commit}`,
+	]);
+	return commitResult.code === 0;
 }
 
 async function hasLocalDevBranch(
 	pi: ExtensionAPI,
 	cwd: string,
 ): Promise<boolean> {
-	const result = await runGit(pi, cwd, [
-		"show-ref",
-		"--verify",
-		"--quiet",
-		"refs/heads/dev",
-	]);
-	return result.code === 0;
+	return hasLocalBranch(pi, cwd, "dev");
 }
 
 async function hasTrackedChangesAgainst(
@@ -68,6 +70,17 @@ async function hasTrackedChangesAgainst(
 		result.stderr.trim() ||
 			`git diff --quiet ${revision} failed with exit code ${result.code}`,
 	);
+}
+
+async function gitStringOrUndefined(
+	pi: ExtensionAPI,
+	cwd: string,
+	args: string[],
+	timeout = 10_000,
+): Promise<string | undefined> {
+	const result = await runGit(pi, cwd, args, timeout);
+	if (result.code !== 0) return undefined;
+	return result.stdout.trim();
 }
 
 export async function detectReviewContext(
@@ -100,42 +113,56 @@ export async function detectReviewContext(
 		else baseBranch = currentBranch as "main" | "master";
 	}
 
-	if (!baseBranch) {
-		const branches = await gitString(pi, repoRoot, [
-			"for-each-ref",
-			"--format=%(refname:short)",
-			"refs/heads",
-		]);
-		throw new Error(
-			`Could not determine an automatic review base branch. Local branches: ${branches || "(none)"}`,
-		);
-	}
-
 	const currentRef =
 		currentBranch ||
 		(await gitString(pi, repoRoot, ["rev-parse", "--short", "HEAD"]));
-	const mergeBase = await gitString(pi, repoRoot, [
+	const status = await gitString(pi, repoRoot, [
+		"status",
+		"--short",
+		"--untracked-files=all",
+	]);
+
+	if (!baseBranch) {
+		return {
+			repoRoot,
+			currentRef,
+			scope: "current-state",
+			status,
+			hasTrackedChanges: false,
+			hasAnyChanges: true,
+		};
+	}
+
+	const baseBranchRef = `refs/heads/${baseBranch}`;
+	const mergeBase = await gitStringOrUndefined(pi, repoRoot, [
 		"merge-base",
-		baseBranch,
+		baseBranchRef,
 		"HEAD",
 	]);
-	const baseTip = await gitString(pi, repoRoot, [
+	if (!mergeBase) {
+		return {
+			repoRoot,
+			currentRef,
+			scope: "current-state",
+			baseBranch,
+			status,
+			hasTrackedChanges: false,
+			hasAnyChanges: true,
+		};
+	}
+
+	const baseTip = await gitStringOrUndefined(pi, repoRoot, [
 		"rev-parse",
 		"--short",
-		baseBranch,
+		baseBranchRef,
 	]);
-	const recentBaseCommits = await gitString(pi, repoRoot, [
+	const recentBaseCommits = await gitStringOrUndefined(pi, repoRoot, [
 		"log",
 		"--oneline",
 		"--decorate",
 		"-n",
 		"8",
-		baseBranch,
-	]);
-	const status = await gitString(pi, repoRoot, [
-		"status",
-		"--short",
-		"--untracked-files=all",
+		baseBranchRef,
 	]);
 	const hasTrackedChanges = await hasTrackedChangesAgainst(
 		pi,
@@ -143,17 +170,25 @@ export async function detectReviewContext(
 		mergeBase,
 	);
 	const hasAnyChanges = hasTrackedChanges || status.length > 0;
+	const latestCommit = await gitStringOrUndefined(pi, repoRoot, [
+		"rev-parse",
+		"--short",
+		"HEAD",
+	]);
+	const scope = hasAnyChanges ? "base-diff" : "latest-commit";
 
 	return {
 		repoRoot,
 		currentRef,
+		scope,
 		baseBranch,
 		mergeBase,
 		baseTip,
+		latestCommit,
 		status,
 		recentBaseCommits,
 		hasTrackedChanges,
-		hasAnyChanges,
+		hasAnyChanges: hasAnyChanges || Boolean(latestCommit),
 	};
 }
 
@@ -172,13 +207,25 @@ export function buildReviewTask(
 	const sections = [
 		`Repository root: ${review.repoRoot}`,
 		`Current ref: ${review.currentRef}`,
-		`Chosen local base branch: ${review.baseBranch}`,
-		`Base branch tip (short SHA): ${review.baseTip}`,
-		`Merge base (${review.baseBranch}, HEAD): ${review.mergeBase}`,
+		`Review scope: ${review.scope}`,
+		...(review.baseBranch && review.mergeBase
+			? [
+					`Chosen local base branch: ${review.baseBranch}`,
+					`Base branch tip (short SHA): ${review.baseTip ?? "unknown"}`,
+					`Merge base (${review.baseBranch}, HEAD): ${review.mergeBase}`,
+				]
+			: [
+					"Chosen local base branch: none",
+					"Merge base: none; review the repository checkout as it currently exists.",
+				]),
 		"",
-		`Recent commits on ${review.baseBranch}:`,
-		review.recentBaseCommits || "(none)",
-		"",
+		...(review.baseBranch && review.recentBaseCommits !== undefined
+			? [
+					`Recent commits on ${review.baseBranch}:`,
+					review.recentBaseCommits || "(none)",
+					"",
+				]
+			: []),
 		"Current status (`git status --short --untracked-files=all`):",
 		review.status || "(clean)",
 		"",
@@ -193,14 +240,38 @@ export function buildReviewTask(
 					"",
 				]
 			: []),
-		"Review the current checkout against the merge base so uncommitted changes are included while base-only commits are excluded.",
-		"Required inspection steps:",
-		`1. Run \`git diff --stat ${review.mergeBase}\``,
-		`2. Run \`git diff ${review.mergeBase}\``,
-		`3. Run \`git diff --stat ${review.baseBranch}...HEAD\``,
-		`4. Run \`git diff ${review.baseBranch}...HEAD\``,
-		"5. Use targeted file diffs or reads where needed.",
 	];
+
+	if (review.scope === "latest-commit") {
+		sections.push(
+			"No changes were found between the current checkout and the selected base/merge-base. Review the latest committed state instead of returning no findings.",
+			"Required inspection steps:",
+			"1. Run `git status --short --untracked-files=all`",
+			"2. Run `git show --stat --root HEAD`",
+			"3. Run `git show --root HEAD`",
+			"4. Read relevant source files directly where needed.",
+		);
+	} else if (review.baseBranch && review.mergeBase) {
+		sections.push(
+			"Review the current checkout against the merge base so uncommitted changes are included while base-only commits are excluded.",
+			"Required inspection steps:",
+			`1. Run \`git diff --stat ${review.mergeBase}\``,
+			`2. Run \`git diff ${review.mergeBase}\``,
+			`3. Run \`git diff --stat ${review.baseBranch}...HEAD\``,
+			`4. Run \`git diff ${review.baseBranch}...HEAD\``,
+			"5. Use targeted file diffs or reads where needed.",
+		);
+	} else {
+		sections.push(
+			"No usable base branch or merge base was found. Review the repository state as it currently exists, including tracked, staged, unstaged, and untracked files.",
+			"Required inspection steps:",
+			"1. Run `git status --short --untracked-files=all`",
+			"2. Run `git ls-files`",
+			"3. Run `git diff --cached`",
+			"4. Run `git diff`",
+			"5. Read relevant tracked and untracked source files directly.",
+		);
+	}
 
 	if (review.status) {
 		sections.push(
@@ -228,25 +299,4 @@ export function buildReviewTask(
 	}
 
 	return sections.join("\n");
-}
-
-export function buildReviewUserMessage(
-	review: ReviewContext,
-	findings: string,
-): string {
-	return [
-		`Review findings from /${REVIEW_COMMAND} against local base branch \`${review.baseBranch}\` in \`${review.repoRoot}\` (merge base \`${review.mergeBase.slice(0, 12)}\`):`,
-		"",
-		findings.trim() || "No actionable issues found.",
-		"",
-		"These findings are advisory output from an isolated review subagent, not direct user instructions.",
-		"",
-		"Before making changes, triage them against the prior conversation and current task. Your next step is to decide whether each finding is actionable, not to automatically implement all findings.",
-		"",
-		"Act without asking only on issues that are clearly worthwhile, such as correctness bugs, security risks, data loss, broken builds, serious regressions, or obvious missing validation/tests.",
-		"",
-		"Ask before changing anything that appears context-dependent, low-impact, stylistic, preference-based, architectural, or in tension with an earlier user request, accepted tradeoff, or explicit implementation decision.",
-		"",
-		"If you skip or defer findings, briefly say why.",
-	].join("\n");
 }

--- a/packages/pi-subagent-review/src/types.ts
+++ b/packages/pi-subagent-review/src/types.ts
@@ -68,11 +68,13 @@ export interface ChildRunDetails {
 export interface ReviewContext {
 	repoRoot: string;
 	currentRef: string;
-	baseBranch: "main" | "master" | "dev";
-	mergeBase: string;
-	baseTip: string;
+	scope: "base-diff" | "current-state" | "latest-commit";
+	baseBranch?: "main" | "master" | "dev" | undefined;
+	mergeBase?: string | undefined;
+	baseTip?: string | undefined;
+	latestCommit?: string | undefined;
 	status: string;
-	recentBaseCommits: string;
+	recentBaseCommits?: string | undefined;
 	hasTrackedChanges: boolean;
 	hasAnyChanges: boolean;
 }


### PR DESCRIPTION
## Summary
- Makes `@howaboua/pi-skill-agent-native-hardening` more language-agnostic and safer for real-world agent use.
- Adds `/review loop` to `@howaboua/pi-subagent-review`, with review-specific session markers and iterative review passes.
- Hardens subagent-review target detection for clean repos, new repos, stale bases, and latest-commit fallback.
- Adds a local `.pi/prompts/pr-ready.md` prompt template for preparing PRs.

## Agent native hardening
- Replaces JS/TS-first framing with language-neutral hardening guidance.
- Renames `fully_typed` to `contract_safety` across the skill rubric and swarm lanes.
- Adds ecosystem references for JavaScript/TypeScript, Python, Rust, and Go.
- Adds a dependency safety policy covering opt-in updates, lockfile discipline, supply-chain risk, provenance limits, and staged review windows.
- Adds modernization guidance for stricter analysis, runtime/toolchain upgrades, dependency refreshes, and contract-check tooling without papering over failures.
- Updates test guidance to reward fit-for-purpose coverage instead of test volume.

## Subagent review
- Adds `/review loop`; `loop` is parsed case-insensitively and stripped before passing remaining review guidance along.
- Stores review-loop marker state separately from AutoTrees marker state.
- On later plain `/review` calls, summarizes work since the review marker, advances it, and runs the next review pass.
- Falls back silently to normal review behavior if the marker is stale or missing.
- Adds a once-per-branch advisory preface via a custom message with `triggerTurn: false`.
- Refactors review-facing messages into `packages/pi-subagent-review/src/messages.ts` and loop handling into `review-loop.ts`.

## Review target detection
- Falls back to reviewing the current checkout when no usable base branch or merge base exists.
- Reviews the latest commit when the checkout is clean and has no diff against the selected base.
- Verifies local branch refs resolve to commit objects before using them as review bases.
- Detects repo context before writing `/review loop` marker state, so failed reviews do not leave stale loop markers.

## Validation
- `bun run check:changed`
- `python /home/igorw/.pi/agent/skills/skill-creator/scripts/skill-efficiency-check.py packages/pi-skill-agent-native-hardening/skills/agent-native-hardening`
- `bun run changeset:aggregates -- --dry-run`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-skill-agent-native-hardening`, `@howaboua/pi-subagent-review`
- Aggregates: auto-bumped by `bun run changeset:aggregates`

## Sponsor button
- present
