### PR TITLE
Promote workflow utilities through dynamic tools

### DIFF
--- a/.changeset/calm-tools-compose.md
+++ b/.changeset/calm-tools-compose.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-dynamic-tools": patch
+"@howaboua/pi-subagent-review": patch
+---
+
+Adds bundled promoted examples for subagents, vent logging, workflow creation, and semantic grep. Subagent prompts now explicitly require each subagent to perform its assigned role without further delegation.

--- a/.changeset/calm-tools-rest.md
+++ b/.changeset/calm-tools-rest.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-semantic-grep": patch
+"@howaboua/pi-markdown-workflows": patch
+---
+
+Add a JSON `toolRegistration` setting that can hide the agent tool while keeping the rest of each extension active.

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -148,7 +148,7 @@ examples/spawn-agent/
 
 When the user explicitly asks to enable the example, copy `examples/spawn_agent.toml` into the definitions directory and copy `examples/spawn-agent/` beside it, preserving that layout. The TOML's relative command then resolves to `spawn-agent/spawn-agent.mjs`.
 
-The example demonstrates a deferred tool with JSON input:
+The example demonstrates a promoted tool with JSON input:
 
 ```js
 const result = await tools.spawn_agent(JSON.stringify({
@@ -169,7 +169,7 @@ Its contract is:
 
 `reviewer` runs GPT-5.6 Sol with medium reasoning and the same rubric as the review extension. Before starting Pi, the example resolves the Git repository root and prepares a user message with the current ref, selected local base branch, merge base, working-tree status, appropriate diff commands, and the caller's instructions. The rubric is appended to Pi's normal system prompt; project context remains loaded.
 
-Both roles disable child extensions, skills, and prompt templates. This avoids recursive dynamic tools and machine-specific behavior while retaining project context files and Pi's built-in discovery tools.
+Both roles disable child extensions, skills, and prompt templates. Their appended prompts prohibit further subagent delegation, while project context files and Pi's built-in discovery tools remain available.
 
 ### `port_info`
 
@@ -196,3 +196,36 @@ It returns normalized JSON containing TCP/UDP listeners, active connections, own
 Process command lines and working directories can contain sensitive information. Enable or invoke this example only when that system inspection is appropriate.
 
 When the user explicitly asks to enable it, copy `examples/port_info.toml` into the definitions directory and copy `examples/port-info/` beside it, preserving the layout.
+
+### `vent`
+
+The package also contains:
+
+```text
+examples/vent.toml
+examples/vent/vent.mjs
+```
+
+This promoted tool validates JSON containing `thought` and optional `trigger`, then appends one timestamped entry to `VENT.md`. It creates the file with a short purpose heading when needed. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
+
+### `workflows_create`
+
+The package also contains:
+
+```text
+examples/workflows_create.toml
+examples/workflows-create/workflows-create.mjs
+```
+
+This promoted tool validates `name`, `description`, and Markdown `body`, then atomically creates or updates `.pi/workflows/<slug>/SKILL.md`. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
+
+### `semantic_grep`
+
+The package also contains:
+
+```text
+examples/semantic_grep.toml
+examples/semantic-grep/semantic-grep.mjs
+```
+
+This promoted tool searches an existing semantic-grep SQLite index with bounded output. It requires `@howaboua/pi-semantic-grep` to remain installed: that extension owns global/project configuration and session-start indexing, while the dynamic tool owns query execution. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -38,9 +38,15 @@ For command-backed capabilities, dynamic tools are the lightweight default: keep
 
 ## Bundled examples
 
-`examples/spawn_agent.toml` and `examples/spawn-agent/` demonstrate a deferred, dual-role subagent without enabling it. The example accepts JSON containing a required `agent_type` (`explorer` or `reviewer`), required `message`, and optional `cwd`. Explorer uses GPT-5.6 Luna at low reasoning. Reviewer uses GPT-5.6 Sol at medium reasoning and prepares Git base, merge-base, status, and diff context before starting Pi. See `DYNAMIC-TOOLS.md` for the invocation and opt-in copy step.
+`examples/spawn_agent.toml` and `examples/spawn-agent/` demonstrate a promoted, dual-role subagent without enabling it. The example accepts JSON containing a required `agent_type` (`explorer` or `reviewer`), required `message`, and optional `cwd`. Explorer uses GPT-5.6 Luna at low reasoning. Reviewer uses GPT-5.6 Sol at medium reasoning and prepares Git base, merge-base, status, and diff context before starting Pi. See `DYNAMIC-TOOLS.md` for the invocation and opt-in copy step.
 
 `examples/port_info.toml` and `examples/port-info/` demonstrate a one-argument system integration without enabling it. The example turns a port number into normalized listener, connection, process, service, and container diagnostics across Linux, macOS, and Windows.
+
+Three promoted examples package common agent operations without enabling them:
+
+- `vent` appends batched workflow-friction notes to `VENT.md`.
+- `workflows_create` writes repo-local `.pi/workflows/<slug>/SKILL.md` procedures.
+- `semantic_grep` searches an index maintained by `@howaboua/pi-semantic-grep`; that package remains responsible for configuration and indexing lifecycle.
 
 ## Model-facing shape
 

--- a/packages/pi-dynamic-tools/examples/semantic-grep/semantic-grep.mjs
+++ b/packages/pi-dynamic-tools/examples/semantic-grep/semantic-grep.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+
+const ALLOWED_KEYS = new Set(["query", "top_k"]);
+const AGENT_DIR =
+	process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+const CONFIG_PATH = join(AGENT_DIR, "semantic-grep.json");
+const MAX_OUTPUT_BYTES = 45_000;
+const localRequire = createRequire(import.meta.url);
+const agentRequire = createRequire(join(AGENT_DIR, "npm", "package.json"));
+const Database = (() => {
+	try {
+		return localRequire("better-sqlite3");
+	} catch {
+		return agentRequire("better-sqlite3");
+	}
+})();
+
+function parseRequest(text) {
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`input must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("input must be a JSON object");
+	}
+	const unknown = Object.keys(value).filter((key) => !ALLOWED_KEYS.has(key));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+		);
+	}
+	if (typeof value.query !== "string" || !value.query.trim()) {
+		throw new Error("query must be a non-empty string");
+	}
+	if (
+		value.top_k !== undefined &&
+		(typeof value.top_k !== "number" || !Number.isFinite(value.top_k))
+	) {
+		throw new Error("top_k must be a finite number when provided");
+	}
+	return { query: value.query.trim(), top_k: value.top_k };
+}
+
+function deepMerge(base, override) {
+	const out = Array.isArray(base) ? [...base] : { ...base };
+	for (const [key, value] of Object.entries(override)) {
+		if (
+			value &&
+			typeof value === "object" &&
+			!Array.isArray(value) &&
+			key in out
+		) {
+			out[key] = deepMerge(out[key], value);
+		} else if (value !== undefined) {
+			out[key] = value;
+		}
+	}
+	return out;
+}
+
+function readConfig(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function hasMarker(dir, markers) {
+	return markers.some((marker) => existsSync(join(dir, marker)));
+}
+
+function findProjectRoot(cwd, config) {
+	let dir = resolve(cwd);
+	while (true) {
+		if (hasMarker(dir, config.safety.projectMarkers)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return config.safety.requireProjectMarker ? undefined : resolve(cwd);
+}
+
+function samePath(a, b) {
+	return resolve(a).toLowerCase() === resolve(b).toLowerCase();
+}
+
+function expandHome(path) {
+	if (path === "~") return homedir();
+	if (path.startsWith("~/") || path.startsWith("~\\")) {
+		return join(homedir(), path.slice(2));
+	}
+	return path;
+}
+
+function denyReason(root, config) {
+	for (const denied of config.safety.denyRootPaths) {
+		if (samePath(root, expandHome(denied))) {
+			return `refusing to index protected root: ${denied}`;
+		}
+	}
+	const base = basename(root);
+	if (config.safety.denyRootBasenames.includes(base)) {
+		return `refusing to index standard system/user directory: ${base}`;
+	}
+	try {
+		if (!statSync(root).isDirectory()) return `root does not exist: ${root}`;
+	} catch {
+		return `root does not exist: ${root}`;
+	}
+	return undefined;
+}
+
+async function embed(input, config) {
+	const headers = { "Content-Type": "application/json" };
+	if (config.embeddings.apiKey) {
+		headers.Authorization = `Bearer ${config.embeddings.apiKey}`;
+	}
+	const response = await fetch(config.embeddings.url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ model: config.embeddings.model, input }),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`embedding endpoint ${response.status}: ${await response.text()}`,
+		);
+	}
+	const json = await response.json();
+	const vector = json.data?.[0]?.embedding;
+	if (!Array.isArray(vector) || vector.length === 0) {
+		throw new Error("embedding response did not contain data[0].embedding");
+	}
+	return vector;
+}
+
+function cosine(a, b) {
+	let dot = 0;
+	let aa = 0;
+	let bb = 0;
+	const length = Math.min(a.length, b.length);
+	for (let index = 0; index < length; index += 1) {
+		const av = a[index] ?? 0;
+		const bv = b[index] ?? 0;
+		dot += av * bv;
+		aa += av * av;
+		bb += bv * bv;
+	}
+	return aa && bb ? dot / (Math.sqrt(aa) * Math.sqrt(bb)) : 0;
+}
+
+async function search(db, query, topK, config) {
+	const queryVector = await embed(query, config);
+	const best = [];
+	let minimum = Number.NEGATIVE_INFINITY;
+	for (const row of db
+		.prepare("select file, start_line, end_line, text, vector from chunks")
+		.iterate()) {
+		const score = cosine(queryVector, JSON.parse(row.vector));
+		if (best.length >= topK && score <= minimum) continue;
+		best.push({
+			file: row.file,
+			startLine: row.start_line,
+			endLine: row.end_line,
+			text: row.text,
+			score,
+		});
+		best.sort((a, b) => b.score - a.score);
+		if (best.length > topK) best.pop();
+		minimum = best.at(-1)?.score ?? Number.NEGATIVE_INFINITY;
+	}
+	return best;
+}
+
+function formatMatches(matches) {
+	if (matches.length === 0) return "No semantic grep matches.";
+	const sections = [];
+	let used = 0;
+	for (const [index, match] of matches.entries()) {
+		const heading = `## ${index + 1}. ${match.file}:${match.startLine}-${match.endLine} score=${match.score.toFixed(4)}\n\n`;
+		const fenceStart = `\`\`\`${match.file}\n`;
+		const fenceEnd = "\n\`\`\`";
+		const remaining =
+			MAX_OUTPUT_BYTES -
+			used -
+			heading.length -
+			fenceStart.length -
+			fenceEnd.length;
+		if (remaining <= 200) {
+			sections.push(`… ${matches.length - index} additional matches omitted.`);
+			break;
+		}
+		const truncated = match.text.length > remaining;
+		const text = truncated
+			? `${match.text.slice(0, Math.max(0, remaining - 20))}\n… snippet truncated`
+			: match.text;
+		const section = `${heading}${fenceStart}${text}${fenceEnd}`;
+		sections.push(section);
+		used += section.length + 2;
+		if (truncated) {
+			sections.push(
+				`… ${matches.length - index - 1} additional matches omitted.`,
+			);
+			break;
+		}
+	}
+	return sections.join("\n\n");
+}
+
+function boundOutput(text) {
+	if (Buffer.byteLength(text, "utf8") <= MAX_OUTPUT_BYTES) return text;
+	const suffix = "\n\n… output truncated.";
+	let low = 0;
+	let high = text.length;
+	while (low < high) {
+		const middle = Math.ceil((low + high) / 2);
+		if (
+			Buffer.byteLength(text.slice(0, middle) + suffix, "utf8") <=
+			MAX_OUTPUT_BYTES
+		) {
+			low = middle;
+		} else {
+			high = middle - 1;
+		}
+	}
+	return text.slice(0, low) + suffix;
+}
+
+async function readStdin() {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	return input;
+}
+
+async function main() {
+	const request = parseRequest(await readStdin());
+	if (!existsSync(CONFIG_PATH)) {
+		throw new Error(`configuration not found at ${CONFIG_PATH}`);
+	}
+	const globalConfig = readConfig(CONFIG_PATH);
+	const root = findProjectRoot(process.cwd(), globalConfig);
+	if (!root) {
+		process.stdout.write("Semantic grep skipped: no project marker found.\n");
+		return;
+	}
+	const projectConfigPath = join(root, ".pi", "semantic-grep.json");
+	const config = existsSync(projectConfigPath)
+		? deepMerge(globalConfig, readConfig(projectConfigPath))
+		: globalConfig;
+	const denied = denyReason(root, config);
+	if (denied) {
+		process.stdout.write(`Semantic grep skipped: ${denied}.\n`);
+		return;
+	}
+	const dbFile = join(root, ".pi", "semantic-grep.sqlite");
+	if (!existsSync(dbFile)) {
+		throw new Error(
+			`index not found at ${dbFile}; the extension should create it at session start`,
+		);
+	}
+	const topK = Math.min(
+		Math.max(1, request.top_k ?? config.search.defaultTopK),
+		config.search.maxTopK,
+	);
+	const db = new Database(dbFile, { readonly: true, fileMustExist: true });
+	try {
+		const output = formatMatches(await search(db, request.query, topK, config));
+		process.stdout.write(`${boundOutput(output)}\n`);
+	} finally {
+		db.close();
+	}
+}
+
+main().catch((error) => {
+	process.stderr.write(
+		`semantic_grep: ${error instanceof Error ? error.message : String(error)}\n`,
+	);
+	process.exitCode = 1;
+});

