### PR TITLE
Fix empty dynamic tool registration

### DIFF
--- a/.changeset/tidy-tools-appear.md
+++ b/.changeset/tidy-tools-appear.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-dynamic-tools": patch
+---
+
+Always register `exec` and `wait`, rediscover TOML definitions during live sessions, and avoid duplicate registration when loaded directly and through an aggregate package.

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -13,7 +13,7 @@ tools.<filename>(input string)
   → string result
 ```
 
-Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured). Companion scripts may live in subdirectories. Pi reads definitions when it starts or reloads.
+Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured). Companion scripts may live in subdirectories. Pi rediscovers definitions before every `exec`; already-running cells keep the definitions they started with.
 
 The JavaScript cell is isolated V8 with no direct filesystem, network, or Node access. The delegated command is not sandboxed by code mode: it runs locally with the user's permissions, Pi's working directory, and inherited environment.
 
@@ -37,7 +37,7 @@ Build a Pi extension when the capability needs lifecycle events, custom TUI, Pi 
 3. Create or update only the relevant TOML and companion files.
 4. Keep the tool deferred unless the user explicitly wants it named in every system prompt.
 5. Validate the command independently when practical.
-6. Tell the user that Pi must reload before the changed definition is available. Do not send slash commands as agent tool calls.
+6. The changed catalog is available on the next `exec`. Do not send slash commands as agent tool calls.
 
 Minimal definition:
 
@@ -93,7 +93,7 @@ Deferred is the cache-safe default:
 command = "rare-tool"
 ```
 
-A deferred tool remains callable but its name and help do not enter the system prompt or provider tool schema. Its metadata stays local in `ALL_TOOLS` until requested. Once at least one definition has activated the outer `exec` and `wait` tools, adding, removing, or editing deferred definitions does not change that stable provider contract.
+A deferred tool remains callable but its name and help do not enter the system prompt or provider tool schema. Its metadata stays local in `ALL_TOOLS` until requested. The outer `exec` and `wait` tools are always registered, even with an empty catalog, so adding, removing, or editing deferred definitions during a session does not change that stable provider contract.
 
 Inspect only the metadata needed:
 

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -29,7 +29,7 @@ The filename becomes the JavaScript method name, so use letters, numbers, `_`, o
 
 Bare command names resolve through `PATH`. Relative command paths resolve from the TOML file's directory.
 
-Run `/reload` or restart Pi after adding, changing, or removing definitions.
+Definitions are rediscovered before every `exec`, so deferred tools can be added, changed, or removed during a session. Promoted tools enter the system prompt on the next agent turn.
 
 The extension adds the resolved bundled `DYNAMIC-TOOLS.md` path to the system prompt. Agents read that file only when asked to configure or explain dynamic tools.
 

--- a/packages/pi-dynamic-tools/index.ts
+++ b/packages/pi-dynamic-tools/index.ts
@@ -2,9 +2,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerDynamicTools } from "./src/tools.js";
 
 export default async function (pi: ExtensionAPI) {
-	let runtime = await registerDynamicTools(pi);
+	const runtime = await registerDynamicTools(pi);
 	pi.on("session_shutdown", async () => {
-		await runtime?.shutdown();
-		runtime = undefined;
+		await runtime.shutdown();
 	});
 }

