### PR TITLE
Fix semantic grep large index search OOM

### DIFF
--- a/.changeset/semantic-grep-stream-search.md
+++ b/.changeset/semantic-grep-stream-search.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-semantic-grep": patch
+---
+
+Streams semantic search rows from SQLite and keeps only the best matches in memory, avoiding heap exhaustion on large indexes.

--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -24,6 +24,7 @@ Use this instead of the global generic PR flow in this repository.
 ## Hard rules
 
 - Do not manually bump package versions for normal feature/fix PRs. Use `bun changeset`.
+- Treat stale changesets as expected on long-lived `dev`; verify and remove consumed changesets before adding new ones or opening a PR.
 - Do not manually edit aggregate package versions. The release workflow handles them.
 - Do not manually add changesets for `@howaboua/pi-stuff`, `@howaboua/pi-extensions`, or `@howaboua/pi-skills` unless the aggregate package itself changed.
 - Keep changes scoped to the relevant `packages/<name>` directory plus any required repo-level workflow/docs/scripts.
@@ -64,28 +65,36 @@ SKIP_HOOKS=1 git commit -m "wip"
 ## Workflow for implementing a package change
 
 1. Inspect state:
-   ```bash
-   git status --short --branch
-   ```
+	```bash
+	git fetch --prune origin && git status --short --branch
+	```
 2. Create or switch to a focused branch from `main` unless the user says otherwise.
-3. Make scoped edits.
-4. Run:
-   ```bash
-   bun run check:changed
-   ```
-5. If the change should ship, create a changeset:
-   ```bash
-   bun changeset
-   ```
-   - Select only the directly changed individual package(s).
-   - Usually choose `patch`.
-   - Use `minor` for user-visible new capability.
-   - Use `major` only for breaking changes.
-6. Do not create aggregate changesets manually. The release workflow runs:
-   ```bash
-   bun run changeset:aggregates
-   ```
-7. Commit all relevant files, including the `.changeset/*.md` file.
+3. Check for stale changesets before making release edits:
+	```bash
+	ls .changeset
+	git diff --name-status origin/main...HEAD -- .changeset
+	```
+	- `config.json` is not a release changeset.
+	- Remove changesets already consumed by `origin/main` version/publish commits.
+	- Keep only changesets for changes intentionally pending in this branch.
+4. Make scoped edits.
+5. Run:
+	```bash
+	bun run check:changed
+	```
+6. If the change should ship, create a changeset:
+	```bash
+	bun changeset
+	```
+	- Select only the directly changed individual package(s).
+	- Usually choose `patch`.
+	- Use `minor` for user-visible new capability.
+	- Use `major` only for breaking changes.
+7. Do not create aggregate changesets manually. The release workflow runs:
+	```bash
+	bun run changeset:aggregates
+	```
+8. Commit all relevant files, including the intended `.changeset/*.md` file.
 
 ## Workflow for docs/tooling-only changes
 
@@ -165,5 +174,5 @@ Do not re-post on every update unless explicitly asked.
 - Branch and working tree state known.
 - Changed packages listed.
 - Validation command and result listed.
-- Changeset status stated.
+- Changeset status stated, including stale changesets removed/kept.
 - PR/issue links included if created.

--- a/packages/pi-semantic-grep/src/search.ts
+++ b/packages/pi-semantic-grep/src/search.ts
@@ -19,18 +19,29 @@ export async function searchDb(
 	signal?: AbortSignal,
 ): Promise<SearchMatch[]> {
 	const q = await embed(query, config, signal);
-	const rows = db
-		.prepare("select id, file, start_line, end_line, text, vector from chunks")
-		.all() as ChunkRow[];
-	const scored = rows.map((r) => ({
-		file: r.file,
-		startLine: r.start_line,
-		endLine: r.end_line,
-		text: r.text,
-		score: cosine(q, JSON.parse(r.vector) as number[]),
-	}));
-	scored.sort((a, b) => b.score - a.score);
-	return scored.slice(0, topK);
+	const best: SearchMatch[] = [];
+	let minBestScore = Number.NEGATIVE_INFINITY;
+
+	for (const row of db
+		.prepare("select file, start_line, end_line, text, vector from chunks")
+		.iterate() as Iterable<ChunkRow>) {
+		signal?.throwIfAborted();
+		const score = cosine(q, JSON.parse(row.vector) as number[]);
+		if (best.length >= topK && score <= minBestScore) continue;
+
+		best.push({
+			file: row.file,
+			startLine: row.start_line,
+			endLine: row.end_line,
+			text: row.text,
+			score,
+		});
+		best.sort((a, b) => b.score - a.score);
+		if (best.length > topK) best.pop();
+		minBestScore = best.at(-1)?.score ?? Number.NEGATIVE_INFINITY;
+	}
+
+	return best;
 }
 
 export function formatMatches(matches: SearchMatch[]): string {


### PR DESCRIPTION
## Summary
- Stream semantic grep search rows from SQLite instead of loading all chunks into JS memory.
- Keep only the best matches in memory while scoring.
- Update the repo PR workflow skill to require stale changeset checks.

## Validation
- `bun run check:changed`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-semantic-grep`
- Aggregates: auto-bumped by `bun run changeset:aggregates`