--- a/packages/pi-dynamic-tools/examples/semantic_grep.toml
+++ b/packages/pi-dynamic-tools/examples/semantic_grep.toml
@@ -1,0 +1,5 @@
+usage = '''await tools.semantic_grep(JSON.stringify({ query: string, top_k?: number })) // conceptual or cross-file discovery; use exact grep for literals'''
+description = "Searches the current repository's existing semantic-grep index and returns ranked paths, line ranges, scores, and snippets."
+command = "./semantic-grep/semantic-grep.mjs"
+input = "stdin"
+defer_loading = false

--- a/packages/pi-dynamic-tools/examples/spawn-agent/explorer.prompt.md
+++ b/packages/pi-dynamic-tools/examples/spawn-agent/explorer.prompt.md
@@ -1,3 +1,3 @@
 You are the Explorer Subagent, an isolated codebase discovery specialist.
 
-Stay strictly in discovery mode. Treat the user message as the entire brief. Inspect and summarize without editing files or proposing implementation. Follow loaded project instructions. Do not invoke other subagents. Prefer evidence over assumptions, cite file paths and line ranges, and state what remains unverified.
+Stay strictly in discovery mode. Treat the user message as the entire brief. Inspect and summarize without editing files or proposing implementation. Follow loaded project instructions. You are the subagent: do not spawn other subagents; perform the explorer duties yourself. Prefer evidence over assumptions, cite file paths and line ranges, and state what remains unverified.

