### PR TITLE
Fix review summaries after compaction

### DIFF
--- a/.changeset/polite-parks-allow.md
+++ b/.changeset/polite-parks-allow.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subagent-review": patch
+---
+
+Uses Pi's compaction-aware active session entries when preparing review conversation summaries, preventing superseded history from overflowing the summary model.

--- a/packages/pi-subagent-review/src/conversation-summary.ts
+++ b/packages/pi-subagent-review/src/conversation-summary.ts
@@ -202,7 +202,9 @@ export async function buildReviewConversationSummary(
 ): Promise<string | undefined> {
 	if (!config.summary.enabled) return undefined;
 
-	const conversation = buildSummaryInput(ctx.sessionManager.getBranch());
+	const conversation = buildSummaryInput(
+		ctx.sessionManager.buildContextEntries(),
+	);
 	if (!conversation.trim()) return undefined;
 
 	const response = await completeSummary(

--- a/packages/pi-subagent-review/tests/conversation-summary.test.ts
+++ b/packages/pi-subagent-review/tests/conversation-summary.test.ts
@@ -2,7 +2,6 @@ import { afterEach, expect, test } from "bun:test";
 import {
 	type Api,
 	type AssistantMessage,
-	type Context,
 	createAssistantMessageEventStream,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
@@ -105,17 +104,14 @@ async function summarizeWithAuth(
 		Parameters<ModelRegistry["registerProvider"]>[1],
 		"apiKey" | "authHeader" | "oauth"
 	>,
-	prepareSession?: (sessionManager: SessionManager) => void,
 ) {
 	registry = ModelRegistry.inMemory(authStorage);
-	let receivedContext: Context | undefined;
 	let receivedOptions: SimpleStreamOptions | undefined;
 	registry.registerProvider(PROVIDER, {
 		baseUrl: "https://summary.invalid/v1",
 		api: API,
 		...authConfig,
-		streamSimple(_model, context, options) {
-			receivedContext = context;
+		streamSimple(_model, _context, options) {
 			receivedOptions = options;
 			return responseStream(options).stream;
 		},
@@ -138,7 +134,6 @@ async function summarizeWithAuth(
 		content: "Please review this change",
 		timestamp: Date.now(),
 	});
-	prepareSession?.(sessionManager);
 	const ctx = {
 		cwd: process.cwd(),
 		modelRegistry: registry,
@@ -158,7 +153,7 @@ async function summarizeWithAuth(
 	};
 
 	const summary = await buildReviewConversationSummary(ctx, config);
-	return { summary, receivedContext, receivedOptions };
+	return { summary, receivedOptions };
 }
 
 test("uses the public Pi session path for extension-registered providers", async () => {
@@ -216,72 +211,6 @@ test("resolves OAuth provider auth", async () => {
 
 	expect(result.summary).toBe("Review context summary");
 	expect(result.receivedOptions?.apiKey).toBe("oauth-access-token");
-});
-
-test("summarizes only the active compaction-aware session entries", async () => {
-	const result = await summarizeWithAuth(
-		AuthStorage.inMemory({
-			[PROVIDER]: { type: "api_key", key: "stored-key" },
-		}),
-		{ apiKey: "configured-key" },
-		(sessionManager) => {
-			sessionManager.appendMessage({
-				role: "user",
-				content: "superseded pre-compaction history",
-				timestamp: Date.now(),
-			});
-			const firstKeptEntryId = sessionManager.appendMessage({
-				role: "assistant",
-				content: [{ type: "text", text: "retained recent context" }],
-				api: API,
-				provider: PROVIDER,
-				model: "summary-model",
-				usage: {
-					input: 1,
-					output: 1,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 2,
-					cost: {
-						input: 0,
-						output: 0,
-						cacheRead: 0,
-						cacheWrite: 0,
-						total: 0,
-					},
-				},
-				stopReason: "stop",
-				timestamp: Date.now(),
-			});
-			sessionManager.appendCompaction(
-				"durable compaction summary",
-				firstKeptEntryId,
-				100_000,
-			);
-			sessionManager.appendMessage({
-				role: "user",
-				content: "post-compaction request",
-				timestamp: Date.now(),
-			});
-		},
-	);
-
-	const prompt = result.receivedContext?.messages
-		.map((message) =>
-			typeof message.content === "string"
-				? message.content
-				: message.content
-						.filter((part) => part.type === "text")
-						.map((part) => part.text)
-						.join("\n"),
-		)
-		.join("\n");
-
-	expect(prompt).toContain("durable compaction summary");
-	expect(prompt).toContain("retained recent context");
-	expect(prompt).toContain("post-compaction request");
-	expect(prompt).not.toContain("superseded pre-compaction history");
-	expect(prompt).not.toContain("Please review this change");
 });
 
 test("aborts an in-flight summary when the review is cancelled", async () => {

--- a/packages/pi-subagent-review/tests/conversation-summary.test.ts
+++ b/packages/pi-subagent-review/tests/conversation-summary.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import {
 	type Api,
 	type AssistantMessage,
+	type Context,
 	createAssistantMessageEventStream,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
@@ -104,14 +105,17 @@ async function summarizeWithAuth(
 		Parameters<ModelRegistry["registerProvider"]>[1],
 		"apiKey" | "authHeader" | "oauth"
 	>,
+	prepareSession?: (sessionManager: SessionManager) => void,
 ) {
 	registry = ModelRegistry.inMemory(authStorage);
+	let receivedContext: Context | undefined;
 	let receivedOptions: SimpleStreamOptions | undefined;
 	registry.registerProvider(PROVIDER, {
 		baseUrl: "https://summary.invalid/v1",
 		api: API,
 		...authConfig,
-		streamSimple(_model, _context, options) {
+		streamSimple(_model, context, options) {
+			receivedContext = context;
 			receivedOptions = options;
 			return responseStream(options).stream;
 		},
@@ -134,6 +138,7 @@ async function summarizeWithAuth(
 		content: "Please review this change",
 		timestamp: Date.now(),
 	});
+	prepareSession?.(sessionManager);
 	const ctx = {
 		cwd: process.cwd(),
 		modelRegistry: registry,
@@ -153,7 +158,7 @@ async function summarizeWithAuth(
 	};
 
 	const summary = await buildReviewConversationSummary(ctx, config);
-	return { summary, receivedOptions };
+	return { summary, receivedContext, receivedOptions };
 }
 
 test("uses the public Pi session path for extension-registered providers", async () => {
@@ -211,6 +216,72 @@ test("resolves OAuth provider auth", async () => {
 
 	expect(result.summary).toBe("Review context summary");
 	expect(result.receivedOptions?.apiKey).toBe("oauth-access-token");
+});
+
+test("summarizes only the active compaction-aware session entries", async () => {
+	const result = await summarizeWithAuth(
+		AuthStorage.inMemory({
+			[PROVIDER]: { type: "api_key", key: "stored-key" },
+		}),
+		{ apiKey: "configured-key" },
+		(sessionManager) => {
+			sessionManager.appendMessage({
+				role: "user",
+				content: "superseded pre-compaction history",
+				timestamp: Date.now(),
+			});
+			const firstKeptEntryId = sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "retained recent context" }],
+				api: API,
+				provider: PROVIDER,
+				model: "summary-model",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						total: 0,
+					},
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			});
+			sessionManager.appendCompaction(
+				"durable compaction summary",
+				firstKeptEntryId,
+				100_000,
+			);
+			sessionManager.appendMessage({
+				role: "user",
+				content: "post-compaction request",
+				timestamp: Date.now(),
+			});
+		},
+	);
+
+	const prompt = result.receivedContext?.messages
+		.map((message) =>
+			typeof message.content === "string"
+				? message.content
+				: message.content
+						.filter((part) => part.type === "text")
+						.map((part) => part.text)
+						.join("\n"),
+		)
+		.join("\n");
+
+	expect(prompt).toContain("durable compaction summary");
+	expect(prompt).toContain("retained recent context");
+	expect(prompt).toContain("post-compaction request");
+	expect(prompt).not.toContain("superseded pre-compaction history");
+	expect(prompt).not.toContain("Please review this change");
 });
 
 test("aborts an in-flight summary when the review is cancelled", async () => {


### PR DESCRIPTION
## Summary
- use Pi's compaction-aware active entries when preparing review conversation summaries
- preserve the latest compaction summary plus retained and post-compaction context
- exclude superseded history that could overflow the summary model

Closes #96

## Validation
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-subagent-review`
- Aggregates: generated by release automation
