### PR TITLE
Fix auto reasoning turn baseline restore

### DIFF
--- a/.changeset/auto-reasoning-turn-baseline.md
+++ b/.changeset/auto-reasoning-turn-baseline.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-auto-reasoning-tool": patch
+---
+
+Restore reasoning to the current agent turn's starting level instead of reusing the first level captured after extension load.

--- a/packages/pi-auto-reasoning-tool/src/index.ts
+++ b/packages/pi-auto-reasoning-tool/src/index.ts
@@ -88,7 +88,7 @@ function isRetryableAssistantError(
 
 export default function autoReasoningSelector(pi: ExtensionAPI) {
 	let lastSelection: LastSelection | undefined;
-	let baselineReasoningLevel: AppliedReasoningLevel | undefined;
+	let turnBaselineReasoningLevel: AppliedReasoningLevel | undefined;
 
 	pi.registerTool({
 		name: "change_reasoning",
@@ -138,7 +138,7 @@ export default function autoReasoningSelector(pi: ExtensionAPI) {
 	});
 
 	pi.on("agent_start", async () => {
-		baselineReasoningLevel ??= pi.getThinkingLevel();
+		turnBaselineReasoningLevel ??= pi.getThinkingLevel();
 	});
 
 	pi.on("agent_end", async (event, ctx) => {
@@ -146,8 +146,10 @@ export default function autoReasoningSelector(pi: ExtensionAPI) {
 		if (isRetryableAssistantError(lastAssistant, ctx.model?.contextWindow)) {
 			return;
 		}
-		pi.setThinkingLevel(
-			baselineReasoningLevel ?? FALLBACK_BASELINE_REASONING_LEVEL,
-		);
+
+		const levelToRestore =
+			turnBaselineReasoningLevel ?? FALLBACK_BASELINE_REASONING_LEVEL;
+		turnBaselineReasoningLevel = undefined;
+		pi.setThinkingLevel(levelToRestore);
 	});
 }

--- a/packages/pi-auto-reasoning-tool/src/index.ts
+++ b/packages/pi-auto-reasoning-tool/src/index.ts
@@ -137,6 +137,10 @@ export default function autoReasoningSelector(pi: ExtensionAPI) {
 		},
 	});
 
+	pi.on("before_agent_start", async () => {
+		turnBaselineReasoningLevel = pi.getThinkingLevel();
+	});
+
 	pi.on("agent_start", async () => {
 		turnBaselineReasoningLevel ??= pi.getThinkingLevel();
 	});


### PR DESCRIPTION
## Summary
- capture the reasoning baseline per agent turn instead of once per extension lifetime
- clear the saved baseline after successful/non-retryable runs so temporary medium/high changes do not stick

## Validation
- `bun run check:changed`
- `bun run --filter @howaboua/pi-auto-reasoning-tool check`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-auto-reasoning-tool`
- Aggregates: auto-bumped by `bun run changeset:aggregates`
