### PR TITLE
Preserve Codex response continuation

### DIFF
--- a/.changeset/calm-codex-websockets.md
+++ b/.changeset/calm-codex-websockets.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Preserve Codex WebSocket continuation across parallel tool-output replay drift and keep native web-search response items in Responses history for stable follow-up replay.

--- a/.changeset/custom-codex-providers.md
+++ b/.changeset/custom-codex-providers.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Adds an `adapterProviders` setting for enabling the Codex adapter on named custom providers.

--- a/.changeset/slim-explore-subagents.md
+++ b/.changeset/slim-explore-subagents.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-explore-subagents": patch
+---
+
+Persist only minimal explore subagent result metadata in parent sessions instead of the child subagent transcript.

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -55,11 +55,22 @@ The settings UI also has **Usage**, **Overrides**, and **About** tabs. **Usage**
 
 - add only the Pi `apply_patch` tool for GPT/Codex models while keeping Pi's default toolkit, prompt, provider behavior, and compaction flow
 
+Advanced users with custom Codex-compatible providers can opt specific providers into the adapter from the **Overrides** tab, or by editing `~/.pi/agent/pi-codex-conversion.json`:
+
+```json
+{
+  "useAdapterProviders": true,
+  "adapterProviders": ["my-provider"]
+}
+```
+
+This only enables the Codex tool/prompt adapter for those provider ids. Native Codex web search, native image generation, and priority service tier remain limited to the built-in `openai-codex` provider.
+
 The **Compaction** tab can enable native OpenAI Responses compaction and choose the compaction model/reasoning. If native compaction fails, the extension falls back to Pi's normal compaction flow; when an older native compacted window exists, it is included in that Pi fallback summarization request so OpenAI can still use the prior opaque context server-side.
 
 For OpenAI Codex subscription models, the extension also adjusts Pi's registered model context windows so Pi's fixed reserve-token compaction heuristic trips at roughly Codex's native auto-compact budget: 90% of Pi's resolved model window. This is calculated from Pi's current model metadata instead of hardcoded per-model limits.
 
-When `all` is on, non-Codex providers get the shell, patch, skill, and prompt-adapter behavior, but keep their normal Pi provider path. Native web search, native image generation, and priority service tier stay limited to the OpenAI Codex provider. Verbosity is applied to Responses API providers.
+When `all` is on, or when a provider is listed in `adapterProviders`, non-Codex providers get the shell, patch, skill, and prompt-adapter behavior, but keep their normal Pi provider path. Native web search, native image generation, and priority service tier stay limited to the OpenAI Codex provider. Verbosity is applied to Responses API providers.
 
 The footer shows the active state, for example:
 