--- a/packages/pi-dynamic-tools/examples/spawn-agent/reviewer.prompt.md
+++ b/packages/pi-dynamic-tools/examples/spawn-agent/reviewer.prompt.md
@@ -4,7 +4,7 @@ Rules:
 - Stay strictly in review mode.
 - You do not inherit the parent agent's prior conversation, plan, or hidden context. Treat the provided task as the entire brief.
 - Do not edit files.
-- Do not invoke other subagents or delegate again.
+- You are the subagent: do not spawn other subagents; perform the reviewer duties yourself.
 - Prefer `git diff`, targeted file reads, and concrete evidence over assumptions.
 - Focus on actionable findings, not broad summaries.
 - Prioritize correctness, regressions, security, data loss, performance, concurrency, and missing tests.

--- a/packages/pi-dynamic-tools/examples/spawn_agent.toml
+++ b/packages/pi-dynamic-tools/examples/spawn_agent.toml
@@ -2,3 +2,4 @@ usage = '''await tools.spawn_agent(JSON.stringify({ agent_type: "explorer" | "re
 description = "Relative cwd resolves from Pi's working directory."
 command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
+defer_loading = false

--- a/packages/pi-dynamic-tools/examples/vent.toml
+++ b/packages/pi-dynamic-tools/examples/vent.toml
@@ -1,0 +1,5 @@
+usage = '''await tools.vent(JSON.stringify({ thought: string, trigger?: string })) // repeated/systemic workflow friction only; use after finishing the task'''
+description = "Appends one batched workflow-friction entry to VENT.md in Pi's working directory."
+command = "./vent/vent.mjs"
+input = "stdin"
+defer_loading = false

