### PR TITLE
Match Codex background terminal polling

### DIFF
--- a/.changeset/gentle-plums-wait.md
+++ b/.changeset/gentle-plums-wait.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Match Codex background terminal polling by allowing empty `write_stdin` waits to use a dedicated 5-minute cap instead of the normal 30-second exec cap.

--- a/packages/pi-codex-conversion/src/tools/exec-command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-command-tool.ts
@@ -15,8 +15,8 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 			description: "Allocate a TTY. Defaults to false.",
 		}),
 	),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait for output before yielding." })),
-	max_output_tokens: Type.Optional(Type.Number({ description: "Excess output will be truncated." })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait before yielding. Max 30000." })),
+	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate excess output." })),
 	login: Type.Optional(Type.Boolean({ description: "Whether to run through a login-style shell so user PATH/toolchain setup is loaded. Defaults to true." })),
 });
 

--- a/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
@@ -60,7 +60,7 @@ export type ExecSessionUpdateCallback = (result: UnifiedExecResult) => void;
 
 export interface ExecSessionManager {
 	exec(input: ExecCommandInput, cwd: string, signal?: AbortSignal, onUpdate?: ExecSessionUpdateCallback): Promise<UnifiedExecResult>;
-	write(input: WriteStdinInput, onUpdate?: ExecSessionUpdateCallback): Promise<UnifiedExecResult>;
+	write(input: WriteStdinInput, signal?: AbortSignal, onUpdate?: ExecSessionUpdateCallback): Promise<UnifiedExecResult>;
 	hasSession(sessionId: number): boolean;
 	getSessionCommand(sessionId: number): string | undefined;
 	onSessionExit(listener: (sessionId: number, command: string) => void): () => void;
@@ -424,9 +424,13 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 	function waitForExitOrTimeout(
 		session: ExecSession,
 		yieldTimeMs: number,
+		signal?: AbortSignal,
 		onUpdate?: (elapsedMs: number) => void,
 	): Promise<number> {
 		if (session.exitCode !== undefined && session.exitCode !== null) {
+			return Promise.resolve(0);
+		}
+		if (signal?.aborted) {
 			return Promise.resolve(0);
 		}
 
@@ -434,6 +438,14 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		let updateTimer: ReturnType<typeof setInterval> | undefined;
 		let lastUpdateAt = 0;
 		return new Promise((resolvePromise) => {
+			let abortCleanup: (() => void) | undefined;
+			let done = false;
+			const finish = () => {
+				if (done) return;
+				done = true;
+				cleanup();
+				resolvePromise(Date.now() - startedAt);
+			};
 			const emitUpdate = (force = false) => {
 				const now = Date.now();
 				if (!force && now - lastUpdateAt < 250) return;
@@ -446,19 +458,19 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 					return;
 				}
 				emitUpdate(true);
-				cleanup();
-				resolvePromise(Date.now() - startedAt);
+				finish();
 			};
 			const timeout = setTimeout(() => {
-				cleanup();
-				resolvePromise(Date.now() - startedAt);
+				finish();
 			}, yieldTimeMs);
+			abortCleanup = registerAbortHandler(signal, finish);
 			if (onUpdate) {
 				updateTimer = setInterval(emitUpdate, 250);
 			}
 			const cleanup = () => {
 				clearTimeout(timeout);
 				if (updateTimer) clearInterval(updateTimer);
+				abortCleanup?.();
 				session.listeners.delete(onWake);
 			};
 			session.listeners.add(onWake);
@@ -621,11 +633,12 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			const waitedMs = await waitForExitOrTimeout(
 				session,
 				clampExecYieldTime(input.yield_time_ms, defaultExecYieldTimeMs, session.interactive, minNonInteractiveExecYieldTimeMs),
+				signal,
 				onUpdate ? (elapsedMs) => onUpdate(makeSnapshotResult(session, elapsedMs, input.max_output_tokens)) : undefined,
 			);
 			return makeResult(session, waitedMs, input.max_output_tokens);
 		},
-		write: async (input, onUpdate) => {
+		write: async (input, signal, onUpdate) => {
 			const session = sessions.get(input.session_id);
 			if (!session) {
 				throw new Error(`Unknown process id ${input.session_id}`);
@@ -651,6 +664,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 								minEmptyWriteYieldTimeMs,
 								maxEmptyWriteYieldTimeMs,
 							),
+							signal,
 							onUpdate ? (elapsedMs) => onUpdate(makeSnapshotSince(session, elapsedMs, updateBaseline, input.max_output_tokens)) : undefined,
 						)
 					: 0;

--- a/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
@@ -633,12 +633,15 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			const waitedMs = await waitForExitOrTimeout(
 				session,
 				clampExecYieldTime(input.yield_time_ms, defaultExecYieldTimeMs, session.interactive, minNonInteractiveExecYieldTimeMs),
-				signal,
+				undefined,
 				onUpdate ? (elapsedMs) => onUpdate(makeSnapshotResult(session, elapsedMs, input.max_output_tokens)) : undefined,
 			);
 			return makeResult(session, waitedMs, input.max_output_tokens);
 		},
 		write: async (input, signal, onUpdate) => {
+			if (signal?.aborted) {
+				throw new Error("write_stdin aborted");
+			}
 			const session = sessions.get(input.session_id);
 			if (!session) {
 				throw new Error(`Unknown process id ${input.session_id}`);

--- a/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec-session-manager.ts
@@ -72,6 +72,7 @@ export interface ExecSessionManagerOptions {
 	defaultWriteYieldTimeMs?: number | undefined;
 	minNonInteractiveExecYieldTimeMs?: number | undefined;
 	minEmptyWriteYieldTimeMs?: number | undefined;
+	maxEmptyWriteYieldTimeMs?: number | undefined;
 	maxSessionBufferChars?: number | undefined;
 }
 
@@ -82,6 +83,7 @@ const MIN_YIELD_TIME_MS = 250;
 const MIN_NON_INTERACTIVE_EXEC_YIELD_TIME_MS = 5_000;
 const MIN_EMPTY_WRITE_YIELD_TIME_MS = 5_000;
 const MAX_YIELD_TIME_MS = 30_000;
+const DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS = 300_000;
 const MAX_COMMAND_HISTORY = 256;
 const DEFAULT_MAX_SESSION_BUFFER_CHARS = 256 * 1024 * 1024;
 
@@ -170,12 +172,12 @@ function clampWriteYieldTime(
 	fallback: number,
 	isEmptyPoll: boolean,
 	minEmptyWriteYieldTimeMs: number,
+	maxEmptyWriteYieldTimeMs: number,
 ): number {
-	const value = clampYieldTime(yieldTimeMs, fallback);
 	if (!isEmptyPoll) {
-		return value;
+		return clampYieldTime(yieldTimeMs, fallback);
 	}
-	return Math.min(MAX_YIELD_TIME_MS, Math.max(minEmptyWriteYieldTimeMs, value));
+	return Math.min(maxEmptyWriteYieldTimeMs, Math.max(minEmptyWriteYieldTimeMs, yieldTimeMs ?? fallback));
 }
 
 function maxCharsForTokens(maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS): number {
@@ -377,6 +379,10 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 	const minEmptyWriteYieldTimeMs = Math.min(
 		MAX_YIELD_TIME_MS,
 		Math.max(MIN_YIELD_TIME_MS, options.minEmptyWriteYieldTimeMs ?? MIN_EMPTY_WRITE_YIELD_TIME_MS),
+	);
+	const maxEmptyWriteYieldTimeMs = Math.max(
+		minEmptyWriteYieldTimeMs,
+		options.maxEmptyWriteYieldTimeMs ?? DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS,
 	);
 	const maxSessionBufferChars = Math.max(1024, options.maxSessionBufferChars ?? DEFAULT_MAX_SESSION_BUFFER_CHARS);
 
@@ -643,6 +649,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 								defaultWriteYieldTimeMs,
 								!input.chars || input.chars.length === 0,
 								minEmptyWriteYieldTimeMs,
+								maxEmptyWriteYieldTimeMs,
 							),
 							onUpdate ? (elapsedMs) => onUpdate(makeSnapshotSince(session, elapsedMs, updateBaseline, input.max_output_tokens)) : undefined,
 						)

--- a/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
@@ -111,7 +111,7 @@ export function registerWriteStdinTool(pi: ExtensionAPI, sessions: ExecSessionMa
 		description: "Writes to or polls a running exec session.",
 		promptSnippet: "Write to an exec session.",
 		parameters: WRITE_STDIN_PARAMETERS,
-		async execute(_toolCallId, params, _signal, onUpdate) {
+		async execute(_toolCallId, params, signal, onUpdate) {
 			const typed = parseWriteStdinParams(params);
 			const command = sessions.getSessionCommand(typed.session_id);
 			let result: UnifiedExecResult;
@@ -120,7 +120,7 @@ export function registerWriteStdinTool(pi: ExtensionAPI, sessions: ExecSessionMa
 					content: [{ type: "text" as const, text: formatUnifiedExecResult(partial, command) }],
 					details: partial,
 				});
-				result = await sessions.write(typed, onUpdate ? (partial) => onUpdate(toToolResult(partial)) : undefined);
+				result = await sessions.write(typed, signal, onUpdate ? (partial) => onUpdate(toToolResult(partial)) : undefined);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(`write_stdin failed: ${message}`);

--- a/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/write-stdin-tool.ts
@@ -8,8 +8,8 @@ import { formatUnifiedExecResult } from "./unified-exec-format.ts";
 const WRITE_STDIN_PARAMETERS = Type.Object({
 	session_id: Type.Number({ description: "Running exec session ID." }),
 	chars: Type.Optional(Type.String({ description: "Bytes to write. Empty polls." })),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait for output before yielding." })),
-	max_output_tokens: Type.Optional(Type.Number({ description: "Excess output will be truncated." })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait before yielding. Empty polls can wait up to 300000." })),
+	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate excess output." })),
 });
 
 interface WriteStdinParams {

--- a/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
@@ -387,6 +387,50 @@ test("empty write_stdin polls return promptly when aborted", async () => {
 	}
 });
 
+test("write_stdin does not write input when already aborted", async () => {
+	const sessions = createFastTestExecSessionManager();
+	try {
+		const started = await sessions.exec(
+			{
+				cmd: "read line && printf ':%s' \"$line\"",
+				shell: "/bin/bash",
+				login: false,
+				tty: true,
+				yield_time_ms: 50,
+			},
+			process.cwd(),
+		);
+
+		assert.equal(typeof started.session_id, "number");
+		const controller = new AbortController();
+		controller.abort();
+
+		await assert.rejects(
+			() =>
+				sessions.write(
+					{
+						session_id: started.session_id!,
+						chars: "cancelled\n",
+						yield_time_ms: 50,
+					},
+					controller.signal,
+				),
+			/write_stdin aborted/,
+		);
+
+		const resumed = await sessions.write({
+			session_id: started.session_id!,
+			chars: "hello\n",
+			yield_time_ms: 500,
+		});
+
+		assert.equal(resumed.output, "hello\n:hello");
+		assert.equal(resumed.exit_code, 0);
+	} finally {
+		sessions.shutdown();
+	}
+});
+
 test("non-empty write_stdin calls stay responsive and do not use the empty-poll minimum", async () => {
 	const sessions = createExecSessionManager({ minNonInteractiveExecYieldTimeMs: 50, minEmptyWriteYieldTimeMs: 500 });
 	try {

--- a/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
@@ -228,6 +228,7 @@ test("write_stdin partial updates do not replay already consumed output", async 
 				chars: "hello\n",
 				yield_time_ms: 500,
 			},
+			undefined,
 			(update) => updates.push(update),
 		);
 
@@ -342,6 +343,44 @@ test("empty write_stdin polls can wait beyond the normal 30s exec cap", async ()
 
 		assert.ok(elapsed >= 200, `expected empty poll to use dedicated max, got ${elapsed}ms`);
 		assert.ok(elapsed < 800, `expected empty poll to cap before requested 1000ms, got ${elapsed}ms`);
+		assert.equal(resumed.session_id, started.session_id);
+	} finally {
+		sessions.shutdown();
+	}
+});
+
+test("empty write_stdin polls return promptly when aborted", async () => {
+	const sessions = createExecSessionManager({
+		minNonInteractiveExecYieldTimeMs: 50,
+		minEmptyWriteYieldTimeMs: 50,
+		maxEmptyWriteYieldTimeMs: 5_000,
+	});
+	try {
+		const started = await sessions.exec(
+			{
+				cmd: "sleep 5",
+				shell: "/bin/bash",
+				login: false,
+				yield_time_ms: 50,
+			},
+			process.cwd(),
+		);
+
+		assert.equal(typeof started.session_id, "number");
+
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 100);
+		const start = Date.now();
+		const resumed = await sessions.write(
+			{
+				session_id: started.session_id!,
+				yield_time_ms: 5_000,
+			},
+			controller.signal,
+		);
+		const elapsed = Date.now() - start;
+
+		assert.ok(elapsed < 1_000, `expected abort to interrupt empty poll, got ${elapsed}ms`);
 		assert.equal(resumed.session_id, started.session_id);
 	} finally {
 		sessions.shutdown();

--- a/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-session-manager.test.ts
@@ -314,6 +314,40 @@ test("empty write_stdin polls are clamped to the configured minimum", async () =
 	}
 });
 
+test("empty write_stdin polls can wait beyond the normal 30s exec cap", async () => {
+	const sessions = createExecSessionManager({
+		minNonInteractiveExecYieldTimeMs: 50,
+		minEmptyWriteYieldTimeMs: 50,
+		maxEmptyWriteYieldTimeMs: 250,
+	});
+	try {
+		const started = await sessions.exec(
+			{
+				cmd: "sleep 2",
+				shell: "/bin/bash",
+				login: false,
+				yield_time_ms: 50,
+			},
+			process.cwd(),
+		);
+
+		assert.equal(typeof started.session_id, "number");
+
+		const start = Date.now();
+		const resumed = await sessions.write({
+			session_id: started.session_id!,
+			yield_time_ms: 1_000,
+		});
+		const elapsed = Date.now() - start;
+
+		assert.ok(elapsed >= 200, `expected empty poll to use dedicated max, got ${elapsed}ms`);
+		assert.ok(elapsed < 800, `expected empty poll to cap before requested 1000ms, got ${elapsed}ms`);
+		assert.equal(resumed.session_id, started.session_id);
+	} finally {
+		sessions.shutdown();
+	}
+});
+
 test("non-empty write_stdin calls stay responsive and do not use the empty-poll minimum", async () => {
 	const sessions = createExecSessionManager({ minNonInteractiveExecYieldTimeMs: 50, minEmptyWriteYieldTimeMs: 500 });
 	try {


### PR DESCRIPTION
## Summary
- let empty `write_stdin` polls wait up to Codex's 300000ms background cap
- keep regular exec/non-empty stdin waits capped at 30000ms
- tighten exec/write_stdin schema wording and add coverage for the dedicated empty-poll cap

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `bun run --cwd packages/pi-codex-conversion typecheck`
- `bun run --cwd packages/pi-codex-conversion test -- tests/exec-session-manager.test.ts`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: auto-bumped by `bun run changeset:aggregates`
