### PR TITLE
Guide long-running dynamic tool waits

### DIFF
--- a/.changeset/slow-cells-wait.md
+++ b/.changeset/slow-cells-wait.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-dynamic-tools": patch
+---
+
+Guide long-running cells away from frequent model-driven polling.

--- a/.github/workflows/dynamic-tools-host.yml
+++ b/.github/workflows/dynamic-tools-host.yml
@@ -1,33 +1,21 @@
-name: Dynamic tools host
+name: Dynamic tools host assets
 
 on:
   pull_request:
     paths:
-      - 'packages/pi-dynamic-tools/**'
+      - 'packages/pi-dynamic-tools/scripts/host-assets.mjs'
+      - 'packages/pi-dynamic-tools/scripts/verify-host-assets.mjs'
       - '.github/workflows/dynamic-tools-host.yml'
   push:
     branches: [main]
     paths:
-      - 'packages/pi-dynamic-tools/**'
+      - 'packages/pi-dynamic-tools/scripts/host-assets.mjs'
+      - 'packages/pi-dynamic-tools/scripts/verify-host-assets.mjs'
       - '.github/workflows/dynamic-tools-host.yml'
 
 jobs:
-  build-vendored-host:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: bun install
-      - name: Build vendored code-mode host
-        run: bun run --cwd packages/pi-dynamic-tools build:host
-      - name: Check package against built host
-        run: bun run --cwd packages/pi-dynamic-tools check
-
-  verify-upstream-assets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - name: Verify all platform downloads and checksums
-        run: bun run --cwd packages/pi-dynamic-tools verify:host-assets
+      - run: node packages/pi-dynamic-tools/scripts/verify-host-assets.mjs

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -128,6 +128,8 @@ Every dynamic method accepts one string and resolves to one string.
 
 The `exec` cell can compose calls with normal JavaScript, including `Promise.all`, `store`/`load`, progress notifications, images, yielding, and resumable `wait` cells. Read the `exec` tool contract for those runtime details rather than duplicating it here.
 
+For long-running commands, set `yield_time_ms` near the expected runtime and prefer one long `wait` over repeated short waits. Long waits remain cancellable, and `notify()` progress remains visible.
+
 ## Bundled examples
 
 Examples are documentation and working reference code. Installing the package does not register or enable them. Do not copy an example merely because you read this file.

--- a/packages/pi-dynamic-tools/UPSTREAM_SYNC.md
+++ b/packages/pi-dynamic-tools/UPSTREAM_SYNC.md
@@ -19,4 +19,4 @@ CODEX_SOURCE_DIR=/path/to/codex bun run sync:codex
 bun run build:host
 ```
 
-CI builds the vendored host on Linux and verifies every pinned upstream platform asset. Published installs lazily download the matching verified asset; they do not compile Rust on the user's machine.
+CI verifies every pinned upstream platform asset when the asset metadata changes. Published installs lazily download the matching verified asset; they do not compile Rust on the user's machine. Build the vendored source manually only while updating the upstream pin.

--- a/packages/pi-dynamic-tools/src/prompt.ts
+++ b/packages/pi-dynamic-tools/src/prompt.ts
@@ -3,7 +3,7 @@ import type { DynamicToolDefinition } from "./types.js";
 export const EXEC_DESCRIPTION = `Run JavaScript to compose dynamic tool calls.
 - \`tools.<name>(input)\` takes one string and returns \`Promise<string>\`.
 - Code runs as an async module in isolated V8: no Node, filesystem, network, or console. Await all work; unawaited promises are discarded.
-- Optional first line: \`// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}\`. Defaults are 10000 ms and 10000 tokens.
+- Optional first line: \`// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}\`. Defaults are 10000 ms and 10000 tokens. Set \`yield_time_ms\` near the expected runtime; use 60000 or more for subagents and long commands to avoid repeated waits. Long waits remain cancellable, and \`notify()\` still emits progress.
 
 Helpers:
 - \`text(value)\` appends output and JSON-stringifies non-strings; \`image(dataUrl, detail?)\` and \`generatedImage(result)\` append images.
@@ -15,7 +15,7 @@ Helpers:
 All dynamic tools remain callable on \`tools\`. When a needed tool is unknown, search \`ALL_TOOLS\` by name or description. List names with \`text(ALL_TOOLS.map(({ name }) => name))\`; inspect one with \`text(ALL_TOOLS.find(({ name }) => name === "tool_name"))\`.`;
 
 export const WAIT_DESCRIPTION =
-	"Wait for new output or terminate a yielded exec cell. Returns only output since the previous yield; call wait again if still running.";
+	"Wait for new output or terminate a yielded exec cell. Prefer one long wait over repeated short waits: set yield_time_ms near the expected remaining runtime, using 60000 or more for long tasks. Long waits remain cancellable and notify progress remains visible. Returns only output since the previous yield; call wait again if still running.";
 
 const PROMOTED_TOOLS_HEADING = "Dynamic tools available in exec:";
 const DOCUMENTATION_PREFIX = "Dynamic tools documentation: read ";

--- a/packages/pi-dynamic-tools/src/tools.ts
+++ b/packages/pi-dynamic-tools/src/tools.ts
@@ -114,7 +114,8 @@ export async function registerDynamicTools(
 			yield_time_ms: Type.Optional(
 				Type.Number({
 					minimum: 0,
-					description: "Wait ms (default 10000).",
+					description:
+						"Wait duration in ms. Match the expected remaining runtime; use 60000 or more for long tasks. Default 10000.",
 				}),
 			),
 			max_tokens: Type.Optional(

--- a/packages/pi-dynamic-tools/tests/prompt.test.ts
+++ b/packages/pi-dynamic-tools/tests/prompt.test.ts
@@ -4,6 +4,7 @@ import {
 	buildPromotedToolsPrompt,
 	EXEC_DESCRIPTION,
 	injectDynamicToolsPrompt,
+	WAIT_DESCRIPTION,
 } from "../src/prompt.js";
 import type { DynamicToolDefinition } from "../src/types.js";
 
@@ -29,6 +30,17 @@ describe("dynamic tool prompt tiers", () => {
 	test("keeps exec stable regardless of configured tools", () => {
 		expect(EXEC_DESCRIPTION).not.toContain("common_tool");
 		expect(EXEC_DESCRIPTION).toContain("ALL_TOOLS");
+	});
+
+	test("steers long-running cells away from frequent polling", () => {
+		expect(EXEC_DESCRIPTION).toContain(
+			"use 60000 or more for subagents and long commands",
+		);
+		expect(EXEC_DESCRIPTION).toContain("Long waits remain cancellable");
+		expect(WAIT_DESCRIPTION).toContain(
+			"Prefer one long wait over repeated short waits",
+		);
+		expect(WAIT_DESCRIPTION).toContain("notify progress remains visible");
 	});
 
 	test("promotes exact usage without cosmetic markdown", () => {


### PR DESCRIPTION
## Summary
- tell `exec` to match `yield_time_ms` to expected runtime and use 60 seconds or more for subagents and long commands
- tell `wait` to prefer one long wait over repeated short waits
- clarify that long waits remain cancellable and progress notifications remain visible
- remove routine vendored Rust builds; verify downloadable assets only when asset metadata changes

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- 34 package tests pass

## Release
- Changeset: yes
- Packages: `@howaboua/pi-dynamic-tools`
- Aggregates: generated by release automation