--- a/packages/pi-dynamic-tools/examples/vent/vent.mjs
+++ b/packages/pi-dynamic-tools/examples/vent/vent.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { appendFile, open } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const ALLOWED_KEYS = new Set(["thought", "trigger"]);
+const HEADING =
+	"# VENT\n\nFeedback log. Repeated/systemic workflow friction that should become future automation, docs, or workflow fixes.\n\n";
+
+function clean(value) {
+	return value.trim().replace(/\r\n/g, "\n");
+}
+
+function parseRequest(text) {
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`input must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("input must be a JSON object");
+	}
+	const unknown = Object.keys(value).filter((key) => !ALLOWED_KEYS.has(key));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+		);
+	}
+	if (typeof value.thought !== "string" || !clean(value.thought)) {
+		throw new Error("thought must be a non-empty string");
+	}
+	if (
+		value.trigger !== undefined &&
+		(typeof value.trigger !== "string" || !clean(value.trigger))
+	) {
+		throw new Error("trigger must be a non-empty string when provided");
+	}
+	return {
+		thought: clean(value.thought),
+		trigger: value.trigger === undefined ? undefined : clean(value.trigger),
+	};
+}
+
+function timestamp(now = new Date()) {
+	const date = [
+		String(now.getFullYear()).slice(-2),
+		String(now.getMonth() + 1).padStart(2, "0"),
+		String(now.getDate()).padStart(2, "0"),
+	].join("-");
+	const time = [
+		String(now.getHours()).padStart(2, "0"),
+		String(now.getMinutes()).padStart(2, "0"),
+	].join(":");
+	return `${date} ${time}`;
+}
+
+async function ensureFile(path) {
+	try {
+		const handle = await open(path, "wx");
+		try {
+			await handle.writeFile(HEADING, "utf8");
+		} finally {
+			await handle.close();
+		}
+	} catch (error) {
+		if (error?.code !== "EEXIST") throw error;
+	}
+}
+
+async function readStdin() {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	return input;
+}
+
+async function main() {
+	const request = parseRequest(await readStdin());
+	const path = resolve(process.cwd(), "VENT.md");
+	const now = timestamp();
+	const entry = [
+		`## ${now}${request.trigger ? ` — ${request.trigger}` : ""}`,
+		"",
+		request.thought,
+		"",
+	].join("\n");
+	await ensureFile(path);
+	await appendFile(path, entry, "utf8");
+	process.stdout.write(`Appended vent entry to VENT.md (${now}).\n`);
+}
+
+main().catch((error) => {
+	process.stderr.write(
+		`vent: ${error instanceof Error ? error.message : String(error)}\n`,
+	);
+	process.exitCode = 1;
+});