--- a/packages/pi-codex-conversion/src/adapter/activation.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation.ts
@@ -33,7 +33,13 @@ export function syncAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: Adap
 
 export function shouldUseCodexAdapter(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
 	if (config.applyPatchOnly) return false;
-	return config.useOnAllModels || isCodexLikeContext(ctx);
+	return config.useOnAllModels || isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx);
+}
+
+function isConfiguredAdapterProvider(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
+	if (!config.useAdapterProviders) return false;
+	const provider = ctx.model?.provider?.trim().toLowerCase();
+	return Boolean(provider && config.adapterProviders.includes(provider));
 }
 
 export function shouldUseApplyPatchOnly(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
@@ -104,6 +110,7 @@ function getStatusConfig(ctx: ExtensionContext, config: CodexConversionConfig): 
 	const showResponsesVerbosity = isResponsesContext(ctx);
 	return {
 		useOnAllModels: config.useOnAllModels,
+		useAdapterProviders: config.useAdapterProviders && isConfiguredAdapterProvider(ctx, config),
 		fast: showOpenAICodexFlags && config.fast,
 		webSearch: showOpenAICodexFlags && !config.applyPatchOnly && config.webSearch && supportsNativeWebSearch(ctx.model),
 		imageGeneration: showOpenAICodexFlags && !config.applyPatchOnly && config.imageGeneration && supportsNativeImageGeneration(ctx.model),

--- a/packages/pi-codex-conversion/src/adapter/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/config.ts
@@ -11,6 +11,7 @@ export const COMPACTION_REASONING_LEVELS: readonly CompactionReasoning[] = ["cur
 
 export interface CodexConversionConfig {
 	applyPatchOnly: boolean;
+	adapterProviders: string[];
 	fast: boolean;
 	forceCachedWebSockets?: boolean | undefined;
 	imageGeneration: boolean;
@@ -18,6 +19,7 @@ export interface CodexConversionConfig {
 	compactionReasoning: CompactionReasoning;
 	responsesCompaction?: boolean | undefined;
 	statusLine: boolean;
+	useAdapterProviders: boolean;
 	useOnAllModels: boolean;
 	webSearch: boolean;
 	verbosity: CodexVerbosity;
@@ -26,6 +28,7 @@ export interface CodexConversionConfig {
 export const CODEX_CONVERSION_CONFIG_BASENAME = "pi-codex-conversion.json";
 export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	applyPatchOnly: false,
+	adapterProviders: [],
 	fast: false,
 	forceCachedWebSockets: true,
 	imageGeneration: true,
@@ -33,6 +36,7 @@ export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	compactionReasoning: "current",
 	responsesCompaction: false,
 	statusLine: true,
+	useAdapterProviders: false,
 	useOnAllModels: false,
 	webSearch: true,
 	verbosity: "low",
@@ -58,6 +62,14 @@ export function normalizeCompactionReasoning(value: unknown): CompactionReasonin
 	return (COMPACTION_REASONING_LEVELS as readonly string[]).includes(value) ? (value as CompactionReasoning) : undefined;
 }
 
+export function normalizeProviderList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return [...new Set(value
+		.filter((entry): entry is string => typeof entry === "string")
+		.map((entry) => entry.trim().toLowerCase())
+		.filter(Boolean))];
+}
+
 export function getCodexConversionConfigPath(agentDir: string = getAgentDir()): string {
 	return join(agentDir, CODEX_CONVERSION_CONFIG_BASENAME);
 }
@@ -73,6 +85,7 @@ export function readCodexConversionConfig(configPath: string = getCodexConversio
 		if (!isObject(parsed)) return { ...DEFAULT_CODEX_CONVERSION_CONFIG };
 		return {
 			applyPatchOnly: typeof parsed["applyPatchOnly"]! === "boolean" ? parsed["applyPatchOnly"]! : DEFAULT_CODEX_CONVERSION_CONFIG.applyPatchOnly,
+			adapterProviders: normalizeProviderList(parsed["adapterProviders"]!),
 			fast: typeof parsed["fast"]! === "boolean" ? parsed["fast"]! : DEFAULT_CODEX_CONVERSION_CONFIG.fast,
 			forceCachedWebSockets: typeof parsed["forceCachedWebSockets"]! === "boolean" ? parsed["forceCachedWebSockets"]! : DEFAULT_CODEX_CONVERSION_CONFIG.forceCachedWebSockets,
 			imageGeneration: typeof parsed["imageGeneration"]! === "boolean" ? parsed["imageGeneration"]! : DEFAULT_CODEX_CONVERSION_CONFIG.imageGeneration,
@@ -80,6 +93,7 @@ export function readCodexConversionConfig(configPath: string = getCodexConversio
 			compactionReasoning: normalizeCompactionReasoning(parsed["compactionReasoning"]!) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionReasoning,
 			responsesCompaction: typeof parsed["responsesCompaction"]! === "boolean" ? parsed["responsesCompaction"]! : DEFAULT_CODEX_CONVERSION_CONFIG.responsesCompaction,
 			statusLine: typeof parsed["statusLine"]! === "boolean" ? parsed["statusLine"]! : DEFAULT_CODEX_CONVERSION_CONFIG.statusLine,
+			useAdapterProviders: typeof parsed["useAdapterProviders"]! === "boolean" ? parsed["useAdapterProviders"]! : DEFAULT_CODEX_CONVERSION_CONFIG.useAdapterProviders,
 			useOnAllModels: typeof parsed["useOnAllModels"]! === "boolean" ? parsed["useOnAllModels"]! : DEFAULT_CODEX_CONVERSION_CONFIG.useOnAllModels,
 			webSearch: typeof parsed["webSearch"]! === "boolean" ? parsed["webSearch"]! : DEFAULT_CODEX_CONVERSION_CONFIG.webSearch,
 			verbosity: normalizeCodexVerbosity(parsed["verbosity"]!) ?? DEFAULT_CODEX_CONVERSION_CONFIG.verbosity,

--- a/packages/pi-codex-conversion/src/adapter/tool-set.ts
+++ b/packages/pi-codex-conversion/src/adapter/tool-set.ts
@@ -2,9 +2,10 @@ export const STATUS_KEY = "codex-adapter";
 export const STATUS_TEXT = "\u001b[38;2;0;76;255mCodex adapter\u001b[0m";
 export const APPLY_PATCH_ONLY_STATUS_TEXT = `${STATUS_TEXT} • apply patch only`;
 
-export function buildStatusText(options: { verbosity?: string | undefined; webSearch: boolean; imageGeneration: boolean; fast: boolean; useOnAllModels: boolean; compaction?: { enabled: boolean; model: string; reasoning: string } | undefined }): string {
+export function buildStatusText(options: { verbosity?: string | undefined; webSearch: boolean; imageGeneration: boolean; fast: boolean; useOnAllModels: boolean; useAdapterProviders?: boolean | undefined; compaction?: { enabled: boolean; model: string; reasoning: string } | undefined }): string {
 	const extras = [
 		options.useOnAllModels ? "all models" : undefined,
+		options.useAdapterProviders ? "codex proxy" : undefined,
 		options.webSearch ? "web search" : undefined,
 		options.imageGeneration ? "image gen" : undefined,
 		options.compaction?.enabled ? `compact ${options.compaction.model}/${options.compaction.reasoning}` : undefined,

--- a/packages/pi-codex-conversion/src/codex-settings/command.ts
+++ b/packages/pi-codex-conversion/src/codex-settings/command.ts
@@ -110,5 +110,5 @@ function getCommandConfigUpdate(arg: string, config: CodexConversionConfig): Cod
 }
 
 function formatCodexSettings(config: CodexConversionConfig): string {
-	return `Codex settings: all models ${config.useOnAllModels ? "on" : "off"}, statusline ${config.statusLine ? "on" : "off"}, fast ${config.fast ? "on" : "off"}, cached websocket upgrade ${config.forceCachedWebSockets === false ? "off" : "on"}, web search ${config.webSearch ? "on" : "off"}, image generation ${config.imageGeneration ? "on" : "off"}, responses compaction ${(config.responsesCompaction ?? false) ? "on" : "off"} (${config.compactionModel}/${config.compactionReasoning}), verbosity ${config.verbosity}`;
+	return `Codex settings: all models ${config.useOnAllModels ? "on" : "off"}, codex proxy ${config.useAdapterProviders ? "on" : "off"}${config.adapterProviders.length > 0 ? ` (${config.adapterProviders.join(", ")})` : ""}, statusline ${config.statusLine ? "on" : "off"}, fast ${config.fast ? "on" : "off"}, cached websocket upgrade ${config.forceCachedWebSockets === false ? "off" : "on"}, web search ${config.webSearch ? "on" : "off"}, image generation ${config.imageGeneration ? "on" : "off"}, responses compaction ${(config.responsesCompaction ?? false) ? "on" : "off"} (${config.compactionModel}/${config.compactionReasoning}), verbosity ${config.verbosity}`;
 }

--- a/packages/pi-codex-conversion/src/codex-settings/ui.ts
+++ b/packages/pi-codex-conversion/src/codex-settings/ui.ts
@@ -1,5 +1,5 @@
 import { getSettingsListTheme, type ExtensionContext, type Theme } from "@earendil-works/pi-coding-agent";
-import { SettingsList, truncateToWidth, type SettingItem } from "@earendil-works/pi-tui";
+import { Container, type Focusable, Input, SettingsList, Spacer, Text, truncateToWidth, type SettingItem } from "@earendil-works/pi-tui";
 import {
 	COMPACTION_MODELS,
 	COMPACTION_REASONING_LEVELS,
@@ -7,6 +7,7 @@ import {
 	normalizeCodexVerbosity,
 	normalizeCompactionModel,
 	normalizeCompactionReasoning,
+	normalizeProviderList,
 	type CodexConversionConfig,
 } from "../adapter/config.ts";
 import { CHANGELOG_URL, DISCORD_URL, GITHUB_URL, ISSUE_URL, openExternalUrl } from "./links.ts";
@@ -23,6 +24,39 @@ export interface CodexSettingsScreenOptions {
 type SettingsTab = "general" | "compaction" | "usage" | "overrides" | "about";
 
 const TAB_ORDER: readonly SettingsTab[] = ["general", "compaction", "usage", "overrides", "about"];
+
+class TextSettingSubmenu extends Container implements Focusable {
+	private input: Input;
+	private theme: Theme;
+
+	constructor(title: string, description: string, currentValue: string, onSubmit: (value: string) => void, onCancel: () => void, theme: Theme) {
+		super();
+		this.theme = theme;
+		this.input = new Input();
+		this.input.setValue(currentValue);
+		this.input.onSubmit = () => onSubmit(this.input.getValue());
+		this.input.onEscape = onCancel;
+		this.addChild(new Text(this.theme.bold(this.theme.fg("accent", title)), 0, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(this.theme.fg("dim", description), 0, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(this.input);
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(this.theme.fg("dim", "  Enter to save · Esc to cancel"), 0, 0));
+	}
+
+	get focused(): boolean {
+		return this.input.focused;
+	}
+
+	set focused(value: boolean) {
+		this.input.focused = value;
+	}
+
+	handleInput(data: string): void {
+		this.input.handleInput(data);
+	}
+}
 
 export async function openCodexSettingsScreen(ctx: ExtensionContext, options: CodexSettingsScreenOptions): Promise<void> {
 	let draft = { ...options.initialConfig };
@@ -41,7 +75,7 @@ export async function openCodexSettingsScreen(ctx: ExtensionContext, options: Co
 	};
 
 	await ctx.ui.custom<void>((tui, theme, _kb, done) => {
-		let settingsList = createSettingsList(activeTab, draft, options, (nextDraft) => {
+		let settingsList = createSettingsList(activeTab, draft, options, theme, (nextDraft) => {
 			draft = nextDraft;
 		}, done, () => tui.requestRender());
 		if (activeTab === "usage" && !usageState) loadUsage(() => tui.requestRender());
@@ -49,7 +83,7 @@ export async function openCodexSettingsScreen(ctx: ExtensionContext, options: Co
 		const switchTab = () => {
 			const currentIndex = TAB_ORDER.indexOf(activeTab);
 			activeTab = TAB_ORDER[(currentIndex + 1) % TAB_ORDER.length] ?? "general";
-			settingsList = createSettingsList(activeTab, draft, options, (nextDraft) => {
+			settingsList = createSettingsList(activeTab, draft, options, theme, (nextDraft) => {
 				draft = nextDraft;
 			}, done, () => tui.requestRender());
 			if (activeTab === "usage" && !usageState) loadUsage(() => tui.requestRender());
@@ -111,14 +145,15 @@ function createSettingsList(
 	tab: SettingsTab,
 	draft: CodexConversionConfig,
 	options: CodexSettingsScreenOptions,
+	theme: Theme,
 	onDraftChanged: (draft: CodexConversionConfig) => void,
 	done: (value?: void) => void,
 	requestRender: () => void,
 ): SettingsList {
 	let settingsList: SettingsList;
-	settingsList = new SettingsList(buildItems(tab, draft), 8, getSettingsListTheme(), (id, value) => {
+	settingsList = new SettingsList(buildItems(tab, draft, theme), 8, getSettingsListTheme(), (id, value) => {
 		const nextDraft = applySettingChange(id, value, draft);
-		const previousValue = buildItems(tab, draft).find((item) => item.id === id)?.currentValue;
+		const previousValue = buildItems(tab, draft, theme).find((item) => item.id === id)?.currentValue;
 		if (options.onChange(nextDraft)) {
 			onDraftChanged(nextDraft);
 			draft = nextDraft;
@@ -130,7 +165,7 @@ function createSettingsList(
 	return settingsList;
 }
 
-function buildItems(tab: SettingsTab, draft: CodexConversionConfig): SettingItem[] {
+function buildItems(tab: SettingsTab, draft: CodexConversionConfig, theme: Theme): SettingItem[] {
 	if (tab === "usage" || tab === "about") return [];
 
 	if (tab === "compaction") {
@@ -144,6 +179,13 @@ function buildItems(tab: SettingsTab, draft: CodexConversionConfig): SettingItem
 	if (tab === "overrides") {
 		return [
 			{ id: "applyPatchOnly", label: "Apply patch only", currentValue: draft.applyPatchOnly ? "on" : "off", values: ["off", "on"] },
+			{ id: "useAdapterProviders", label: "Codex proxy", currentValue: draft.useAdapterProviders ? "on" : "off", values: ["off", "on"] },
+			{
+				id: "adapterProviders",
+				label: "Proxy providers",
+				currentValue: formatProviderList(draft.adapterProviders),
+				submenu: (currentValue, done) => new TextSettingSubmenu("Proxy providers", "Comma-separated Pi provider ids that should use the Codex adapter.", currentValue, (value) => done(formatProviderList(normalizeProviderListFromText(value))), () => done(), theme),
+			},
 		];
 	}
 
@@ -161,7 +203,9 @@ function buildItems(tab: SettingsTab, draft: CodexConversionConfig): SettingItem
 function applySettingChange(id: string, value: string, draft: CodexConversionConfig): CodexConversionConfig {
 	const nextDraft = { ...draft };
 	if (id === "applyPatchOnly") nextDraft.applyPatchOnly = value === "on";
+	if (id === "adapterProviders") nextDraft.adapterProviders = normalizeProviderListFromText(value);
 	if (id === "useOnAllModels") nextDraft.useOnAllModels = value === "on";
+	if (id === "useAdapterProviders") nextDraft.useAdapterProviders = value === "on";
 	if (id === "statusLine") nextDraft.statusLine = value === "on";
 	if (id === "fast") nextDraft.fast = value === "on";
 	if (id === "forceCachedWebSockets") nextDraft.forceCachedWebSockets = value === "on";
@@ -172,6 +216,14 @@ function applySettingChange(id: string, value: string, draft: CodexConversionCon
 	if (id === "compactionReasoning") nextDraft.compactionReasoning = normalizeCompactionReasoning(value) ?? DEFAULT_CODEX_CONVERSION_CONFIG.compactionReasoning;
 	if (id === "verbosity") nextDraft.verbosity = normalizeCodexVerbosity(value) ?? DEFAULT_CODEX_CONVERSION_CONFIG.verbosity;
 	return nextDraft;
+}
+
+function formatProviderList(providers: string[]): string {
+	return providers.join(", ");
+}
+
+function normalizeProviderListFromText(value: string): string[] {
+	return normalizeProviderList(value.split(","));
 }
 
 function formatTabs(activeTab: SettingsTab, theme: Theme): string {

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -770,6 +770,7 @@ function closeWebSocketSilently(socket: WebSocketLike, code = 1000, reason = "do
 	}
 }
 
+
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 	const closeEntry = (entry: SessionWebSocketCacheEntry) => {
 		if (entry.idleTimer) {
@@ -1023,6 +1024,35 @@ function requestBodiesMatchExceptInput(a: ResponsesBody, b: ResponsesBody): bool
 	return JSON.stringify(requestBodyForWebSocketContinuationComparison(a)) === JSON.stringify(requestBodyForWebSocketContinuationComparison(b));
 }
 
+function getFunctionCallId(item: unknown): string | undefined {
+	return item && typeof item === "object" && (item as { type?: unknown }).type === "function_call" && typeof (item as { call_id?: unknown }).call_id === "string"
+		? (item as { call_id: string }).call_id
+		: undefined;
+}
+
+function getFunctionCallOutputId(item: unknown): string | undefined {
+	return item && typeof item === "object" && (item as { type?: unknown }).type === "function_call_output" && typeof (item as { call_id?: unknown }).call_id === "string"
+		? (item as { call_id: string }).call_id
+		: undefined;
+}
+
+function getPendingToolOutputDelta(body: ResponsesBody, continuation: CachedWebSocketContinuationState): unknown[] | undefined {
+	const pendingCallIds = continuation.lastResponseItems.map(getFunctionCallId).filter((id): id is string => id !== undefined);
+	if (pendingCallIds.length === 0) return undefined;
+
+	const pending = new Set(pendingCallIds);
+	const currentInput = body.input ?? [];
+	let firstOutputIndex: number | undefined;
+	for (const [index, item] of currentInput.entries()) {
+		const callId = getFunctionCallOutputId(item);
+		if (!callId || !pending.has(callId)) continue;
+		firstOutputIndex ??= index;
+		pending.delete(callId);
+	}
+
+	return pending.size === 0 && firstOutputIndex !== undefined ? currentInput.slice(firstOutputIndex) : undefined;
+}
+
 function getCachedWebSocketInputDelta(body: ResponsesBody, continuation: CachedWebSocketContinuationState): { delta?: unknown[] | undefined; decision: WebSocketContinuationDecision } {
 	if (!requestBodiesMatchExceptInput(body, continuation.lastRequestBody)) {
 		return { decision: "body_mismatch" };
@@ -1036,6 +1066,10 @@ function getCachedWebSocketInputDelta(body: ResponsesBody, continuation: CachedW
 
 	const prefix = currentInput.slice(0, baseline.length);
 	if (!responseInputsEqual(prefix, baseline)) {
+		const pendingToolOutputDelta = getPendingToolOutputDelta(body, continuation);
+		if (pendingToolOutputDelta) {
+			return { delta: pendingToolOutputDelta, decision: "delta" };
+		}
 		return { decision: "input_prefix_mismatch" };
 	}
 

--- a/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-responses-shared.ts
@@ -18,7 +18,20 @@ interface ImageGenerationCallBlock {
 	item: ImageGenerationCallItem;
 }
 
-type InternalAssistantContent = Extract<Message, { role: "assistant" }>["content"][number] | ImageGenerationCallBlock;
+interface WebSearchCallItem {
+	type: "web_search_call";
+	id: string;
+	status?: string | undefined;
+	action?: unknown | undefined;
+	results?: unknown | undefined;
+}
+
+interface WebSearchCallBlock {
+	type: "web_search_call";
+	item: WebSearchCallItem;
+}
+
+type InternalAssistantContent = Extract<Message, { role: "assistant" }>["content"][number] | ImageGenerationCallBlock | WebSearchCallBlock;
 
 export interface OpenAIResponsesStreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"] | undefined;
@@ -75,6 +88,10 @@ function isImageGenerationCallBlock(block: InternalAssistantContent): block is I
 	return block.type === "image_generation_call" && block.item?.type === "image_generation_call";
 }
 
+function isWebSearchCallBlock(block: InternalAssistantContent): block is WebSearchCallBlock {
+	return block.type === "web_search_call" && block.item?.type === "web_search_call";
+}
+
 function sanitizeImageGenerationCallItem(item: unknown): ImageGenerationCallItem | undefined {
 	if (!item || typeof item !== "object") return undefined;
 	const candidate = item as Record<string, unknown>;
@@ -89,6 +106,21 @@ function sanitizeImageGenerationCallItem(item: unknown): ImageGenerationCallItem
 		status: candidate["status"]!,
 		result: candidate["result"]!,
 		...(typeof candidate["revised_prompt"]! === "string" ? { revised_prompt: candidate["revised_prompt"]! } : {}),
+	};
+}
+
+function sanitizeWebSearchCallItem(item: unknown): WebSearchCallItem | undefined {
+	if (!item || typeof item !== "object") return undefined;
+	const candidate = item as Record<string, unknown>;
+	if (candidate["type"] !== "web_search_call") return undefined;
+	if (typeof candidate["id"]! !== "string" || candidate["id"] === "") return undefined;
+
+	return {
+		type: "web_search_call",
+		id: candidate["id"]!,
+		...(typeof candidate["status"]! === "string" ? { status: candidate["status"]! } : {}),
+		...(candidate["action"] !== undefined ? { action: candidate["action"]! } : {}),
+		...(candidate["results"] !== undefined ? { results: candidate["results"]! } : {}),
 	};
 }
 
@@ -147,6 +179,7 @@ function transformMessages(
 				assistantMsg.provider === model.provider && assistantMsg.api === model.api && assistantMsg.model === model.id;
 			const transformedContent = (assistantMsg.content as InternalAssistantContent[]).flatMap((block) => {
 				if (isImageGenerationCallBlock(block)) return block;
+				if (isWebSearchCallBlock(block)) return block;
 				if (block.type === "thinking") {
 					if (block.redacted) return isSameModel ? block : [];
 					if (isSameModel && block.thinkingSignature) return block;
@@ -305,6 +338,9 @@ export function convertResponsesMessages<TApi extends Api>(
 				if (isImageGenerationCallBlock(block)) {
 					const imageGenerationCall = sanitizeImageGenerationCallItem(block.item);
 					if (imageGenerationCall) output.push(imageGenerationCall as ResponseInput[number]);
+				} else if (isWebSearchCallBlock(block)) {
+					const webSearchCall = sanitizeWebSearchCallItem(block.item);
+					if (webSearchCall) output.push(webSearchCall as ResponseInput[number]);
 				} else if (block.type === "thinking") {
 					if (block.thinkingSignature) output.push(JSON.parse(block.thinkingSignature));
 				} else if (block.type === "text") {
@@ -604,6 +640,15 @@ export async function processResponsesStream<TApi extends Api>(
 					(output.content as InternalAssistantContent[]).push({
 						type: "image_generation_call",
 						item: imageGenerationCall,
+					});
+				}
+				outputStates.delete(event.output_index);
+			} else if (item.type === "web_search_call") {
+				const webSearchCall = sanitizeWebSearchCallItem(item);
+				if (webSearchCall) {
+					(output.content as InternalAssistantContent[]).push({
+						type: "web_search_call",
+						item: webSearchCall,
 					});
 				}
 				outputStates.delete(event.output_index);

--- a/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
+++ b/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/config.ts";
+import { DEFAULT_CODEX_CONVERSION_CONFIG, normalizeProviderList } from "../src/adapter/config.ts";
 import { syncAdapter } from "../src/adapter/activation.ts";
 import type { AdapterState } from "../src/adapter/state.ts";
 import { mergeAdapterTools, restoreTools } from "../src/index.ts";
@@ -66,6 +66,50 @@ test("syncAdapter add-apply_patch-only mode is gated to Codex-like models", () =
 		createAdapterState({ applyPatchOnly: true, webSearch: true, imageGeneration: true }),
 	);
 	assert.deepEqual(plainPi.activeTools(), ["read", "bash", "edit", "write", "parallel"]);
+});
+
+test("syncAdapter enables adapter for configured custom providers", () => {
+	const pi = createToolHarness(["read", "bash", "edit", "write", "parallel"]);
+	const ctx = createContext({ provider: "my-provider", api: "custom-responses", id: "gpt-5" });
+	const state = createAdapterState({ useAdapterProviders: true, adapterProviders: ["my-provider"] });
+
+	syncAdapter(pi as never, ctx as never, state);
+
+	assert.deepEqual(pi.activeTools(), ["exec_command", "write_stdin", "apply_patch", "parallel"]);
+});
+
+test("normalizeProviderList trims, lowercases, dedupes, and ignores invalid entries", () => {
+	assert.deepEqual(normalizeProviderList([" My-Provider ", "my-provider", "", 42]), ["my-provider"]);
+});
+
+test("syncAdapter does not enable adapter for unlisted custom providers", () => {
+	const pi = createToolHarness(["read", "bash", "edit", "write", "parallel"]);
+	const ctx = createContext({ provider: "custom-llm", api: "custom-chat", id: "claude" });
+	const state = createAdapterState({ useAdapterProviders: true, adapterProviders: ["my-provider"] });
+
+	syncAdapter(pi as never, ctx as never, state);
+
+	assert.deepEqual(pi.activeTools(), ["read", "bash", "edit", "write", "parallel"]);
+});
+
+test("syncAdapter ignores configured custom providers while codex proxy is off", () => {
+	const pi = createToolHarness(["read", "bash", "edit", "write", "parallel"]);
+	const ctx = createContext({ provider: "my-provider", api: "custom-responses", id: "gpt-5" });
+	const state = createAdapterState({ useAdapterProviders: false, adapterProviders: ["my-provider"] });
+
+	syncAdapter(pi as never, ctx as never, state);
+
+	assert.deepEqual(pi.activeTools(), ["read", "bash", "edit", "write", "parallel"]);
+});
+
+test("syncAdapter custom provider list is adapter-only in apply_patch-only mode", () => {
+	const pi = createToolHarness(["read", "bash", "edit", "write", "parallel"]);
+	const ctx = createContext({ provider: "my-provider", api: "custom-responses", id: "gpt-5" });
+	const state = createAdapterState({ applyPatchOnly: true, useAdapterProviders: true, adapterProviders: ["my-provider"] });
+
+	syncAdapter(pi as never, ctx as never, state);
+
+	assert.deepEqual(pi.activeTools(), ["read", "bash", "edit", "write", "parallel"]);
 });
 
 test("restoreTools restores previous tools and keeps custom tools added while adapter mode was enabled", () => {

--- a/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
@@ -94,6 +94,63 @@ test("cached websocket request body reuses continuation across reasoning changes
 	);
 });
 
+test("cached websocket request body sends parallel tool outputs when assistant item replay drifts", () => {
+	const previousBody = buildRequestBody(codexModel, { systemPrompt: "Instructions", messages: [] }, { sessionId: "session-1" });
+	previousBody.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "inspect" }] }];
+	const responseItems = [
+		{ type: "function_call", id: "fc_1", call_id: "call_1", name: "exec_command", arguments: "{}" },
+		{ type: "function_call", id: "fc_2", call_id: "call_2", name: "semantic_grep", arguments: "{}" },
+	];
+	const toolOutputs = [
+		{ type: "function_call_output", call_id: "call_1", output: "one" },
+		{ type: "function_call_output", call_id: "call_2", output: "two" },
+	];
+	const fullBody = buildRequestBody(codexModel, { systemPrompt: "Instructions", messages: [] }, { sessionId: "session-1" });
+	fullBody.input = [
+		...previousBody.input,
+		{ ...responseItems[0], id: "fc_replayed_1" },
+		{ ...responseItems[1], id: "fc_replayed_2" },
+		...toolOutputs,
+	];
+
+	assert.deepEqual(
+		buildCachedWebSocketRequestBody({ lastRequestBody: previousBody, lastResponseId: "resp_1", lastResponseItems: responseItems }, fullBody),
+		{
+			body: { ...fullBody, previous_response_id: "resp_1", input: toolOutputs },
+			decision: "delta",
+		},
+	);
+});
+
+test("cached websocket request body keeps follow-up input after drifted tool outputs", () => {
+	const previousBody = buildRequestBody(codexModel, { systemPrompt: "Instructions", messages: [] }, { sessionId: "session-1" });
+	previousBody.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "inspect" }] }];
+	const responseItems = [
+		{ type: "function_call", id: "fc_1", call_id: "call_1", name: "exec_command", arguments: "{}" },
+		{ type: "function_call", id: "fc_2", call_id: "call_2", name: "semantic_grep", arguments: "{}" },
+	];
+	const delta = [
+		{ type: "function_call_output", call_id: "call_1", output: "one" },
+		{ type: "function_call_output", call_id: "call_2", output: "two" },
+		{ type: "message", role: "user", content: [{ type: "input_text", text: "now answer this" }] },
+	];
+	const fullBody = buildRequestBody(codexModel, { systemPrompt: "Instructions", messages: [] }, { sessionId: "session-1" });
+	fullBody.input = [
+		...previousBody.input,
+		{ ...responseItems[0], id: "fc_replayed_1" },
+		{ ...responseItems[1], id: "fc_replayed_2" },
+		...delta,
+	];
+
+	assert.deepEqual(
+		buildCachedWebSocketRequestBody({ lastRequestBody: previousBody, lastResponseId: "resp_1", lastResponseItems: responseItems }, fullBody),
+		{
+			body: { ...fullBody, previous_response_id: "resp_1", input: delta },
+			decision: "delta",
+		},
+	);
+});
+
 test("getEffectiveCodexTransport enables cached websockets without overriding auto or sse fallback semantics", () => {
 	assert.equal(getEffectiveCodexTransport(undefined, undefined), "auto");
 	assert.equal(getEffectiveCodexTransport(undefined, { forceCachedWebSockets: true }), "auto");

--- a/packages/pi-codex-conversion/tests/openai-responses-shared.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-responses-shared.test.ts
@@ -198,6 +198,56 @@ test("processResponsesStream preserves image generation calls for later Response
 	assert.deepEqual(messages, [imageItem]);
 });
 
+test("processResponsesStream preserves web search calls for later Responses turns", async () => {
+	const output = createAssistantOutput();
+	const webSearchItem = {
+		type: "web_search_call",
+		id: "ws_123",
+		status: "completed",
+		action: { type: "search", query: "BlackBerry 9700 Bold" },
+		results: [{ title: "BlackBerry Bold 9700", url: "https://example.com/9700" }],
+	};
+
+	await processResponsesStream(
+		asAsyncIterable([
+			{ type: "response.created", response: { id: "resp_1" } },
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "web_search_call", id: "ws_123", status: "in_progress" },
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: webSearchItem,
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_1",
+					status: "completed",
+					usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		]) as AsyncIterable<any>,
+		output as any,
+		{ push: () => undefined } as any,
+		model,
+	);
+
+	assert.deepEqual((output.content as any[]).filter((block) => block.type === "web_search_call"), [
+		{ type: "web_search_call", item: webSearchItem },
+	]);
+
+	const messages = convertResponsesMessages(
+		model,
+		{ messages: [output as any] },
+		new Set(["openai-codex"]),
+	);
+
+	assert.deepEqual(messages, [webSearchItem]);
+});
+
 test("convertResponsesMessages strips unsupported image generation call fields from old history", () => {
 	const messages = convertResponsesMessages(
 		model,

--- a/packages/pi-explore-subagents/src/explore-tool.ts
+++ b/packages/pi-explore-subagents/src/explore-tool.ts
@@ -5,7 +5,18 @@ import { ExploreParams, TOOL_LABEL, TOOL_NAME } from "./constants.js";
 import { getFinalOutput, getMode } from "./messages.js";
 import { renderExploreCall, renderSubagentResultBlock } from "./render.js";
 import { runSubagent } from "./subagent.js";
-import type { ChildRunDetails, ExploreMode } from "./types.js";
+import type {
+	ChildRunDetails,
+	ExploreMode,
+	PersistedChildRunDetails,
+} from "./types.js";
+
+function persistedDetails(details: ChildRunDetails): PersistedChildRunDetails {
+	return {
+		mode: details.mode,
+		cwd: details.cwd,
+	};
+}
 
 export function registerExploreTool(pi: ExtensionAPI) {
 	pi.registerTool({
@@ -41,7 +52,7 @@ export function registerExploreTool(pi: ExtensionAPI) {
 			}
 			return {
 				content: [{ type: "text", text: finalOutput }],
-				details,
+				details: persistedDetails(details),
 			};
 		},
 		renderCall(args, theme) {
@@ -51,8 +62,11 @@ export function registerExploreTool(pi: ExtensionAPI) {
 			);
 		},
 		renderResult(result, { expanded, isPartial }, theme) {
-			const details = result.details as ChildRunDetails | undefined;
-			if (!details) {
+			const details = result.details as
+				| ChildRunDetails
+				| PersistedChildRunDetails
+				| undefined;
+			if (!details || !("messages" in details)) {
 				const first = result.content[0];
 				return new Text(
 					first?.type === "text" ? first.text : "(no output)",

--- a/packages/pi-explore-subagents/src/types.ts
+++ b/packages/pi-explore-subagents/src/types.ts
@@ -44,6 +44,11 @@ export interface ChildRunDetails {
 	usage: UsageStats;
 }
 
+export interface PersistedChildRunDetails {
+	mode: ExploreMode;
+	cwd: string;
+}
+
 export interface ModeSpec {
 	label: string;
 	shortDescription: string;


### PR DESCRIPTION
## Summary
- preserve Codex WebSocket continuation for parallel tool-output follow-ups when replay shape drifts
- preserve native `web_search_call` response items so follow-up Responses history stays aligned
- slim persisted explore subagent tool-result details so parent sessions do not store child transcripts
- add Overrides settings for custom Codex proxy providers: `Codex proxy` on/off plus comma-separated `Proxy providers`

Closes #27

## Validation
- `bun run check:changed`
- `bun run check` in `packages/pi-explore-subagents`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-explore-subagents`
- Aggregates: auto-bumped by `bun run changeset:aggregates`
