### PR TITLE
Add dynamic tool usage contracts

### DIFF
--- a/.changeset/bright-tools-speak.md
+++ b/.changeset/bright-tools-speak.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-dynamic-tools": patch
 ---
 
-Add concise usage contracts for promoted and deferred dynamic tools.
+Require concise usage contracts for promoted and deferred dynamic tools.

--- a/.changeset/bright-tools-speak.md
+++ b/.changeset/bright-tools-speak.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-dynamic-tools": patch
+---
+
+Add concise usage contracts for promoted and deferred dynamic tools.

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -19,7 +19,7 @@ The JavaScript cell is isolated V8 with no direct filesystem, network, or Node a
 
 ## Dynamic tool or Pi extension?
 
-Consider a dynamic tool first when the capability is command-backed, tool-shaped, and useful only occasionally. Deferred tools add no tool-specific system-prompt or provider-schema cost. A stable promoted tool adds only its terse invocation form rather than a full provider-visible JSON schema.
+Consider a dynamic tool first when the capability is command-backed, tool-shaped, and useful only occasionally. Deferred tools add no tool-specific system-prompt or provider-schema cost. A stable promoted tool adds only its name and usage rather than a full provider-visible JSON schema.
 
 Use a dynamic tool when:
 
@@ -50,7 +50,7 @@ A complex tool still receives one string. Encode structured input as JSON and va
 
 ```toml
 # inspect_repo.toml
-description = 'Inspect a repository. Input JSON fields: query (string) and optional cwd (string).'
+usage = 'await tools.inspect_repo(JSON.stringify({ query: string, cwd?: string }))'
 command = "./inspect-repo/inspect-repo.mjs"
 input = "stdin"
 ```
@@ -72,7 +72,8 @@ text(result);
 - `command`: executable name or path.
 - `args`: fixed string arguments placed before the model-provided input. Defaults to `[]`.
 - `input`: `"arg"` appends the input as the final argument; `"stdin"` writes it to standard input. Defaults to `"arg"`.
-- `description`: discovery help. State the action and any input contract the caller must know.
+- `usage`: exact JavaScript invocation contract, without Markdown formatting. For structured input, show the object passed to `JSON.stringify`.
+- `description`: optional discovery help not already clear from the name and usage.
 - `output`: optional discovery help about a reliable result contract. It does not control, validate, or transform command output. Omit it when the result is free-form.
 - `defer_loading`: defaults to `true`. Set to `false` only when the user wants the tool named in the system prompt.
 
@@ -108,7 +109,7 @@ defer_loading = false
 command = "common-tool"
 ```
 
-Promotion adds a terse `await tools.<name>(input)` form to the system prompt. Changing the promoted set or names changes that prompt and can invalidate its cache. Descriptions and `output` help remain available through `ALL_TOOLS` rather than being copied into the system prompt.
+Promotion adds the tool name and `usage` to the system prompt. If `usage` is omitted, it falls back to `await tools.<name>(input)`. Changing the promoted set, names, or usage changes that prompt and can invalidate its cache. Descriptions and `output` help remain available through `ALL_TOOLS` rather than being copied into the system prompt.
 
 ## Execution and failures
 

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -39,27 +39,29 @@ Build a Pi extension when the capability needs lifecycle events, custom TUI, Pi 
 5. Validate the command independently when practical.
 6. The changed catalog is available on the next `exec`. Do not send slash commands as agent tool calls.
 
-Minimal definition:
+The bundled `port_info` definition shows the required invocation contract and optional discovery detail:
 
 ```toml
-# repo_snapshot.toml
-command = "repo-snapshot"
+usage = 'await tools.port_info(port_number)'
+description = "Returns normalized JSON with listeners, connections, owning processes, parent processes, and service or container attribution when available."
+command = "./port-info/port-info.mjs"
 ```
 
-A complex tool still receives one string. Encode structured input as JSON and validate it in the CLI:
+A structured tool still receives one string. The bundled `spawn_agent` example encodes its input as JSON and validates it in the CLI:
 
 ```toml