--- a/packages/pi-dynamic-tools/examples/workflows-create/workflows-create.mjs
+++ b/packages/pi-dynamic-tools/examples/workflows-create/workflows-create.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const ALLOWED_KEYS = new Set(["name", "description", "body"]);
+
+function parseRequest(text) {
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`input must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("input must be a JSON object");
+	}
+	const unknown = Object.keys(value).filter((key) => !ALLOWED_KEYS.has(key));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+		);
+	}
+	for (const key of ALLOWED_KEYS) {
+		if (typeof value[key] !== "string" || !value[key].trim()) {
+			throw new Error(`${key} must be a non-empty string`);
+		}
+	}
+	return {
+		name: value.name.trim(),
+		description: value.description.trim(),
+		body: value.body.replace(/\r\n/g, "\n"),
+	};
+}
+
+function slugify(value) {
+	return value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9\s-]/g, "")
+		.replace(/\s+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function stripFrontmatter(body) {
+	const match = body.match(/^---\n[\s\S]+?\n---\s*\n?/);
+	return match ? body.slice(match[0].length) : body;
+}
+
+async function readStdin() {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	return input;
+}
+
+async function main() {
+	const request = parseRequest(await readStdin());
+	const slug = slugify(request.name) || "workflow";
+	const workflowPath = join(
+		process.cwd(),
+		".pi",
+		"workflows",
+		slug,
+		"SKILL.md",
+	);
+	const content = [
+		"---",
+		`name: ${JSON.stringify(request.name)}`,
+		`description: ${JSON.stringify(request.description)}`,
+		"---",
+		"",
+		stripFrontmatter(request.body).trim(),
+		"",
+	].join("\n");
+	await mkdir(dirname(workflowPath), { recursive: true });
+	const temporaryPath = `${workflowPath}.${process.pid}.tmp`;
+	try {
+		await writeFile(temporaryPath, content, "utf8");
+		await rename(temporaryPath, workflowPath);
+	} finally {
+		await rm(temporaryPath, { force: true });
+	}
+	process.stdout.write(`Workflow created at ${workflowPath}\n`);
+}
+
+main().catch((error) => {
+	process.stderr.write(
+		`workflows_create: ${error instanceof Error ? error.message : String(error)}\n`,
+	);
+	process.exitCode = 1;
+});

--- a/packages/pi-dynamic-tools/examples/workflows_create.toml
+++ b/packages/pi-dynamic-tools/examples/workflows_create.toml
@@ -1,0 +1,5 @@
+usage = '''await tools.workflows_create(JSON.stringify({ name: string, description: string, body: string })) // confirmed repeatable SOPs only; update rather than duplicate'''
+description = "Creates or updates .pi/workflows/<slug>/SKILL.md in Pi's working directory."
+command = "./workflows-create/workflows-create.mjs"
+input = "stdin"
+defer_loading = false

--- a/packages/pi-markdown-workflows/src/config/index.ts
+++ b/packages/pi-markdown-workflows/src/config/index.ts
@@ -1,0 +1,28 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export interface MarkdownWorkflowsConfig {
+	toolRegistration: boolean;
+}
+
+export const CONFIG_PATH = path.join(getAgentDir(), "markdown-workflows.json");
+export const DEFAULT_CONFIG: MarkdownWorkflowsConfig = {
+	toolRegistration: true,
+};
+
+export function ensureConfig(): MarkdownWorkflowsConfig {
+	mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+	if (!existsSync(CONFIG_PATH)) {
+		writeFileSync(
+			CONFIG_PATH,
+			`${JSON.stringify(DEFAULT_CONFIG, null, "\t")}\n`,
+		);
+	}
+	return {
+		...DEFAULT_CONFIG,
+		...(JSON.parse(
+			readFileSync(CONFIG_PATH, "utf8"),
+		) as Partial<MarkdownWorkflowsConfig>),
+	};
+}

--- a/packages/pi-markdown-workflows/src/extension/register.ts
+++ b/packages/pi-markdown-workflows/src/extension/register.ts
@@ -2,13 +2,15 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerLearnCommand } from "../commands/learn.js";
 import { registerSkillsCommand } from "../commands/skills.js";
 import { registerWorkflowsCommand } from "../commands/workflows.js";
+import { ensureConfig } from "../config/index.js";
 import { registerSubdirContextAutoload } from "../core/subdir.js";
 import { registerBeforeAgentStart } from "../hooks/before-agent-start.js";
 import { registerWorkflowsCreateTool } from "../tools/workflows-create.js";
 
 export function registerExtension(pi: ExtensionAPI): void {
+	const config = ensureConfig();
 	registerSubdirContextAutoload(pi);
-	registerWorkflowsCreateTool(pi);
+	if (config.toolRegistration) registerWorkflowsCreateTool(pi);
 	registerBeforeAgentStart(pi);
 	registerWorkflowsCommand(pi);
 	registerSkillsCommand(pi);

--- a/packages/pi-semantic-grep/src/config.ts
+++ b/packages/pi-semantic-grep/src/config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export interface SemanticGrepConfig {
+	toolRegistration: boolean;
 	embeddings: {
 		url: string;
 		model: string;
@@ -42,6 +43,7 @@ export const PROJECT_CONFIG_BASENAME = path.join(
 );
 
 export const DEFAULT_CONFIG: SemanticGrepConfig = {
+	toolRegistration: true,
 	embeddings: {
 		url: "http://127.0.0.1:1234/v1/embeddings",
 		model: "text-embedding-embeddinggemma-300m-qat",

--- a/packages/pi-semantic-grep/src/index.ts
+++ b/packages/pi-semantic-grep/src/index.ts
@@ -34,128 +34,139 @@ function cwdFromCtx(ctx: ExtensionContext): string {
 }
 
 export default function semanticGrepExtension(pi: ExtensionAPI) {
-	ensureConfig();
+	const extensionConfig = ensureConfig();
 	let indexingController: AbortController | undefined;
 
-	pi.registerTool<typeof semanticGrepSchema, SemanticGrepDetails>({
-		name: "semantic_grep",
-		label: "Semantic Grep",
-		description: "Search code and docs by meaning.",
-		promptSnippet: "Use semantic_grep for conceptual code/docs discovery.",
-		promptGuidelines: [
-			"semantic_grep: Use early for conceptual or cross-file discovery.",
-			"semantic_grep: Query for behavior, concepts, features, or code paths—not just exact identifiers.",
-			"semantic_grep: Inspect returned locations with file-reading tools before making precise claims or edits.",
-			"semantic_grep: Use exact text search instead when you need literal string occurrences.",
-		],
-		parameters: semanticGrepSchema,
-		renderCall(args, theme) {
-			const query = typeof args.query === "string" ? args.query : "";
-			const shown = query.length > 90 ? `${query.slice(0, 87)}...` : query;
-			let text = theme.fg("toolTitle", theme.bold("semantic_grep "));
-			text += theme.fg("accent", `"${shown}"`);
-			if (args.top_k) text += theme.fg("dim", ` top_k=${args.top_k}`);
-			return new Text(text, 0, 0);
-		},
+	if (extensionConfig.toolRegistration)
+		pi.registerTool<typeof semanticGrepSchema, SemanticGrepDetails>({
+			name: "semantic_grep",
+			label: "Semantic Grep",
+			description: "Search code and docs by meaning.",
+			promptSnippet: "Use semantic_grep for conceptual code/docs discovery.",
+			promptGuidelines: [
+				"semantic_grep: Use early for conceptual or cross-file discovery.",
+				"semantic_grep: Query for behavior, concepts, features, or code paths—not just exact identifiers.",
+				"semantic_grep: Inspect returned locations with file-reading tools before making precise claims or edits.",
+				"semantic_grep: Use exact text search instead when you need literal string occurrences.",
+			],
+			parameters: semanticGrepSchema,
+			renderCall(args, theme) {
+				const query = typeof args.query === "string" ? args.query : "";
+				const shown = query.length > 90 ? `${query.slice(0, 87)}...` : query;
+				let text = theme.fg("toolTitle", theme.bold("semantic_grep "));
+				text += theme.fg("accent", `"${shown}"`);
+				if (args.top_k) text += theme.fg("dim", ` top_k=${args.top_k}`);
+				return new Text(text, 0, 0);
+			},
 
-		renderResult(result, { expanded, isPartial }, theme) {
-			if (isPartial)
-				return new Text(theme.fg("warning", "Searching semantic index…"), 0, 0);
-			if (result.details?.error) {
-				const errorText = result.content.find(
-					(item): item is { type: "text"; text: string } =>
-						item.type === "text",
-				)?.text;
-				return new Text(
-					theme.fg("error", errorText ?? result.details.error),
-					0,
-					0,
-				);
-			}
-
-			const matches = result.details?.matches ?? [];
-			if (!matches.length)
-				return new Text(theme.fg("dim", "No semantic matches"), 0, 0);
-
-			let text = theme.fg("success", `${matches.length} semantic matches`);
-			text += theme.fg("dim", ` in ${result.details?.root ?? "repo"}`);
-			if (!expanded)
-				text += theme.fg(
-					"muted",
-					` (${keyHint("app.tools.expand", "expand")})`,
-				);
-
-			const limit = expanded ? matches.length : Math.min(matches.length, 5);
-			for (const m of matches.slice(0, limit)) {
-				text += `\n${theme.fg("accent", `${m.file}:${m.startLine}-${m.endLine}`)} ${theme.fg("dim", `score=${m.score.toFixed(4)}`)}`;
-				if (expanded) {
-					const preview = m.text.split("\n").slice(0, 12).join("\n");
-					text += `\n${theme.fg("dim", preview)}`;
+			renderResult(result, { expanded, isPartial }, theme) {
+				if (isPartial)
+					return new Text(
+						theme.fg("warning", "Searching semantic index…"),
+						0,
+						0,
+					);
+				if (result.details?.error) {
+					const errorText = result.content.find(
+						(item): item is { type: "text"; text: string } =>
+							item.type === "text",
+					)?.text;
+					return new Text(
+						theme.fg("error", errorText ?? result.details.error),
+						0,
+						0,
+					);
 				}
-			}
-			if (!expanded && matches.length > limit)
-				text += `\n${theme.fg("muted", `… ${matches.length - limit} more`)}`;
-			return new Text(text, 0, 0);
-		},
 
-		async execute(
-			_toolCallId,
-			params: SemanticGrepParams,
-			signal,
-			_onUpdate,
-			ctx,
-		) {
-			const baseConfig = ensureConfig();
-			const root = findProjectRoot(cwdFromCtx(ctx), baseConfig);
-			if (!root) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: "Semantic grep skipped: no project marker found.",
-						},
-					],
-					details: { error: "no_project_root" },
-				};
-			}
-			const config = ensureConfig(root);
-			const denied = denyReason(root, config);
-			if (denied) {
-				return {
-					content: [
-						{ type: "text", text: `Semantic grep skipped: ${denied}.` },
-					],
-					details: { error: "denied_root", root, reason: denied },
-				};
-			}
-			const dbFile = dbPathFor(root);
-			if (!existsSync(dbFile)) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: `Semantic grep index not found at ${dbFile}. It should be created automatically at session start; check extension logs/status.`,
-						},
-					],
-					details: { error: "missing_index", dbFile },
-				};
-			}
-			const topK = Math.min(
-				Math.max(1, params.top_k ?? config.search.defaultTopK),
-				config.search.maxTopK,
-			);
-			const db = openDb(root);
-			try {
-				const matches = await searchDb(db, params.query, topK, config, signal);
-				return {
-					content: [{ type: "text", text: formatMatches(matches) }],
-					details: { root, dbFile, query: params.query, matches },
-				};
-			} finally {
-				db.close();
-			}
-		},
-	});
+				const matches = result.details?.matches ?? [];
+				if (!matches.length)
+					return new Text(theme.fg("dim", "No semantic matches"), 0, 0);
+
+				let text = theme.fg("success", `${matches.length} semantic matches`);
+				text += theme.fg("dim", ` in ${result.details?.root ?? "repo"}`);
+				if (!expanded)
+					text += theme.fg(
+						"muted",
+						` (${keyHint("app.tools.expand", "expand")})`,
+					);
+
+				const limit = expanded ? matches.length : Math.min(matches.length, 5);
+				for (const m of matches.slice(0, limit)) {
+					text += `\n${theme.fg("accent", `${m.file}:${m.startLine}-${m.endLine}`)} ${theme.fg("dim", `score=${m.score.toFixed(4)}`)}`;
+					if (expanded) {
+						const preview = m.text.split("\n").slice(0, 12).join("\n");
+						text += `\n${theme.fg("dim", preview)}`;
+					}
+				}
+				if (!expanded && matches.length > limit)
+					text += `\n${theme.fg("muted", `… ${matches.length - limit} more`)}`;
+				return new Text(text, 0, 0);
+			},
+
+			async execute(
+				_toolCallId,
+				params: SemanticGrepParams,
+				signal,
+				_onUpdate,
+				ctx,
+			) {
+				const baseConfig = ensureConfig();
+				const root = findProjectRoot(cwdFromCtx(ctx), baseConfig);
+				if (!root) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: "Semantic grep skipped: no project marker found.",
+							},
+						],
+						details: { error: "no_project_root" },
+					};
+				}
+				const config = ensureConfig(root);
+				const denied = denyReason(root, config);
+				if (denied) {
+					return {
+						content: [
+							{ type: "text", text: `Semantic grep skipped: ${denied}.` },
+						],
+						details: { error: "denied_root", root, reason: denied },
+					};
+				}
+				const dbFile = dbPathFor(root);
+				if (!existsSync(dbFile)) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `Semantic grep index not found at ${dbFile}. It should be created automatically at session start; check extension logs/status.`,
+							},
+						],
+						details: { error: "missing_index", dbFile },
+					};
+				}
+				const topK = Math.min(
+					Math.max(1, params.top_k ?? config.search.defaultTopK),
+					config.search.maxTopK,
+				);
+				const db = openDb(root);
+				try {
+					const matches = await searchDb(
+						db,
+						params.query,
+						topK,
+						config,
+						signal,
+					);
+					return {
+						content: [{ type: "text", text: formatMatches(matches) }],
+						details: { root, dbFile, query: params.query, matches },
+					};
+				} finally {
+					db.close();
+				}
+			},
+		});
 
 	pi.on("session_start", async (_event, ctx) => {
 		const baseConfig = ensureConfig();

--- a/packages/pi-subagent-review/review.prompt.md
+++ b/packages/pi-subagent-review/review.prompt.md
@@ -4,7 +4,7 @@ Rules:
 - Stay strictly in review mode.
 - You do not inherit the parent agent's prior conversation, plan, or hidden context. Treat the provided task as the entire brief.
 - Do not edit files.
-- Do not invoke other subagents or delegate again.
+- You are the subagent: do not spawn other subagents; perform the reviewer duties yourself.
 - Prefer `git diff`, targeted file reads, and concrete evidence over assumptions.
 - Focus on actionable findings, not broad summaries.
 - Prioritize correctness, regressions, security, data loss, performance, concurrency, and missing tests.


### PR DESCRIPTION
## Summary
- add opt-in promoted dynamic-tool examples for semantic grep, workflow creation, and vent logging
- allow semantic grep and Markdown Workflows to keep their extension lifecycle active without registering their native agent tools
- tighten bundled subagent prompts against recursive delegation

## Validation
- `bun run check:changed`
- `git diff --check origin/main...HEAD`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-dynamic-tools`, `@howaboua/pi-markdown-workflows`, `@howaboua/pi-semantic-grep`, `@howaboua/pi-subagent-review`
- Aggregates: generated by release automation
