### PR TITLE
Fix Changesets release PR merging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
             exit 0
           fi
 
-          gh pr merge "$pr_number" --merge --auto
+          # PRs created with GITHUB_TOKEN do not trigger the normal PR checks.
+          # Auto-merge also requires a blocking branch rule, so merge this
+          # workflow-generated version PR directly once Changesets has created it.
+          gh pr merge "$pr_number" --merge
 
           for attempt in {1..40}; do
             state=$(gh pr view "$pr_number" --json state --jq '.state')


### PR DESCRIPTION
## Summary
- merge the workflow-generated Changesets version PR directly instead of requesting unavailable auto-merge
- preserve the existing merged-state poll and manual release dispatch before publishing

The release PR is created with `GITHUB_TOKEN`, so it receives no normal PR checks. GitHub auto-merge requires a blocking branch rule, which `main` does not have; this made release runs fail repeatedly before publishing.

## Validation
- inspected failed release runs `29056443258`, `28055161144`, and `26602656959`
- confirmed the generated version PR is mergeable with zero checks
- parsed `.github/workflows/release.yml`
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: no; workflow-only fix