-# inspect_repo.toml
-usage = 'await tools.inspect_repo(JSON.stringify({ query: string, cwd?: string }))'
-command = "./inspect-repo/inspect-repo.mjs"
+usage = '''await tools.spawn_agent(JSON.stringify({ agent_type: "explorer" | "reviewer", message: string, cwd?: string }))'''
+description = "Relative cwd resolves from Pi's working directory."
+command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
 ```
 
 The model calls it with:
 
 ```js
-const result = await tools.inspect_repo(JSON.stringify({
-  query: "Find the authentication entry points",
+const result = await tools.spawn_agent(JSON.stringify({
+  agent_type: "explorer",
+  message: "Find the authentication entry points and cite the relevant files.",
   cwd: "../another-repo",
 }));
 text(result);
@@ -67,12 +69,12 @@ text(result);
 
 ## TOML fields
 
-`command` is required. These fields are accepted; unknown fields, invalid TOML, and invalid filename identifiers prevent the extension from loading its tool catalog until corrected.
+`usage` and `command` are required. Unknown fields, invalid TOML, missing contracts, and invalid filename identifiers prevent the extension from loading its tool catalog until corrected.
 
 - `command`: executable name or path.
 - `args`: fixed string arguments placed before the model-provided input. Defaults to `[]`.
 - `input`: `"arg"` appends the input as the final argument; `"stdin"` writes it to standard input. Defaults to `"arg"`.
-- `usage`: exact JavaScript invocation contract, without Markdown formatting. For structured input, show the object passed to `JSON.stringify`.
+- `usage`: required exact JavaScript invocation contract, without Markdown formatting. For structured input, show the object passed to `JSON.stringify`.
 - `description`: optional discovery help not already clear from the name and usage.
 - `output`: optional discovery help about a reliable result contract. It does not control, validate, or transform command output. Omit it when the result is free-form.
 - `defer_loading`: defaults to `true`. Set to `false` only when the user wants the tool named in the system prompt.
@@ -91,7 +93,8 @@ Command resolution:
 Deferred is the cache-safe default:
 
 ```toml
-command = "rare-tool"
+usage = 'await tools.port_info(port_number)'
+command = "./port-info/port-info.mjs"
 ```
 
 A deferred tool remains callable but its name and help do not enter the system prompt or provider tool schema. Its metadata stays local in `ALL_TOOLS` until requested. The outer `exec` and `wait` tools are always registered, even with an empty catalog, so adding, removing, or editing deferred definitions during a session does not change that stable provider contract.
@@ -99,17 +102,18 @@ A deferred tool remains callable but its name and help do not enter the system p
 Inspect only the metadata needed:
 
 ```js
-text(ALL_TOOLS.find(({ name }) => name === "rare_tool"));
+text(ALL_TOOLS.find(({ name }) => name === "port_info"));
 ```
 
 Promote a stable, frequently used tool only by explicit choice:
 
 ```toml
 defer_loading = false
-command = "common-tool"
+usage = 'await tools.port_info(port_number)'
+command = "./port-info/port-info.mjs"
 ```
 
-Promotion adds the tool name and `usage` to the system prompt. If `usage` is omitted, it falls back to `await tools.<name>(input)`. Changing the promoted set, names, or usage changes that prompt and can invalidate its cache. Descriptions and `output` help remain available through `ALL_TOOLS` rather than being copied into the system prompt.
+Promotion adds the tool name and `usage` to the system prompt. Changing the promoted set, names, or usage changes that prompt and can invalidate its cache. Descriptions and `output` help remain available through `ALL_TOOLS` rather than being copied into the system prompt.
 
 ## Execution and failures
 

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -12,15 +12,16 @@ The first startup with at least one definition downloads OpenAI Codex's code-mod
 
 ## Define a tool
 
-Create `~/.pi/agent/dynamic-tools/summarize.toml`:
+Each definition must state the exact invocation contract. The bundled `spawn_agent` example uses:
 
 ```toml
-usage = "await tools.summarize(text)"
-command = "summary-cli"
+usage = '''await tools.spawn_agent(JSON.stringify({ agent_type: "explorer" | "reviewer", message: string, cwd?: string }))'''
+description = "Relative cwd resolves from Pi's working directory."
+command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
 ```
 
-The filename becomes the JavaScript method name, so use letters, numbers, `_`, or `$`. `usage` records the exact invocation contract. `description` and `output` are optional on-demand help text; `output` documents a reliable contract but does not control the command's result. Tools are deferred by default; set `defer_loading = false` to add a commonly used tool's name and usage to the system prompt. Full help remains local until requested through `ALL_TOOLS`.
+The filename becomes the JavaScript method name, so use letters, numbers, `_`, or `$`. `usage` is required; the agent should never need to guess the input. `description` and `output` are optional on-demand help text for details not already clear from the name and usage. `output` documents a reliable contract but does not control the command's result. Tools are deferred by default; set `defer_loading = false` to add a commonly used tool's name and usage to the system prompt. Full help remains local until requested through `ALL_TOOLS`.
 
 `input` can be:
 
@@ -47,24 +48,20 @@ Tools are discovered on demand without changing the stable `exec` schema:
 
 ```js
 text(ALL_TOOLS.map(({ name }) => name));
-text(ALL_TOOLS.find(({ name }) => name === "summarize"));
+text(ALL_TOOLS.find(({ name }) => name === "spawn_agent"));
 ```
 
-With the definition above, `exec` exposes:
+With both bundled examples enabled, `exec` can compose unrelated system and agent work without intermediate model turns:
 
 ```js
-const result = await tools.summarize("Long text to summarize...");
-text(result);
-```
-
-Multiple tools can be composed without returning intermediate output to the model:
-
-```js
-const [auth, config] = await Promise.all([
-  tools.summarize("Long authentication report..."),
-  tools.summarize("Long configuration report..."),
+const [port, review] = await Promise.all([
+  tools.port_info("3000"),
+  tools.spawn_agent(JSON.stringify({
+    agent_type: "reviewer",
+    message: "Review the current branch.",
+  })),
 ]);
-text({ auth, config });
+text({ port, review });
 ```
 
 The runtime is OpenAI Codex's isolated V8 code-mode host. It provides `text`, `image`, `store`, `load`, `notify`, `yield_control`, timers, resumable cells, and the companion `wait` tool. It does not expose Node, filesystem, network, or console APIs to JavaScript.

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -15,12 +15,12 @@ The first startup with at least one definition downloads OpenAI Codex's code-mod
 Create `~/.pi/agent/dynamic-tools/summarize.toml`:
 
 ```toml
-description = "Summarize text."
+usage = "await tools.summarize(text)"
 command = "summary-cli"
 input = "stdin"
 ```
 
-The filename becomes the JavaScript method name, so use letters, numbers, `_`, or `$`. `description` and `output` are optional on-demand help text; `output` documents a reliable contract but does not control the command's result. Tools are deferred by default; set `defer_loading = false` to add a commonly used tool's terse invocation form to the system prompt. Full help remains local until requested through `ALL_TOOLS`.
+The filename becomes the JavaScript method name, so use letters, numbers, `_`, or `$`. `usage` records the exact invocation contract. `description` and `output` are optional on-demand help text; `output` documents a reliable contract but does not control the command's result. Tools are deferred by default; set `defer_loading = false` to add a commonly used tool's name and usage to the system prompt. Full help remains local until requested through `ALL_TOOLS`.
 
 `input` can be:
 

--- a/packages/pi-dynamic-tools/examples/port_info.toml
+++ b/packages/pi-dynamic-tools/examples/port_info.toml
@@ -1,2 +1,3 @@
-description = "Inspect a local TCP or UDP port. Input: port number. Returns normalized JSON with listeners, connections, owning processes, parent processes, and service or container attribution when available."
+usage = 'await tools.port_info(port_number)'
+description = "Returns normalized JSON with listeners, connections, owning processes, parent processes, and service or container attribution when available."
 command = "./port-info/port-info.mjs"

--- a/packages/pi-dynamic-tools/examples/spawn_agent.toml
+++ b/packages/pi-dynamic-tools/examples/spawn_agent.toml
@@ -1,3 +1,4 @@
-description = """Spawn an isolated explorer or reviewer. Input JSON fields: agent_type ("explorer" or "reviewer"), message (string), and optional cwd (string). Relative cwd resolves from Pi's working directory."""
+usage = '''await tools.spawn_agent(JSON.stringify({ agent_type: "explorer" | "reviewer", message: string, cwd?: string }))'''
+description = "Relative cwd resolves from Pi's working directory."
 command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -86,7 +86,7 @@ export function parseDynamicTool(
 		isAbsolute(resolvedCommand) && NODE_SCRIPT_PATTERN.test(resolvedCommand);
 	return {
 		name,
-		usage: optionalString(value["usage"], "usage", path),
+		usage: requiredString(value["usage"], "usage", path),
 		description: optionalString(value["description"], "description", path),
 		output: optionalString(value["output"], "output", path),
 		deferLoading: deferLoading(value["defer_loading"], path),

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -64,6 +64,7 @@ export function parseDynamicTool(
 		);
 	const value = parse(text) as Record<string, unknown>;
 	const known = new Set([
+		"usage",
 		"description",
 		"output",
 		"defer_loading",
@@ -85,6 +86,7 @@ export function parseDynamicTool(
 		isAbsolute(resolvedCommand) && NODE_SCRIPT_PATTERN.test(resolvedCommand);
 	return {
 		name,
+		usage: optionalString(value["usage"], "usage", path),
 		description: optionalString(value["description"], "description", path),
 		output: optionalString(value["output"], "output", path),
 		deferLoading: deferLoading(value["defer_loading"], path),

--- a/packages/pi-dynamic-tools/src/prompt.ts
+++ b/packages/pi-dynamic-tools/src/prompt.ts
@@ -17,13 +17,17 @@ All dynamic tools remain callable on \`tools\`. When a needed tool is unknown, s
 export const WAIT_DESCRIPTION =
 	"Wait for new output or terminate a yielded exec cell. Returns only output since the previous yield; call wait again if still running.";
 
-const PROMOTED_TOOLS_HEADING = "Dynamic tools available in `exec`:";
+const PROMOTED_TOOLS_HEADING = "Dynamic tools available in exec:";
 const DOCUMENTATION_PREFIX = "Dynamic tools documentation: read ";
 const DYNAMIC_TOOLS_GUIDANCE =
 	"Prefer a dynamic tool over a Pi extension for a command-backed capability.";
 
 export function formatDynamicToolHelp(tool: DynamicToolDefinition): string {
-	return [tool.description, tool.output ? `Output: ${tool.output}` : undefined]
+	return [
+		tool.usage ? `Usage: ${tool.usage}` : undefined,
+		tool.description,
+		tool.output ? `Output: ${tool.output}` : undefined,
+	]
 		.filter(Boolean)
 		.join("\n");
 }
@@ -31,18 +35,22 @@ export function formatDynamicToolHelp(tool: DynamicToolDefinition): string {
 export function buildPromotedToolsPrompt(
 	tools: DynamicToolDefinition[],
 ): string {
-	const names = tools
+	const promoted = tools
 		.filter((tool) => !tool.deferLoading)
-		.map((tool) => tool.name)
-		.sort((left, right) => left.localeCompare(right));
-	if (names.length === 0) return "";
-	return `${PROMOTED_TOOLS_HEADING}\n${names.map((name) => `- \`await tools.${name}(input)\``).join("\n")}`;
+		.sort((left, right) => left.name.localeCompare(right.name));
+	if (promoted.length === 0) return "";
+	return `${PROMOTED_TOOLS_HEADING}\n${promoted
+		.map(
+			(tool) =>
+				`- ${tool.name}: ${tool.usage ?? `await tools.${tool.name}(input)`}`,
+		)
+		.join("\n")}`;
 }
 
 export function buildDynamicToolsDocumentationPrompt(
 	documentationPath: string,
 ): string {
-	return `${DOCUMENTATION_PREFIX}\`${documentationPath}\` before adding, changing, or answering questions about dynamic tools.\n${DYNAMIC_TOOLS_GUIDANCE}`;
+	return `${DOCUMENTATION_PREFIX}${documentationPath} before adding, changing, or answering questions about dynamic tools.\n${DYNAMIC_TOOLS_GUIDANCE}`;
 }
 
 export function injectDynamicToolsPrompt(

--- a/packages/pi-dynamic-tools/src/prompt.ts
+++ b/packages/pi-dynamic-tools/src/prompt.ts
@@ -24,7 +24,7 @@ const DYNAMIC_TOOLS_GUIDANCE =
 
 export function formatDynamicToolHelp(tool: DynamicToolDefinition): string {
 	return [
-		tool.usage ? `Usage: ${tool.usage}` : undefined,
+		`Usage: ${tool.usage}`,
 		tool.description,
 		tool.output ? `Output: ${tool.output}` : undefined,
 	]
@@ -40,10 +40,7 @@ export function buildPromotedToolsPrompt(
 		.sort((left, right) => left.name.localeCompare(right.name));
 	if (promoted.length === 0) return "";
 	return `${PROMOTED_TOOLS_HEADING}\n${promoted
-		.map(
-			(tool) =>
-				`- ${tool.name}: ${tool.usage ?? `await tools.${tool.name}(input)`}`,
-		)
+		.map((tool) => `- ${tool.name}: ${tool.usage}`)
 		.join("\n")}`;
 }
 

--- a/packages/pi-dynamic-tools/src/types.ts
+++ b/packages/pi-dynamic-tools/src/types.ts
@@ -2,6 +2,7 @@ export type DynamicToolInputMode = "arg" | "stdin";
 
 export interface DynamicToolDefinition {
 	name: string;
+	usage?: string | undefined;
 	description?: string | undefined;
 	output?: string | undefined;
 	deferLoading: boolean;

--- a/packages/pi-dynamic-tools/src/types.ts
+++ b/packages/pi-dynamic-tools/src/types.ts
@@ -2,7 +2,7 @@ export type DynamicToolInputMode = "arg" | "stdin";
 
 export interface DynamicToolDefinition {
 	name: string;
-	usage?: string | undefined;
+	usage: string;
 	description?: string | undefined;
 	output?: string | undefined;
 	deferLoading: boolean;

--- a/packages/pi-dynamic-tools/tests/config.test.ts
+++ b/packages/pi-dynamic-tools/tests/config.test.ts
@@ -8,6 +8,7 @@ describe("dynamic tool TOML", () => {
 				"/tmp/subagent.toml",
 				`
  description = "Run a discovery agent."
+ usage = 'await tools.subagent(task)'
  command = "pi-subagent"
  args = ["--mode", "deep"]
  input = "stdin"
@@ -15,6 +16,7 @@ describe("dynamic tool TOML", () => {
 			),
 		).toEqual({
 			name: "subagent",
+			usage: "await tools.subagent(task)",
 			description: "Run a discovery agent.",
 			output: undefined,
 			deferLoading: true,
@@ -33,6 +35,7 @@ describe("dynamic tool TOML", () => {
 			),
 		).toEqual({
 			name: "repo_snapshot",
+			usage: undefined,
 			description: undefined,
 			output: "JSON with files and git_status.",
 			deferLoading: false,

--- a/packages/pi-dynamic-tools/tests/config.test.ts
+++ b/packages/pi-dynamic-tools/tests/config.test.ts
@@ -27,15 +27,15 @@ describe("dynamic tool TOML", () => {
 		});
 	});
 
-	test("allows self-explanatory tools and optional output help", () => {
+	test("requires usage and allows optional output help", () => {
 		expect(
 			parseDynamicTool(
 				"/tmp/repo_snapshot.toml",
-				`command = "repo-snapshot"\noutput = "JSON with files and git_status."\ndefer_loading = false`,
+				`usage = "await tools.repo_snapshot(path)"\ncommand = "repo-snapshot"\noutput = "JSON with files and git_status."\ndefer_loading = false`,
 			),
 		).toEqual({
 			name: "repo_snapshot",
-			usage: undefined,
+			usage: "await tools.repo_snapshot(path)",
 			description: undefined,
 			output: "JSON with files and git_status.",
 			deferLoading: false,
@@ -46,9 +46,18 @@ describe("dynamic tool TOML", () => {
 		});
 	});
 
+	test("rejects tools without an invocation contract", () => {
+		expect(() =>
+			parseDynamicTool("repo_snapshot.toml", `command = "repo-snapshot"`),
+		).toThrow("usage must be a non-empty string");
+	});
+
 	test("requires filenames that are directly callable JavaScript names", () => {
 		expect(() =>
-			parseDynamicTool("semantic-grep.toml", `command = "semantic-grep"`),
+			parseDynamicTool(
+				"semantic-grep.toml",
+				`usage = "await tools.semantic_grep(query)"\ncommand = "semantic-grep"`,
+			),
 		).toThrow("filename must be a JavaScript-compatible tool name");
 	});
 
@@ -56,7 +65,7 @@ describe("dynamic tool TOML", () => {
 		expect(() =>
 			parseDynamicTool(
 				"tool.toml",
-				`description = "x"\ncommand = "x"\nmagic = true`,
+				`usage = "await tools.tool(input)"\ndescription = "x"\ncommand = "x"\nmagic = true`,
 			),
 		).toThrow("unknown field: magic");
 	});
@@ -64,7 +73,7 @@ describe("dynamic tool TOML", () => {
 	test("runs a relative JavaScript command with the current runtime", () => {
 		const parsed = parseDynamicTool(
 			"/tmp/spawn_agent.toml",
-			`command = "./spawn-agent/spawn-agent.mjs"\ninput = "stdin"`,
+			`usage = "await tools.spawn_agent(input)"\ncommand = "./spawn-agent/spawn-agent.mjs"\ninput = "stdin"`,
 		);
 		expect(parsed.command).toBe(process.execPath);
 		expect(parsed.args).toHaveLength(1);

--- a/packages/pi-dynamic-tools/tests/host-client.test.ts
+++ b/packages/pi-dynamic-tools/tests/host-client.test.ts
@@ -67,6 +67,7 @@ describe("Codex code-mode host", () => {
 		await host.execute(`text(ALL_TOOLS.length);`, { cwd: process.cwd() });
 		const lateTool: DynamicToolDefinition = {
 			name: "late_tool",
+			usage: "await tools.late_tool(input)",
 			description: "Added during the session.",
 			deferLoading: true,
 			command: process.execPath,

--- a/packages/pi-dynamic-tools/tests/host-client.test.ts
+++ b/packages/pi-dynamic-tools/tests/host-client.test.ts
@@ -19,6 +19,7 @@ afterEach(async () => {
 function client(): CodeModeHostClient {
 	const echo: DynamicToolDefinition = {
 		name: "echo",
+		usage: "await tools.echo(text)",
 		description: "Echo text.",
 		output: "The same text.",
 		deferLoading: true,
@@ -56,7 +57,7 @@ describe("Codex code-mode host", () => {
 		expect(response.contentItems).toEqual([
 			{
 				type: "input_text",
-				text: '{"name":"echo","description":"Echo text.\\nOutput: The same text."}',
+				text: '{"name":"echo","description":"Usage: await tools.echo(text)\\nEcho text.\\nOutput: The same text."}',
 			},
 		]);
 	});

--- a/packages/pi-dynamic-tools/tests/prompt.test.ts
+++ b/packages/pi-dynamic-tools/tests/prompt.test.ts
@@ -7,9 +7,14 @@ import {
 } from "../src/prompt.js";
 import type { DynamicToolDefinition } from "../src/types.js";
 
-function tool(name: string, deferLoading: boolean): DynamicToolDefinition {
+function tool(
+	name: string,
+	deferLoading: boolean,
+	usage?: string,
+): DynamicToolDefinition {
 	return {
 		name,
+		usage,
 		description: "This detail stays on demand.",
 		output: "Plain text.",
 		deferLoading,
@@ -26,14 +31,15 @@ describe("dynamic tool prompt tiers", () => {
 		expect(EXEC_DESCRIPTION).toContain("ALL_TOOLS");
 	});
 
-	test("promotes only terse direct-tool forms", () => {
+	test("promotes exact usage without cosmetic markdown", () => {
 		const prompt = buildPromotedToolsPrompt([
-			tool("common_tool", false),
+			tool("common_tool", false, "await tools.common_tool({ query: string })"),
 			tool("rare_tool", true),
 		]);
 		expect(prompt).toBe(
-			"Dynamic tools available in `exec`:\n- `await tools.common_tool(input)`",
+			"Dynamic tools available in exec:\n- common_tool: await tools.common_tool({ query: string })",
 		);
+		expect(prompt).not.toContain("`");
 		expect(prompt).not.toContain("This detail stays on demand.");
 		expect(prompt).not.toContain("Plain text.");
 	});
@@ -44,23 +50,23 @@ describe("dynamic tool prompt tiers", () => {
 				"/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md",
 			),
 		).toBe(
-			"Dynamic tools documentation: read `/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md` before adding, changing, or answering questions about dynamic tools.\nPrefer a dynamic tool over a Pi extension for a command-backed capability.",
+			"Dynamic tools documentation: read /packages/pi-dynamic-tools/DYNAMIC-TOOLS.md before adding, changing, or answering questions about dynamic tools.\nPrefer a dynamic tool over a Pi extension for a command-backed capability.",
 		);
 	});
 
 	test("injects documentation and promoted forms before runtime context", () => {
 		const prompt = injectDynamicToolsPrompt(
 			"Instructions\n\nCurrent shell: /bin/bash\nCurrent date: 2026-07-11",
-			[tool("subagent", false)],
+			[tool("subagent", false, "await tools.subagent(task)")],
 			"/package/DYNAMIC-TOOLS.md",
 		);
 		expect(prompt).toBe(
-			"Instructions\n\nDynamic tools documentation: read `/package/DYNAMIC-TOOLS.md` before adding, changing, or answering questions about dynamic tools.\nPrefer a dynamic tool over a Pi extension for a command-backed capability.\nDynamic tools available in `exec`:\n- `await tools.subagent(input)`\nCurrent shell: /bin/bash\nCurrent date: 2026-07-11",
+			"Instructions\n\nDynamic tools documentation: read /package/DYNAMIC-TOOLS.md before adding, changing, or answering questions about dynamic tools.\nPrefer a dynamic tool over a Pi extension for a command-backed capability.\nDynamic tools available in exec:\n- subagent: await tools.subagent(task)\nCurrent shell: /bin/bash\nCurrent date: 2026-07-11",
 		);
 		expect(
 			injectDynamicToolsPrompt(
 				prompt,
-				[tool("subagent", false)],
+				[tool("subagent", false, "await tools.subagent(task)")],
 				"/package/DYNAMIC-TOOLS.md",
 			),
 		).toBe(prompt);

--- a/packages/pi-dynamic-tools/tests/prompt.test.ts
+++ b/packages/pi-dynamic-tools/tests/prompt.test.ts
@@ -10,7 +10,7 @@ import type { DynamicToolDefinition } from "../src/types.js";
 function tool(
 	name: string,
 	deferLoading: boolean,
-	usage?: string,
+	usage = `await tools.${name}(input)`,
 ): DynamicToolDefinition {
 	return {
 		name,

--- a/packages/pi-dynamic-tools/tests/tools.test.ts
+++ b/packages/pi-dynamic-tools/tests/tools.test.ts
@@ -66,9 +66,11 @@ describe("dynamic tool registration", () => {
 		expect(first.systemPrompt).not.toContain("late_tool");
 		writeFileSync(
 			join(dir, "late_tool.toml"),
-			'defer_loading = false\ncommand = "late-tool"\n',
+			'defer_loading = false\nusage = "await tools.late_tool(query)"\ncommand = "late-tool"\n',
 		);
 		const second = handler!({ systemPrompt: "Base" });
-		expect(second.systemPrompt).toContain("await tools.late_tool(input)");
+		expect(second.systemPrompt).toContain(
+			"late_tool: await tools.late_tool(query)",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- require TOML `usage` so agents always receive a precise invocation contract
- include promoted tool names and usage without cosmetic Markdown tokens
- expose usage through deferred `ALL_TOOLS` help
- replace the manufactured README demo with the bundled `spawn_agent` and `port_info` examples

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- 33 package tests pass

## Release
- Changeset: yes
- Packages: `@howaboua/pi-dynamic-tools`
- Aggregates: generated by release automation