--- a/packages/pi-dynamic-tools/src/host-client.ts
+++ b/packages/pi-dynamic-tools/src/host-client.ts
@@ -15,6 +15,7 @@ type Pending = {
 	resolve: (value: any) => void;
 	reject: (error: Error) => void;
 	context?: ToolExecutionContext | undefined;
+	tools?: Map<string, DynamicToolDefinition> | undefined;
 };
 
 type HostClientOptions = {
@@ -33,6 +34,7 @@ export class CodeModeHostClient {
 	private pending = new Map<number, Pending>();
 	private initial = new Map<number, Pending>();
 	private cellContexts = new Map<string, ToolExecutionContext>();
+	private cellTools = new Map<string, Map<string, DynamicToolDefinition>>();
 	private delegates = new Map<number, AbortController>();
 	private notifications = new Map<string, string[]>();
 	private stderr = "";
@@ -83,6 +85,7 @@ export class CodeModeHostClient {
 		source: string,
 		context: ToolExecutionContext,
 		signal?: AbortSignal,
+		tools: DynamicToolDefinition[] = [...this.tools.values()],
 	): Promise<RuntimeResponse> {
 		await this.start();
 		const { code, yieldTimeMs, maxOutputTokens } = parseExecSource(source);
@@ -90,6 +93,7 @@ export class CodeModeHostClient {
 		const initial = new Promise<any>((resolve, reject) =>
 			this.initial.set(id, { resolve, reject }),
 		);
+		const toolSet = new Map(tools.map((tool) => [tool.name, tool]));
 		const started = this.requestWithId(
 			id,
 			{
@@ -97,13 +101,14 @@ export class CodeModeHostClient {
 				sessionId: this.sessionId,
 				request: {
 					tool_call_id: `exec-${id}`,
-					enabled_tools: [...this.tools.values()].map(toWireToolDefinition),
+					enabled_tools: tools.map(toWireToolDefinition),
 					source: code,
 					yield_time_ms: yieldTimeMs,
 					max_output_tokens: maxOutputTokens,
 				},
 			},
 			context,
+			toolSet,
 		);
 		const abort = () => {
 			this.send({ type: "operation/cancel", id });
@@ -194,9 +199,10 @@ export class CodeModeHostClient {
 		id: number,
 		request: Record<string, unknown>,
 		context?: ToolExecutionContext,
+		tools?: Map<string, DynamicToolDefinition>,
 	): Promise<any> {
 		return new Promise((resolve, reject) => {
-			this.pending.set(id, { resolve, reject, context });
+			this.pending.set(id, { resolve, reject, context, tools });
 			this.send({ type: "operation/request", id, request });
 		});
 	}
@@ -256,8 +262,10 @@ export class CodeModeHostClient {
 			if (message.result?.status === "error")
 				return pending.reject(new Error(message.result.message));
 			const value = message.result?.value;
-			if (value?.type === "execution/started" && pending.context)
+			if (value?.type === "execution/started" && pending.context) {
 				this.cellContexts.set(value.cellId, pending.context);
+				if (pending.tools) this.cellTools.set(value.cellId, pending.tools);
+			}
 			pending.resolve(value);
 			return;
 		}
@@ -280,6 +288,7 @@ export class CodeModeHostClient {
 		}
 		if (message.type === "cell/closed") {
 			this.cellContexts.delete(message.cellId);
+			this.cellTools.delete(message.cellId);
 		}
 	}
 
@@ -313,7 +322,9 @@ export class CodeModeHostClient {
 			return;
 		}
 		const invocation = request.invocation;
-		const tool = this.tools.get(invocation?.tool_name?.name);
+		const tool = this.cellTools
+			.get(invocation?.cell_id)
+			?.get(invocation?.tool_name?.name);
 		const context = this.cellContexts.get(invocation?.cell_id);
 		if (!tool || !context) {
 			this.send({

--- a/packages/pi-dynamic-tools/src/tools.ts
+++ b/packages/pi-dynamic-tools/src/tools.ts
@@ -21,28 +21,43 @@ import type { RuntimeContentItem, RuntimeResponse } from "./types.js";
 
 const DEFAULT_WAIT_MS = 10_000;
 const DEFAULT_MAX_TOKENS = 10_000;
+const REGISTRATION_KEY = Symbol.for("@howaboua/pi-dynamic-tools.registered");
+const NOOP_RUNTIME = { async shutdown() {} };
 
 export async function registerDynamicTools(
 	pi: ExtensionAPI,
-): Promise<{ shutdown(): Promise<void> } | undefined> {
-	const toolsDir = getDynamicToolsDir();
+	toolsDir: string = getDynamicToolsDir(),
+): Promise<{ shutdown(): Promise<void> }> {
+	const sharedState = pi.events as typeof pi.events & {
+		[REGISTRATION_KEY]?: object;
+	};
+	if (sharedState[REGISTRATION_KEY]) return NOOP_RUNTIME;
+	const owner = {};
 	const documentationPath = fileURLToPath(
 		new URL("../DYNAMIC-TOOLS.md", import.meta.url),
 	);
-	const tools = discoverDynamicTools(toolsDir);
 	pi.on("before_agent_start", (event) => {
 		const systemPrompt = injectDynamicToolsPrompt(
 			event.systemPrompt,
-			tools,
+			discoverDynamicTools(toolsDir),
 			documentationPath,
 		);
 		return systemPrompt === event.systemPrompt ? undefined : { systemPrompt };
 	});
-	if (tools.length === 0) return undefined;
-	const client = new CodeModeHostClient({
-		binary: await ensureCodeModeHostBinary(),
-		tools,
-	});
+	sharedState[REGISTRATION_KEY] = owner;
+	let clientPromise: Promise<CodeModeHostClient> | undefined;
+	const getClient = async () => {
+		if (!clientPromise) {
+			const pending = ensureCodeModeHostBinary().then(
+				(binary) => new CodeModeHostClient({ binary, tools: [] }),
+			);
+			clientPromise = pending;
+			void pending.catch(() => {
+				if (clientPromise === pending) clientPromise = undefined;
+			});
+		}
+		return clientPromise;
+	};
 	const renderTracker = createCodeModeRenderTracker();
 	const renderResult = (
 		result: Parameters<typeof renderTrackedCodeModeResult>[0],
@@ -64,10 +79,13 @@ export async function registerDynamicTools(
 		async execute(id, params, signal, onUpdate, ctx) {
 			renderTracker.start(id);
 			try {
+				const tools = discoverDynamicTools(toolsDir);
+				const client = await getClient();
 				const response = await client.execute(
 					params.code,
 					{ cwd: ctx.cwd, onUpdate },
 					signal,
+					tools,
 				);
 				renderTracker.finish(
 					id,
@@ -112,6 +130,7 @@ export async function registerDynamicTools(
 		async execute(id, params, signal, onUpdate, ctx) {
 			renderTracker.start(id);
 			try {
+				const client = await getClient();
 				const response = params.terminate
 					? await client.terminate(params.cell_id)
 					: await client.wait(
@@ -137,7 +156,20 @@ export async function registerDynamicTools(
 		) => renderWaitCall(args, theme, context, renderTracker)) as any,
 		renderResult: renderResult as any,
 	});
-	return { shutdown: () => client.shutdown() };
+	return {
+		async shutdown() {
+			if (sharedState[REGISTRATION_KEY] === owner)
+				delete sharedState[REGISTRATION_KEY];
+			const pending = clientPromise;
+			clientPromise = undefined;
+			if (!pending) return;
+			try {
+				await (await pending).shutdown();
+			} catch {
+				// Startup failure already reached the caller.
+			}
+		},
+	};
 }
 
 function toToolResult(response: RuntimeResponse, maxTokens?: number) {

--- a/packages/pi-dynamic-tools/tests/host-client.test.ts
+++ b/packages/pi-dynamic-tools/tests/host-client.test.ts
@@ -61,6 +61,29 @@ describe("Codex code-mode host", () => {
 		]);
 	});
 
+	test("accepts tools discovered after the host starts", async () => {
+		const host = client();
+		await host.execute(`text(ALL_TOOLS.length);`, { cwd: process.cwd() });
+		const lateTool: DynamicToolDefinition = {
+			name: "late_tool",
+			description: "Added during the session.",
+			deferLoading: true,
+			command: process.execPath,
+			args: ["-e", "process.stdout.write(process.argv[1])"],
+			input: "arg",
+			sourcePath: "late_tool.toml",
+		};
+		const response = await host.execute(
+			`const value = await tools.late_tool("available"); text(value);`,
+			{ cwd: process.cwd() },
+			undefined,
+			[lateTool],
+		);
+		expect(response.contentItems).toEqual([
+			{ type: "input_text", text: "available" },
+		]);
+	});
+
 	test("shares store values between exec cells", async () => {
 		const host = client();
 		await host.execute(`store("answer", 42);`, { cwd: process.cwd() });

--- a/packages/pi-dynamic-tools/tests/tools.test.ts
+++ b/packages/pi-dynamic-tools/tests/tools.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerDynamicTools } from "../src/tools.js";
+
+const dirs: string[] = [];
+afterEach(() => {
+	for (const dir of dirs.splice(0))
+		rmSync(dir, { recursive: true, force: true });
+});
+
+function fakePi(events: object = {}) {
+	const tools: string[] = [];
+	const handlers = new Map<string, (event: any) => any>();
+	return {
+		api: {
+			events,
+			registerTool(tool: { name: string }) {
+				tools.push(tool.name);
+			},
+			on(event: string, handler: (value: any) => any) {
+				handlers.set(event, handler);
+			},
+		},
+		tools,
+		handlers,
+	};
+}
+
+function emptyToolsDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-tools-"));
+	dirs.push(dir);
+	return dir;
+}
+
+describe("dynamic tool registration", () => {
+	test("registers exec and wait with an empty catalog", async () => {
+		const fake = fakePi();
+		await registerDynamicTools(fake.api as never, emptyToolsDir());
+		expect(fake.tools).toEqual(["exec", "wait"]);
+	});
+
+	test("does not register twice through direct and aggregate packages", async () => {
+		const events = {};
+		const direct = fakePi(events);
+		const aggregate = fakePi(events);
+		const dir = emptyToolsDir();
+		const runtime = await registerDynamicTools(direct.api as never, dir);
+		await registerDynamicTools(aggregate.api as never, dir);
+		expect(direct.tools).toEqual(["exec", "wait"]);
+		expect(aggregate.tools).toEqual([]);
+
+		await runtime.shutdown();
+		await registerDynamicTools(aggregate.api as never, dir);
+		expect(aggregate.tools).toEqual(["exec", "wait"]);
+	});
+
+	test("rediscovers promoted tools before each agent turn", async () => {
+		const fake = fakePi();
+		const dir = emptyToolsDir();
+		await registerDynamicTools(fake.api as never, dir);
+		const handler = fake.handlers.get("before_agent_start");
+		expect(handler).toBeDefined();
+		const first = handler!({ systemPrompt: "Base" });
+		expect(first.systemPrompt).not.toContain("late_tool");
+		writeFileSync(
+			join(dir, "late_tool.toml"),
+			'defer_loading = false\ncommand = "late-tool"\n',
+		);
+		const second = handler!({ systemPrompt: "Base" });
+		expect(second.systemPrompt).toContain("await tools.late_tool(input)");
+	});
+});


### PR DESCRIPTION
## Summary
- always register `exec` and `wait`, including with an empty TOML catalog
- rediscover definitions before each `exec` while preserving running-cell snapshots
- prevent duplicate registration when dynamic tools load directly and through an aggregate package
- keep host startup lazy and update the bundled documentation

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- 32 package tests pass

## Release
- Changeset: yes
- Packages: `@howaboua/pi-dynamic-tools`
- Aggregates: generated by release automation; existing aggregate membership is unchanged
