### PR TITLE
Fix Codex exec previews and extra tool overlays

### DIFF
--- a/.changeset/calm-pears-tap.md
+++ b/.changeset/calm-pears-tap.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Bounds collapsed exec_command previews for large outputs to avoid repeated full-output wrapping in the TUI.

--- a/.changeset/calm-pears-tap.md
+++ b/.changeset/calm-pears-tap.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Bounds collapsed exec_command previews for large outputs to avoid repeated full-output wrapping in the TUI.
+Bounds collapsed exec_command previews for large outputs and adds an all-models extras-only mode with per-tool overlays for apply_patch, view_image, web_run, and imagegen.

--- a/packages/pi-codex-conversion/src/adapter/activation/activation.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/activation.ts
@@ -12,7 +12,7 @@ import {
 	SHELL_ADAPTER_TOOL_NAMES,
 	VIEW_IMAGE_TOOL_NAME,
 	WEB_SEARCH_TOOL_NAME,
-	buildApplyPatchOnlyStatusText,
+	buildExtraToolsOnlyStatusText,
 	buildStatusText,
 } from "./tool-set.ts";
 import { supportsNativeImageGeneration } from "../../tools/imagegen/tool.ts";
@@ -22,8 +22,8 @@ import { supportsViewImageInputs } from "../../tools/view-image/tool.ts";
 const ADAPTER_TOOL_NAMES = [...CORE_ADAPTER_TOOL_NAMES, WEB_SEARCH_TOOL_NAME, IMAGE_GENERATION_TOOL_NAME, VIEW_IMAGE_TOOL_NAME];
 
 export function syncAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState): void {
-	if (shouldUseApplyPatchOnly(ctx, state.config)) {
-		enableApplyPatchOnly(pi, ctx, state);
+	if (shouldUseExtraToolsOnly(ctx, state.config)) {
+		enableExtraToolsOnly(pi, ctx, state);
 		return;
 	}
 	if (shouldUseCodexAdapter(ctx, state.config)) {
@@ -34,8 +34,8 @@ export function syncAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: Adap
 }
 
 export function shouldUseCodexAdapter(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
-	if (shouldUseApplyPatchOnly(ctx, config)) return false;
-	return config.scope.allProviders || isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx);
+	if (shouldUseExtraToolsOnly(ctx, config)) return false;
+	return usesFullAdapterOnAllProviders(config) || isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx);
 }
 
 export function isConfiguredAdapterProvider(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
@@ -48,25 +48,39 @@ export function shouldUseProxyNativeTools(ctx: ExtensionContext, config: CodexCo
 }
 
 function shouldUseCodexBackedNativeTools(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
-	return config.mode === "normal" && (config.scope.allProviders || isConfiguredAdapterProvider(ctx, config));
+	return config.mode === "normal" && (usesAnyAdapterModeOnAllProviders(config) || isConfiguredAdapterProvider(ctx, config));
 }
 
 export function isEffectiveOpenAICodexContext(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
 	return isOpenAICodexContext(ctx) || shouldUseProxyNativeTools(ctx, config);
 }
 
-export function shouldUseApplyPatchOnly(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
+export function shouldUseExtraToolsOnly(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
 	if (config.mode !== "normal") return false;
-	return config.tools.applyPatchOnly && shouldUseCodexAdapterByScope(ctx, config);
+	if (!hasExtraToolsOnlyConfig(config)) return false;
+	if (usesExtraToolsOnlyOnAllProviders(config)) return true;
+	return config.scope.allProviders === "off" && (isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx));
 }
 
-function shouldUseCodexAdapterByScope(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
-	return config.scope.allProviders || isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx);
+function hasExtraToolsOnlyConfig(config: CodexConversionConfig): boolean {
+	return config.tools.applyPatchOnly || config.tools.viewImageOnly || config.tools.webRunOnly || config.tools.imageGenerationOnly;
 }
 
-function enableApplyPatchOnly(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState): void {
-	const adapterOwnedTools = [APPLY_PATCH_TOOL_NAME];
-	if (!state.enabled || state.adapterOwnedToolNames?.some((toolName) => toolName !== APPLY_PATCH_TOOL_NAME)) {
+function usesFullAdapterOnAllProviders(config: CodexConversionConfig): boolean {
+	return config.scope.allProviders === "on";
+}
+
+function usesExtraToolsOnlyOnAllProviders(config: CodexConversionConfig): boolean {
+	return config.scope.allProviders === "extras";
+}
+
+function usesAnyAdapterModeOnAllProviders(config: CodexConversionConfig): boolean {
+	return config.scope.allProviders !== "off";
+}
+
+function enableExtraToolsOnly(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState): void {
+	const adapterOwnedTools = getExtraToolsOnlyToolNames(ctx, state.config);
+	if (!state.enabled || !sameToolSet(state.adapterOwnedToolNames ?? [], adapterOwnedTools)) {
 		const restoredBase = state.enabled
 			? restoreTools(state.previousToolNames && state.previousToolNames.length > 0 ? state.previousToolNames : DEFAULT_TOOL_NAMES, pi.getActiveTools(), state.adapterOwnedToolNames ?? ADAPTER_TOOL_NAMES)
 			: stripAdapterTools(pi.getActiveTools(), ADAPTER_TOOL_NAMES);
@@ -75,7 +89,7 @@ function enableApplyPatchOnly(pi: ExtensionAPI, ctx: ExtensionContext, state: Ad
 	}
 	state.adapterOwnedToolNames = adapterOwnedTools;
 	pi.setActiveTools(mergeToolNames(state.previousToolNames ?? DEFAULT_TOOL_NAMES, adapterOwnedTools));
-	setApplyPatchOnlyStatus(ctx, state.config);
+	setExtraToolsOnlyStatus(ctx, state.config, adapterOwnedTools);
 }
 
 function enableAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState): void {
@@ -124,7 +138,7 @@ function getStatusConfig(ctx: ExtensionContext, config: CodexConversionConfig): 
 	const useCodexBackedNativeTools = shouldUseCodexBackedNativeTools(ctx, config);
 	return {
 		mode: config.mode,
-		useOnAllModels: config.scope.allProviders,
+		useOnAllModels: usesFullAdapterOnAllProviders(config),
 		additionalProvider: isConfiguredAdapterProvider(ctx, config),
 		fast: showOpenAICodexFlags && config.openai.fast,
 		webSearch: config.mode === "normal" && config.tools.webRun && (supportsNativeWebSearch(ctx.model) || useCodexBackedNativeTools),
@@ -144,6 +158,16 @@ function getAdapterToolNames(ctx: ExtensionContext, config: CodexConversionConfi
 	return toolNames;
 }
 
+function getExtraToolsOnlyToolNames(ctx: ExtensionContext, config: CodexConversionConfig): string[] {
+	const useCodexBackedNativeTools = shouldUseCodexBackedNativeTools(ctx, config);
+	const toolNames: string[] = [];
+	if (config.tools.applyPatchOnly) toolNames.push(APPLY_PATCH_TOOL_NAME);
+	if (config.tools.viewImageOnly && (supportsViewImageInputs(ctx.model) || config.tools.viewImageFallback)) toolNames.push(VIEW_IMAGE_TOOL_NAME);
+	if (config.tools.webRunOnly && (supportsNativeWebSearch(ctx.model) || useCodexBackedNativeTools)) toolNames.push(WEB_SEARCH_TOOL_NAME);
+	if (config.tools.imageGenerationOnly && (supportsNativeImageGeneration(ctx.model) || useCodexBackedNativeTools)) toolNames.push(IMAGE_GENERATION_TOOL_NAME);
+	return toolNames;
+}
+
 function getAdapterOwnedToolNames(config: CodexConversionConfig): string[] {
 	if (config.mode === "path") return [...ADAPTER_TOOL_NAMES];
 	return [
@@ -155,9 +179,9 @@ function getAdapterOwnedToolNames(config: CodexConversionConfig): string[] {
 	];
 }
 
-function setApplyPatchOnlyStatus(ctx: ExtensionContext, config: CodexConversionConfig): void {
+function setExtraToolsOnlyStatus(ctx: ExtensionContext, config: CodexConversionConfig, toolNames: string[]): void {
 	if (!ctx.hasUI) return;
-	ctx.ui.setStatus(STATUS_KEY, config.ui.statusLine ? buildApplyPatchOnlyStatusText(ctx.ui.theme) : undefined);
+	ctx.ui.setStatus(STATUS_KEY, config.ui.statusLine ? buildExtraToolsOnlyStatusText(toolNames, ctx.ui.theme) : undefined);
 }
 
 function mergeToolNames(...toolNameGroups: string[][]): string[] {
@@ -186,4 +210,8 @@ export function stripAdapterTools(toolNames: string[], adapterOwnedTools: string
 
 function hasAdapterTools(activeTools: string[], adapterOwnedTools: string[]): boolean {
 	return activeTools.some((toolName) => adapterOwnedTools.includes(toolName));
+}
+
+function sameToolSet(left: string[], right: string[]): boolean {
+	return left.length === right.length && left.every((toolName) => right.includes(toolName));
 }

--- a/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
@@ -17,8 +17,8 @@ export function migrateCodexConversionConfigIfNeeded(value: unknown): { migrated
 
 	const config: CodexConversionConfig = {
 		...structuredClone(DEFAULT_CODEX_CONVERSION_CONFIG),
-		scope: {
-			allProviders: typeof value["useOnAllModels"] === "boolean" ? value["useOnAllModels"] : DEFAULT_CODEX_CONVERSION_CONFIG.scope["allProviders"],
+	scope: {
+			allProviders: value["useOnAllModels"] === true ? "on" : value["useOnAllModels"] === false ? "off" : DEFAULT_CODEX_CONVERSION_CONFIG.scope["allProviders"],
 			additionalProviders: value["useAdapterProviders"] === true ? normalizeProviderList(value["adapterProviders"]) : [],
 		},
 		tools: {
@@ -26,6 +26,9 @@ export function migrateCodexConversionConfigIfNeeded(value: unknown): { migrated
 			imageGeneration: adapterProviderCodexToolsDisabled ? false : typeof value["imageGeneration"] === "boolean" ? value["imageGeneration"] : DEFAULT_CODEX_CONVERSION_CONFIG.tools["imageGeneration"],
 			viewImageFallback: DEFAULT_CODEX_CONVERSION_CONFIG.tools["viewImageFallback"],
 			applyPatchOnly: typeof value["applyPatchOnly"] === "boolean" ? value["applyPatchOnly"] : DEFAULT_CODEX_CONVERSION_CONFIG.tools["applyPatchOnly"],
+			viewImageOnly: DEFAULT_CODEX_CONVERSION_CONFIG.tools["viewImageOnly"],
+			webRunOnly: DEFAULT_CODEX_CONVERSION_CONFIG.tools["webRunOnly"],
+			imageGenerationOnly: DEFAULT_CODEX_CONVERSION_CONFIG.tools["imageGenerationOnly"],
 		},
 		ui: {
 			statusLine: typeof value["statusLine"] === "boolean" ? value["statusLine"] : DEFAULT_CODEX_CONVERSION_CONFIG.ui["statusLine"],

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -5,6 +5,7 @@ import { migrateCodexConversionConfigIfNeeded } from "./config-migration.ts";
 
 export type CodexVerbosity = "low" | "medium" | "high";
 export type CodexAdapterMode = "normal" | "path";
+export type AllProvidersMode = "off" | "on" | "extras";
 export type CompactionModel = "gpt-5.5" | "gpt-5.3-codex-spark" | "gpt-5.4-mini";
 export type WebSearchModel = "gpt-5.5" | "gpt-5.4-mini" | "gpt-5.3-codex-spark";
 export type CompactionReasoning = "current" | "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -15,8 +16,16 @@ export const COMPACTION_REASONING_LEVELS: readonly CompactionReasoning[] = ["cur
 
 export interface CodexConversionConfig {
 	mode: CodexAdapterMode;
-	scope: { allProviders: boolean; additionalProviders: string[] };
-	tools: { webRun: boolean; imageGeneration: boolean; viewImageFallback: boolean; applyPatchOnly: boolean };
+	scope: { allProviders: AllProvidersMode; additionalProviders: string[] };
+	tools: {
+		webRun: boolean;
+		imageGeneration: boolean;
+		viewImageFallback: boolean;
+		applyPatchOnly: boolean;
+		viewImageOnly: boolean;
+		webRunOnly: boolean;
+		imageGenerationOnly: boolean;
+	};
 	ui: {
 		statusLine: boolean;
 		toolRendering: boolean;
@@ -40,8 +49,8 @@ export interface CodexConversionConfig {
 export const CODEX_CONVERSION_CONFIG_BASENAME = "pi-codex-conversion.json";
 export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	mode: "normal",
-	scope: { allProviders: false, additionalProviders: [] },
-	tools: { webRun: true, imageGeneration: true, viewImageFallback: false, applyPatchOnly: false },
+	scope: { allProviders: "off", additionalProviders: [] },
+	tools: { webRun: true, imageGeneration: true, viewImageFallback: false, applyPatchOnly: false, viewImageOnly: false, webRunOnly: false, imageGenerationOnly: false },
 	ui: {
 		statusLine: true,
 		toolRendering: true,
@@ -68,6 +77,12 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 
 export function normalizeCodexAdapterMode(value: unknown): CodexAdapterMode | undefined {
 	return value === "normal" || value === "path" ? value : undefined;
+}
+
+export function normalizeAllProvidersMode(value: unknown): AllProvidersMode | undefined {
+	if (value === true) return "on";
+	if (value === false) return "off";
+	return value === "off" || value === "on" || value === "extras" ? value : undefined;
 }
 
 export function normalizeCodexVerbosity(value: unknown): CodexVerbosity | undefined {
@@ -117,7 +132,7 @@ export function normalizeCodexConversionConfig(value: unknown): CodexConversionC
 	return {
 		mode: normalizeCodexAdapterMode(value["mode"]) ?? DEFAULT_CODEX_CONVERSION_CONFIG.mode,
 		scope: {
-			allProviders: bool(scope["allProviders"], DEFAULT_CODEX_CONVERSION_CONFIG.scope["allProviders"]),
+			allProviders: normalizeAllProvidersMode(scope["allProviders"]) ?? DEFAULT_CODEX_CONVERSION_CONFIG.scope["allProviders"],
 			additionalProviders: normalizeProviderList(scope["additionalProviders"]),
 		},
 		tools: {
@@ -125,6 +140,9 @@ export function normalizeCodexConversionConfig(value: unknown): CodexConversionC
 			imageGeneration: bool(tools["imageGeneration"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["imageGeneration"]),
 			viewImageFallback: bool(tools["viewImageFallback"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["viewImageFallback"]),
 			applyPatchOnly: bool(tools["applyPatchOnly"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["applyPatchOnly"]),
+			viewImageOnly: bool(tools["viewImageOnly"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["viewImageOnly"]),
+			webRunOnly: bool(tools["webRunOnly"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["webRunOnly"]),
+			imageGenerationOnly: bool(tools["imageGenerationOnly"], DEFAULT_CODEX_CONVERSION_CONFIG.tools["imageGenerationOnly"]),
 		},
 		ui: {
 			statusLine: bool(ui["statusLine"], DEFAULT_CODEX_CONVERSION_CONFIG.ui["statusLine"]),

--- a/packages/pi-codex-conversion/src/adapter/activation/tool-set.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/tool-set.ts
@@ -10,8 +10,8 @@ function formatStatusText(suffix: string, theme?: StatusTheme | undefined): stri
 	return `${theme.fg("accent", STATUS_TEXT)}${suffix ? theme.fg("dim", suffix) : ""}`;
 }
 
-export function buildApplyPatchOnlyStatusText(theme?: StatusTheme | undefined): string {
-	return formatStatusText(" • apply patch only", theme);
+export function buildExtraToolsOnlyStatusText(tools: string[], theme?: StatusTheme | undefined): string {
+	return formatStatusText(` • extra tools${tools.length > 0 ? `: ${tools.join(", ")}` : ""}`, theme);
 }
 
 export function buildStatusText(options: { mode?: "normal" | "path" | undefined; verbosity?: string | undefined; webSearch?: boolean | undefined; imageGeneration?: boolean | undefined; fast: boolean; useOnAllModels: boolean; additionalProvider?: boolean | undefined; compaction?: { enabled: boolean; model: string; reasoning: string } | undefined }, theme?: StatusTheme | undefined): string {

--- a/packages/pi-codex-conversion/src/index.ts
+++ b/packages/pi-codex-conversion/src/index.ts
@@ -75,16 +75,16 @@ export default function codexConversion(pi: ExtensionAPI) {
 
 	function ensureOptionalNativeToolsRegistered(config = state.config): void {
 		const allowConfiguredProvider = (model: Model<any> | undefined): boolean => {
-			if (config.scope.allProviders) return true;
+			if (config.scope.allProviders !== "off") return true;
 			const provider = model?.provider?.trim().toLowerCase();
 			return Boolean(provider && config.scope.additionalProviders.includes(provider));
 		};
-		if (config.tools.webRun) {
+		if (config.tools.webRun || config.tools.webRunOnly) {
 			const webSearchToolName = WEB_SEARCH_TOOL_NAME;
 			registerWebSearchTool(pi, webSearchToolName, { getRecentInput: () => latestRecentWebSearchInput, model: () => state.config.openai.webSearchModel, allowConfiguredProvider, ...customRenderingOptions(config), ...promptSnippetOptions(config) });
 			registeredNativeWebSearchTools.add(webSearchToolName);
 		}
-		if (config.tools.imageGeneration) {
+		if (config.tools.imageGeneration || config.tools.imageGenerationOnly) {
 			registerImageGenerationTool(pi, { allowConfiguredProvider, ...customRenderingOptions(config), ...promptSnippetOptions(config) });
 		}
 	}

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -123,8 +123,22 @@ interface ExecCommandToolOptions {
 }
 
 const COLLAPSED_OUTPUT_MAX_VISUAL_LINES = 5;
+const COLLAPSED_OUTPUT_MAX_RAW_CHARS = 16_000;
+const COLLAPSED_OUTPUT_MAX_RAW_LINES = 160;
 
 type CollapsedExecOutput = Pick<UnifiedExecResult, "output"> & Partial<Pick<UnifiedExecResult, "exit_code" | "session_id" | "wall_time_seconds">>;
+
+interface CollapsedExecOutputRenderState {
+	cachedLines?: string[] | undefined;
+	cachedSkipped?: number | undefined;
+	cachedWidth?: number | undefined;
+	cachedRawTruncated?: boolean | undefined;
+}
+
+interface CollapsedExecOutputText {
+	text: string;
+	rawTruncated: boolean;
+}
 
 function formatDuration(seconds: number): string {
 	return `${seconds.toFixed(1)}s`;
@@ -160,25 +174,58 @@ function expandHint(): string {
 	}
 }
 
-function formatCollapsedOutput(result: CollapsedExecOutput, theme: { fg(role: string, text: string): string }): string {
-	const lines = [result.output.trimEnd()];
+function tailCollapsedOutput(output: string): { output: string; truncated: boolean } {
+	let text = output.trimEnd();
+	let truncated = false;
+	if (text.length > COLLAPSED_OUTPUT_MAX_RAW_CHARS) {
+		text = text.slice(-COLLAPSED_OUTPUT_MAX_RAW_CHARS);
+		truncated = true;
+		const firstNewline = text.indexOf("\n");
+		if (firstNewline !== -1) text = text.slice(firstNewline + 1);
+	}
+	const lines = text.split("\n");
+	if (lines.length > COLLAPSED_OUTPUT_MAX_RAW_LINES) {
+		text = lines.slice(-COLLAPSED_OUTPUT_MAX_RAW_LINES).join("\n");
+		truncated = true;
+	}
+	return { output: text, truncated };
+}
+
+function formatCollapsedOutput(result: CollapsedExecOutput, theme: { fg(role: string, text: string): string }): CollapsedExecOutputText {
+	const tail = tailCollapsedOutput(result.output);
+	const lines = [tail.output];
 	if (result.session_id !== undefined) lines.push(theme.fg("accent", `Session ${result.session_id} still running`));
 	if (result.exit_code !== undefined && result.exit_code !== 0) lines.push(theme.fg("muted", `Exit code: ${result.exit_code}`));
 	if (typeof result.wall_time_seconds === "number" && lines.some((line) => line.length > 0)) lines.push(theme.fg("muted", `Took ${formatDuration(result.wall_time_seconds)}`));
-	return lines.filter((line) => line.length > 0).join("\n");
+	return { text: lines.filter((line) => line.length > 0).join("\n"), rawTruncated: tail.truncated };
 }
 
 function renderCollapsedExecOutputPreview(result: CollapsedExecOutput, theme: { fg(role: string, text: string): string }) {
+	const state: CollapsedExecOutputRenderState = {};
 	return {
 		render(width: number): string[] {
-			const output = formatCollapsedOutput(result, theme);
-			if (!output) return [];
-			const preview = truncateToVisualLines(theme.fg("dim", output), COLLAPSED_OUTPUT_MAX_VISUAL_LINES, width, 4);
-			if (preview.skippedCount <= 0) return preview.visualLines;
-			const hint = `    ${theme.fg("muted", `... (${preview.skippedCount} earlier lines,`)} ${expandHint()}${theme.fg("muted", ")")}`;
-			return [truncateToWidth(hint, width, "..."), ...preview.visualLines];
+			if (state.cachedLines === undefined || state.cachedWidth !== width) {
+				const output = formatCollapsedOutput(result, theme);
+				if (!output.text) return [];
+				const preview = truncateToVisualLines(theme.fg("dim", output.text), COLLAPSED_OUTPUT_MAX_VISUAL_LINES, width, 4);
+				state.cachedLines = preview.visualLines;
+				state.cachedSkipped = preview.skippedCount;
+				state.cachedRawTruncated = output.rawTruncated;
+				state.cachedWidth = width;
+			}
+			const rawTruncated = state.cachedRawTruncated === true;
+			const skipped = state.cachedSkipped ?? 0;
+			if (!rawTruncated && skipped <= 0) return state.cachedLines ?? [];
+			const hintText = rawTruncated ? "... (earlier output hidden," : `... (${skipped} earlier lines,`;
+			const hint = `    ${theme.fg("muted", hintText)} ${expandHint()}${theme.fg("muted", ")")}`;
+			return [truncateToWidth(hint, width, "..."), ...(state.cachedLines ?? [])];
 		},
-		invalidate(): void {},
+		invalidate(): void {
+			state.cachedLines = undefined;
+			state.cachedSkipped = undefined;
+			state.cachedRawTruncated = undefined;
+			state.cachedWidth = undefined;
+		},
 	};
 }
 

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -124,12 +124,28 @@ export function registerCodexCommand(
 
 function getCommandConfigUpdate(arg: string, config: CodexConversionConfig): CodexConversionConfig | undefined {
 	if (arg === "fast") return { ...config, openai: { ...config.openai, fast: !config.openai.fast } };
-	if (arg === "all") return { ...config, scope: { ...config.scope, allProviders: !config.scope.allProviders } };
+	if (arg === "all") return { ...config, scope: { ...config.scope, allProviders: nextAllProvidersMode(config.scope.allProviders) } };
 	if (arg === "status") return { ...config, ui: { ...config.ui, statusLine: !config.ui.statusLine } };
 	const verbosity = normalizeCodexVerbosity(arg);
 	return verbosity ? { ...config, openai: { ...config.openai, verbosity } } : undefined;
 }
 
+function nextAllProvidersMode(value: CodexConversionConfig["scope"]["allProviders"]): CodexConversionConfig["scope"]["allProviders"] {
+	if (value === "off") return "on";
+	if (value === "on") return "extras";
+	return "off";
+}
+
+function formatAllProvidersMode(value: CodexConversionConfig["scope"]["allProviders"]): string {
+	return value === "extras" ? "only extras" : value;
+}
+
 function formatCodexSettings(config: CodexConversionConfig): string {
-	return `Codex settings: all models ${config.scope.allProviders ? "on" : "off"}, additional providers ${config.scope.additionalProviders.length > 0 ? config.scope.additionalProviders.join(", ") : "none"}, statusline ${config.ui.statusLine ? "on" : "off"}, tool rendering ${config.ui.toolRendering ? "on" : "off"}, background shells widget ${config.ui.backgroundShellWidget ? "on" : "off"}, image descriptions ${config.tools.viewImageFallback ? "on" : "off"}, fast ${config.openai.fast ? "on" : "off"}, cached websocket upgrade ${config.openai.forceCachedWebSockets === false ? "off" : "on"}, responses compaction ${(config.compaction.responsesCompaction ?? false) ? "on" : "off"} (${config.openai.compactionModel}/${config.openai.compactionReasoning}), verbosity ${config.openai.verbosity}`;
+	const extraTools = [
+		config.tools.applyPatchOnly ? "apply_patch" : undefined,
+		config.tools.viewImageOnly ? "view_image" : undefined,
+		config.tools.webRunOnly ? "web_run" : undefined,
+		config.tools.imageGenerationOnly ? "imagegen" : undefined,
+	].filter(Boolean).join(", ") || "off";
+	return `Codex settings: all models ${formatAllProvidersMode(config.scope.allProviders)}, additional providers ${config.scope.additionalProviders.length > 0 ? config.scope.additionalProviders.join(", ") : "none"}, statusline ${config.ui.statusLine ? "on" : "off"}, tool rendering ${config.ui.toolRendering ? "on" : "off"}, background shells widget ${config.ui.backgroundShellWidget ? "on" : "off"}, image descriptions ${config.tools.viewImageFallback ? "on" : "off"}, extra tools only ${extraTools}, fast ${config.openai.fast ? "on" : "off"}, cached websocket upgrade ${config.openai.forceCachedWebSockets === false ? "off" : "on"}, responses compaction ${(config.compaction.responsesCompaction ?? false) ? "on" : "off"} (${config.openai.compactionModel}/${config.openai.compactionReasoning}), verbosity ${config.openai.verbosity}`;
 }

--- a/packages/pi-codex-conversion/src/ui/settings/ui.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/ui.ts
@@ -226,6 +226,9 @@ function buildItems(tab: SettingsTab, draft: CodexConversionConfig, theme: Theme
 			{ id: "webRun", label: "Web search", currentValue: draft.tools.webRun ? "on" : "off", values: ["off", "on"] },
 			{ id: "imageGeneration", label: "Image generation", currentValue: draft.tools.imageGeneration ? "on" : "off", values: ["off", "on"] },
 			{ id: "applyPatchOnly", label: "Only add apply_patch", currentValue: draft.tools.applyPatchOnly ? "on" : "off", values: ["off", "on"] },
+			{ id: "viewImageOnly", label: "Only add view_image", currentValue: draft.tools.viewImageOnly ? "on" : "off", values: ["off", "on"] },
+			{ id: "webRunOnly", label: "Only add web_run", currentValue: draft.tools.webRunOnly ? "on" : "off", values: ["off", "on"] },
+			{ id: "imageGenerationOnly", label: "Only add imagegen", currentValue: draft.tools.imageGenerationOnly ? "on" : "off", values: ["off", "on"] },
 		];
 	}
 
@@ -242,7 +245,7 @@ function buildItems(tab: SettingsTab, draft: CodexConversionConfig, theme: Theme
 
 	return [
 		{ id: "mode", label: "PATH mode", currentValue: draft.mode === "path" ? "on" : "off", values: ["off", "on"] },
-		{ id: "allProviders", label: "Use for all providers/models", currentValue: draft.scope.allProviders ? "on" : "off", values: ["off", "on"] },
+		{ id: "allProviders", label: "Use for all providers/models", currentValue: formatAllProvidersMode(draft.scope.allProviders), values: ["off", "on", "only extras"] },
 		{
 			id: "additionalProviders",
 			label: "Additional providers",
@@ -259,7 +262,7 @@ function buildItems(tab: SettingsTab, draft: CodexConversionConfig, theme: Theme
 
 function applySettingChange(id: string, value: string, draft: CodexConversionConfig): CodexConversionConfig {
 	if (id === "mode") return { ...draft, mode: value === "on" ? "path" : "normal" };
-	if (id === "allProviders") return { ...draft, scope: { ...draft.scope, allProviders: value === "on" } };
+	if (id === "allProviders") return { ...draft, scope: { ...draft.scope, allProviders: parseAllProvidersMode(value) } };
 	if (id === "additionalProviders") return { ...draft, scope: { ...draft.scope, additionalProviders: normalizeProviderListFromText(value) } };
 	if (id === "statusLine") return { ...draft, ui: { ...draft.ui, statusLine: value === "on" } };
 	if (id === "toolRendering") return { ...draft, ui: { ...draft.ui, toolRendering: value === "on" } };
@@ -269,6 +272,9 @@ function applySettingChange(id: string, value: string, draft: CodexConversionCon
 	if (id === "imageGeneration") return { ...draft, tools: { ...draft.tools, imageGeneration: value === "on" } };
 	if (id === "viewImageFallback") return { ...draft, tools: { ...draft.tools, viewImageFallback: value === "on" } };
 	if (id === "applyPatchOnly") return { ...draft, tools: { ...draft.tools, applyPatchOnly: value === "on" } };
+	if (id === "viewImageOnly") return { ...draft, tools: { ...draft.tools, viewImageOnly: value === "on" } };
+	if (id === "webRunOnly") return { ...draft, tools: { ...draft.tools, webRunOnly: value === "on" } };
+	if (id === "imageGenerationOnly") return { ...draft, tools: { ...draft.tools, imageGenerationOnly: value === "on" } };
 	if (id === "fast") return { ...draft, openai: { ...draft.openai, fast: value === "on" } };
 	if (id === "forceCachedWebSockets") return { ...draft, openai: { ...draft.openai, forceCachedWebSockets: value === "on" } };
 	if (id === "webSearchModel") return { ...draft, openai: { ...draft.openai, webSearchModel: normalizeWebSearchModel(value) ?? DEFAULT_CODEX_CONVERSION_CONFIG.openai.webSearchModel } };
@@ -280,6 +286,14 @@ function applySettingChange(id: string, value: string, draft: CodexConversionCon
 
 function formatProviderList(providers: string[]): string {
 	return providers.join(", ");
+}
+
+function formatAllProvidersMode(value: CodexConversionConfig["scope"]["allProviders"]): string {
+	return value === "extras" ? "only extras" : value;
+}
+
+function parseAllProvidersMode(value: string): CodexConversionConfig["scope"]["allProviders"] {
+	return value === "only extras" ? "extras" : value === "on" ? "on" : "off";
 }
 
 function normalizeProviderListFromText(value: string): string[] {

--- a/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
+++ b/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
@@ -58,7 +58,7 @@ test("syncAdapter preserves unrelated tools across repeated syncs", () => {
 test("syncAdapter leaves PATH tools to shell for configured custom providers", () => {
 	const pi = createToolHarness(["read", "bash", "edit", "write", "parallel"]);
 	const ctx = createContext({ provider: "my-provider", api: "custom-responses", id: "gpt-5" });
-	const state = createAdapterState({ mode: "path", scope: { allProviders: false, additionalProviders: ["my-provider"] } });
+	const state = createAdapterState({ mode: "path", scope: { allProviders: "off", additionalProviders: ["my-provider"] } });
 
 	syncAdapter(pi as never, ctx as never, state);
 

--- a/packages/pi-codex-conversion/tests/config-migration.test.ts
+++ b/packages/pi-codex-conversion/tests/config-migration.test.ts
@@ -24,8 +24,8 @@ test("old flat config migrates to grouped config and respects disabled provider 
 	assert.equal(migration.migrated, true);
 	const config = normalizeCodexConversionConfig(migration.config);
 	assert.equal(config.mode, "normal");
-	assert.deepEqual(config.scope, { allProviders: true, additionalProviders: [] });
-	assert.deepEqual(config.tools, { webRun: false, imageGeneration: false, viewImageFallback: false, applyPatchOnly: true });
+	assert.deepEqual(config.scope, { allProviders: "on", additionalProviders: [] });
+	assert.deepEqual(config.tools, { webRun: false, imageGeneration: false, viewImageFallback: false, applyPatchOnly: true, viewImageOnly: false, webRunOnly: false, imageGenerationOnly: false });
 	assert.equal(config.ui.statusLine, false);
 	assert.equal(config.ui.toolRendering, true);
 	assert.equal(config.ui.backgroundShellWidget, false);


### PR DESCRIPTION
## Summary
- bound collapsed exec_command previews and cache them by width
- add per-tool extra overlays for apply_patch, view_image, web_run, and imagegen
- add an all-models only-extras mode that keeps Pi native tools

## Validation
- `bun run check:changed`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: auto-bumped by `bun run changeset:aggregates`

Closes #59