### PR TITLE
Protect persistent branches from auto deletion

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,24 @@
+name: Delete merged branches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-merged-branch:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref != 'main' &&
+      github.event.pull_request.head.ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete merged branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" || true


### PR DESCRIPTION
## Summary
- add a PR-close cleanup workflow that deletes merged repo branches except `main` and `dev`
- keep GitHub's global delete-on-merge setting disabled so persistent branches are not deleted

## Validation
- not run; workflow-only change

## Release
- Changeset: no
- Packages: none
- Aggregates: n/a
