### PR TITLE
Scope Codex native compaction to Codex providers

### DIFF
--- a/.changeset/codex-compaction-scope.md
+++ b/.changeset/codex-compaction-scope.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep native Responses compaction scoped to OpenAI Codex and explicitly configured providers when the adapter is enabled for all models.

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -92,7 +92,7 @@ Settings are saved globally in `~/.pi/agent/pi-codex-conversion.json`.
 
 The settings UI has **General**, **Tools**, **OpenAI**, **Usage**, and **About** tabs. **Usage** refreshes automatically when opened, can be refreshed manually with `R`, and shows banked Codex rate-limit resets with their expiry above the usage windows. When resets are available, press `Ctrl+R` in the Usage tab to use one. After a reset attempt, press `R` before using another reset.
 
-**General** controls PATH mode, scope, status UI, background shells, and whether native Responses compaction is enabled. PATH mode switches the adapter to the shell-only surface above.
+**General** controls PATH mode, scope, status UI, background shells, and whether native Responses compaction is enabled. Native compaction applies to OpenAI Codex and explicitly added providers; all-model scope only changes the tool and prompt adapter. PATH mode switches the adapter to the shell-only surface above.
 
 Advanced users with custom Codex-compatible providers can add provider ids in General, or by editing `~/.pi/agent/pi-codex-conversion.json`:
 

--- a/packages/pi-codex-conversion/src/adapter/activation/activation.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/activation.ts
@@ -38,6 +38,11 @@ export function shouldUseCodexAdapter(ctx: ExtensionContext, config: CodexConver
 	return usesFullAdapterOnAllProviders(config) || isConfiguredAdapterProvider(ctx, config) || isCodexLikeContext(ctx);
 }
 
+export function shouldUseNativeResponsesCompaction(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
+	if (!config.compaction.responsesCompaction || shouldUseExtraToolsOnly(ctx, config)) return false;
+	return isOpenAICodexContext(ctx) || isConfiguredAdapterProvider(ctx, config);
+}
+
 export function isConfiguredAdapterProvider(ctx: ExtensionContext, config: CodexConversionConfig): boolean {
 	const provider = ctx.model?.provider?.trim().toLowerCase();
 	return Boolean(provider && config.scope.additionalProviders.includes(provider));
@@ -143,7 +148,7 @@ function getStatusConfig(ctx: ExtensionContext, config: CodexConversionConfig): 
 		fast: showOpenAICodexFlags && config.openai.fast,
 		webSearch: config.mode === "normal" && config.tools.webRun && (supportsNativeWebSearch(ctx.model) || useCodexBackedNativeTools),
 		imageGeneration: config.mode === "normal" && config.tools.imageGeneration && (supportsNativeImageGeneration(ctx.model) || useCodexBackedNativeTools),
-		compaction: { enabled: Boolean(config.compaction.responsesCompaction), model: config.openai.compactionModel, reasoning: config.openai.compactionReasoning },
+		compaction: { enabled: shouldUseNativeResponsesCompaction(ctx, config), model: config.openai.compactionModel, reasoning: config.openai.compactionReasoning },
 		...(showResponsesVerbosity ? { verbosity: config.openai.verbosity } : {}),
 	};
 }

--- a/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
@@ -16,7 +16,7 @@ import {
 } from "./serializer.ts";
 import { createNativeCompactionDetails, createNativeCompactionShimResult, isNativeCompactionDetails, NATIVE_COMPACTION_SHIM_SUMMARY, type NativeCompactionEntry } from "../compaction/types.ts";
 import { isResponsesContext } from "../prompt/codex-model.ts";
-import { isEffectiveOpenAICodexContext, shouldUseCodexAdapter } from "../activation/activation.ts";
+import { isEffectiveOpenAICodexContext, shouldUseNativeResponsesCompaction } from "../activation/activation.ts";
 import type { AdapterState } from "../activation/state.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -166,7 +166,7 @@ function getSupportedNativeCompactionProviders(state: AdapterState): string[] {
 }
 
 export async function handleCodexSessionBeforeCompact(event: SessionBeforeCompactEvent, ctx: ExtensionContext, state: AdapterState, pi: ExtensionAPI) {
-	if (!state.config.compaction.responsesCompaction || !shouldUseCodexAdapter(ctx, state.config)) {
+	if (!shouldUseNativeResponsesCompaction(ctx, state.config)) {
 		return undefined;
 	}
 
@@ -306,7 +306,7 @@ async function handleCodexSessionBeforeCompactInner(event: SessionBeforeCompactE
 }
 
 export async function rewriteCodexCompactedProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
-	if (!state.config.compaction.responsesCompaction || !shouldUseCodexAdapter(ctx, state.config) || (!isEffectiveOpenAICodexContext(ctx, state.config) && !isResponsesContext(ctx))) return undefined;
+	if (!shouldUseNativeResponsesCompaction(ctx, state.config) || (!isEffectiveOpenAICodexContext(ctx, state.config) && !isResponsesContext(ctx))) return undefined;
 	const resolution = await resolveNativeCompactionEnvironment(ctx, { enabled: true, supportedProviders: getSupportedNativeCompactionProviders(state) }, payload);
 	if (!resolution.ok) return undefined;
 	const runtime = resolution.runtime;

--- a/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
+++ b/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
-import { syncAdapter } from "../src/adapter/activation/activation.ts";
+import { shouldUseNativeResponsesCompaction, syncAdapter } from "../src/adapter/activation/activation.ts";
 import type { AdapterState } from "../src/adapter/activation/state.ts";
 import { mergeAdapterTools } from "../src/index.ts";
 
@@ -73,4 +73,18 @@ test("applyPatchOnly overlays only apply_patch without Codex toolkit rewrites", 
 	syncAdapter(pi as never, ctx as never, state);
 
 	assert.deepEqual(pi.activeTools(), ["read", "bash", "edit", "write", "parallel", "apply_patch"]);
+});
+
+test("all-model mode does not opt non-Codex models into native Responses compaction", () => {
+	const ctx = createContext({ provider: "openai", api: "openai-responses", id: "gpt-5" });
+	const state = createAdapterState({ scope: { allProviders: "on", additionalProviders: [] }, compaction: { responsesCompaction: true } });
+
+	assert.equal(shouldUseNativeResponsesCompaction(ctx as never, state.config), false);
+});
+
+test("native Responses compaction stays scoped to OpenAI Codex and explicit providers", () => {
+	const config = createAdapterState({ scope: { allProviders: "on", additionalProviders: ["my-provider"] }, compaction: { responsesCompaction: true } }).config;
+
+	assert.equal(shouldUseNativeResponsesCompaction(createContext({ provider: "openai-codex", api: "openai-codex-responses", id: "gpt-5" }) as never, config), true);
+	assert.equal(shouldUseNativeResponsesCompaction(createContext({ provider: "my-provider", api: "openai-codex-responses", id: "gpt-5" }) as never, config), true);
 });


### PR DESCRIPTION
## Summary
- keep native Responses compaction scoped to OpenAI Codex and explicitly configured providers
- stop all-model adapter mode from enabling native compaction/replay on unrelated Responses models
- document the scope and add activation coverage

## Validation
- `bun run check:changed`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: auto-bumped by `bun run changeset:aggregates`
