### PR TITLE
Update subagent defaults for GPT-5.6

### DIFF
--- a/.changeset/bright-moons-explore.md
+++ b/.changeset/bright-moons-explore.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-explore-subagents": patch
+---
+
+Uses GPT-5.6 Luna for shallow discovery and GPT-5.6 Terra for deep discovery by default.

--- a/.changeset/quiet-suns-review.md
+++ b/.changeset/quiet-suns-review.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subagent-review": patch
+---
+
+Uses GPT-5.6 Sol for reviews and GPT-5.6 Luna for conversation summaries by default.

--- a/.changeset/warm-stars-btw.md
+++ b/.changeset/warm-stars-btw.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-smart-btw": patch
+---
+
+Uses GPT-5.6 Luna for side-session questions by default.

--- a/packages/pi-explore-subagents/README.md
+++ b/packages/pi-explore-subagents/README.md
@@ -57,12 +57,12 @@ On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with s
 ```json
 {
   "shallow": {
-    "model": "openai-codex/gpt-5.3-codex-spark",
+    "model": "openai-codex/gpt-5.6-luna",
     "thinking": "low"
   },
   "deep": {
-    "model": "openai-codex/gpt-5.4-mini",
-    "thinking": "medium"
+    "model": "openai-codex/gpt-5.6-terra",
+    "thinking": "low"
   }
 }
 ```

--- a/packages/pi-explore-subagents/config.json
+++ b/packages/pi-explore-subagents/config.json
@@ -1,10 +1,10 @@
 {
 	"shallow": {
-		"model": "openai-codex/gpt-5.3-codex-spark",
+		"model": "openai-codex/gpt-5.6-luna",
 		"thinking": "low"
 	},
 	"deep": {
-		"model": "openai-codex/gpt-5.4-mini",
-		"thinking": "medium"
+		"model": "openai-codex/gpt-5.6-terra",
+		"thinking": "low"
 	}
 }

--- a/packages/pi-explore-subagents/src/constants.ts
+++ b/packages/pi-explore-subagents/src/constants.ts
@@ -19,12 +19,12 @@ export const DEEP_PROMPT_PATH = path.join(ROOT_DIR, "deep.prompt.md");
 
 export const DEFAULT_CONFIG: Record<ExploreMode, Required<ExploreConfig>> = {
 	shallow: {
-		model: "openai-codex/gpt-5.3-codex-spark",
+		model: "openai-codex/gpt-5.6-luna",
 		thinking: "low",
 	},
 	deep: {
-		model: "openai-codex/gpt-5.4-mini",
-		thinking: "medium",
+		model: "openai-codex/gpt-5.6-terra",
+		thinking: "low",
 	},
 };
 

--- a/packages/pi-smart-btw/README.md
+++ b/packages/pi-smart-btw/README.md
@@ -49,7 +49,7 @@ In **General**: **Edit shortcuts** opens `~/.pi/agent/pi-smart-btw.json` in `$VI
 ```json
 {
   "provider": "openai-codex",
-  "modelId": "gpt-5.4-mini",
+  "modelId": "gpt-5.6-luna",
   "command": "pi",
   "thinking": "low",
   "injectShortcut": "alt+c",

--- a/packages/pi-smart-btw/src/config.ts
+++ b/packages/pi-smart-btw/src/config.ts
@@ -27,7 +27,7 @@ export function normalizeThinkingLevel(
 
 const DEFAULT_CONFIG: ResolvedBtwConfig = {
 	provider: "openai-codex",
-	modelId: "gpt-5.4-mini",
+	modelId: "gpt-5.6-luna",
 	command: "pi",
 	thinking: "low",
 	composeShortcut: DEFAULT_SHORTCUTS.compose,

--- a/packages/pi-smart-btw/src/settings/models.ts
+++ b/packages/pi-smart-btw/src/settings/models.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { splitModelRef } from "../config.js";
 
-const FALLBACK_REF = "openai-codex/gpt-5.4-mini";
+const FALLBACK_REF = "openai-codex/gpt-5.6-luna";
 
 export function modelRef(provider: string, modelId: string) {
 	return `${provider}/${modelId}`;

--- a/packages/pi-subagent-review/README.md
+++ b/packages/pi-subagent-review/README.md
@@ -75,11 +75,11 @@ Edit that file to change the default review model or thinking level, and the mod
 
 ```json
 {
-  "model": "openai-codex/gpt-5.5",
+  "model": "openai-codex/gpt-5.6-sol",
   "thinking": "medium",
   "summary": {
     "enabled": true,
-    "model": "openai/gpt-5.4-mini",
+    "model": "openai-codex/gpt-5.6-luna",
     "thinking": "low"
   }
 }

--- a/packages/pi-subagent-review/src/constants.ts
+++ b/packages/pi-subagent-review/src/constants.ts
@@ -14,11 +14,11 @@ export const REVIEW_PROMPT_PATH = path.join(
 );
 
 export const DEFAULT_CONFIG = {
-	model: "openai-codex/gpt-5.5",
+	model: "openai-codex/gpt-5.6-sol",
 	thinking: "medium",
 	summary: {
 		enabled: true,
-		model: "openai/gpt-5.4-mini",
+		model: "openai-codex/gpt-5.6-luna",
 		thinking: "low",
 	},
 } as const;


### PR DESCRIPTION
## Summary
- use GPT-5.6 Luna at low thinking for shallow explore subagents and Smart BTW side sessions
- use GPT-5.6 Terra at low thinking for deep explore subagents
- use GPT-5.6 Sol at medium thinking for reviews and GPT-5.6 Luna at low thinking for review context summaries
- update package defaults, fallback values, and user-facing configuration examples

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- dry-packed all three changed packages
- verified all selected models are available through Pi 0.80.6's `openai-codex` provider

## Release
- Changeset: yes
- Packages: `@howaboua/pi-explore-subagents`, `@howaboua/pi-smart-btw`, `@howaboua/pi-subagent-review`
- Aggregates: generated by release automation
