### PR TITLE
Refine tool behavior and package documentation

### DIFF
--- a/.changeset/breezy-planets-drop.md
+++ b/.changeset/breezy-planets-drop.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-markdown-workflows": patch
+---
+
+Load nested AGENTS.md context from successful pi-codex Code Mode tool traces.

--- a/.changeset/clear-docs-land.md
+++ b/.changeset/clear-docs-land.md
@@ -1,0 +1,22 @@
+---
+"@howaboua/pi-auto-trees": patch
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-dynamic-tools": patch
+"@howaboua/pi-explore-subagents": patch
+"@howaboua/pi-memories": patch
+"@howaboua/pi-semantic-grep": patch
+"@howaboua/pi-skill-agent-native-hardening": patch
+"@howaboua/pi-skill-agents-md": patch
+"@howaboua/pi-skill-anti-ai-copy": patch
+"@howaboua/pi-skill-chrome-cdp": patch
+"@howaboua/pi-skill-gh-issue-pr-flow": patch
+"@howaboua/pi-skill-model-facing-api-design": patch
+"@howaboua/pi-skill-omarchy-help": patch
+"@howaboua/pi-skill-project-reference-research": patch
+"@howaboua/pi-skill-skill-creator": patch
+"@howaboua/pi-smart-btw": patch
+"@howaboua/pi-subagent-review": patch
+"@howaboua/pi-vent": patch
+---
+
+Rewrite package documentation around current installation, configuration, usage, and behavior.

--- a/.changeset/famous-peas-wish.md
+++ b/.changeset/famous-peas-wish.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-auto-reasoning-tool": patch
+---
+
+Tighten the change_reasoning agent contract and clarify responses at the user's minimum.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,10 @@
-This repo publishes with Changesets. Do not write "upcoming release", "unreleased", or speculative future release notes.
+This repo publishes through Changesets; every merge to `main` feeds the version and npm publish workflow.
 
-Agent-facing text is behavior: tool/command names, descriptions, schemas, skill files, `promptSnippet`, `promptGuidelines`, and subagent prompts. Keep it token-efficient and non-verbose.
-
-Skills and extensions must be universal for any user; do not ship hardcoded local paths, personal names, machine-specific assumptions, or private workflow details.
-
-Slash commands are for users, not agents; agents use tools. For extensions with commands, default to one entry command that opens UI or routes subactions (for example `/foo` plus `/foo bar` handling) unless the user explicitly asks for multiple command names.
-
-Installed extensions have real users. Treat related package work from one session as one release unit: consolidate it into one branch and PR before merging; do not create serial PRs for iterative fixes, tests, cleanup, or discoveries from that session. Every `main` merge feeds an npm release users must absorb.
-
-When a change is meant to ship, add a changeset for the package(s). On merge to `main`, the version PR and publish workflow turn that into the next concrete version immediately.
-
-Before opening or updating a PR from long-lived `dev` to `main`, fetch/prune, reset `dev` onto `origin/main`, and cherry-pick only the intended pending commits. Do not merge `main` into `dev`; it leaves already-merged history in the PR.
-
-Use concrete version language only:
-
-- good: `0.0.1 initial release`
-- good: `adds a patch changeset for @howaboua/pi-vent`
-- bad: `upcoming release`
-- bad: `unreleased changes`
-
-For package work, prefer:
-
-```bash
-bun run check:changed
-bun changeset
-```
-
-Do not manually bump aggregate package versions. CI derives aggregate changesets with:
-
-```bash
-bun run changeset:aggregates
-```
+- Agent-facing text is behavior: keep tool contracts, skill files, prompt metadata, and subagent prompts compact.
+- Skills and extensions must work for any user. Never ship local paths, personal names, machine assumptions, or private workflow details.
+- Slash commands are for users; agents use tools. Prefer one routed entry command over several command names unless explicitly requested.
+- Treat related package work from one session as one release unit and one PR. Installed users should not absorb serial cleanup releases.
+- Shipped package changes require a changeset. Use concrete release language; never write “upcoming release”, “unreleased”, or speculative notes.
+- Before a `dev` → `main` PR, fetch/prune, reset `dev` onto `origin/main`, then cherry-pick only intended commits. Never merge `main` into `dev`.
+- Prefer `bun run check:changed` and `bun changeset` for package work.
+- Do not bump aggregate package versions or add their changesets manually; CI runs `bun run changeset:aggregates`.

--- a/README.md
+++ b/README.md
@@ -1,230 +1,70 @@
 # Howaboua Pi Stuff
 
-This is my Pi toolbox: the extensions and skills I use to keep agent sessions moving without building a whole fake operating system around them.
+The Pi extensions and skills I use to keep long agent sessions useful without building a fake operating system around them.
 
-Everything here is still published as separate npm packages. Install the full bundle if you want my setup, or pick the one package you actually need. Revolutionary stuff. A table.
+Everything is published as a separate npm package. Install a bundle for the full setup, or pick only what you need. Revolutionary stuff. A table.
 
-Pi packages run with your local permissions. You can obviously trust me, a stranger on the internet with a folder called `pi-stuff`, but maybe read the package before installing it anyway.
+Pi packages run with your local permissions. You can obviously trust me, a stranger on the internet with a folder called `pi-stuff`, but read the source before installing it anyway.
 
-## Packages
+## Bundles
 
-GitHub does not render proper copy-button codeblocks inside Markdown tables. So you get a long list instead. At least the commands copy cleanly. Or send your clanker here to argue about which ones you actually want.
-
-### Bundles
-
-#### `pi-stuff`
-
-General setup: extensions plus shareable skills. Excludes Codex conversion and Omarchy because those depend on your model/workstation setup.
+| Package | Includes | Deliberate exclusions |
+|---|---|---|
+| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 10 general extensions and 8 shareable skills | Codex conversion and Omarchy support |
+| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 10 general extensions | Codex conversion |
+| [`@howaboua/pi-skills`](./packages/pi-skills) | 8 shareable skills | Omarchy support |
 
 ```bash
 pi install npm:@howaboua/pi-stuff
-```
-
-#### `pi-extensions`
-
-General extension packages. Excludes `pi-codex-conversion`; install that separately if you run Codex/GPT models and want native-tool adaptation.
-
-```bash
+# or
 pi install npm:@howaboua/pi-extensions
-```
-
-#### `pi-skills`
-
-Shareable skill packages. Excludes `omarchy-help` because not everyone is running my kind of desktop setup.
-
-```bash
 pi install npm:@howaboua/pi-skills
 ```
 
-### Extensions
-
-#### `pi-codex-conversion`
-
-Codex-style tools for Pi: `exec_command`, `write_stdin`, `apply_patch`, image tools, native Codex web search, and prompt/tool adaptation.
-
-```bash
-pi install npm:@howaboua/pi-codex-conversion
-```
-
-#### `pi-auto-reasoning-tool`
-
-Gives the agent a `change_reasoning` tool so it can raise/lower reasoning level when the work changes shape.
-
-```bash
-pi install npm:@howaboua/pi-auto-reasoning-tool
-```
-
-#### `pi-auto-trees`
-
-Adds `/marker` and `/end` for long sessions. Set a useful return point, summarize what was accomplished, then keep going.
-
-```bash
-pi install npm:@howaboua/pi-auto-trees
-```
-
-#### `pi-subagent-review`
-
-Adds `/review`, an isolated review subagent that checks the right branch/range and returns findings for the main agent to address.
-
-```bash
-pi install npm:@howaboua/pi-subagent-review
-```
-
-#### `pi-semantic-grep`
-
-Adds `semantic_grep`, a meaning-based code/docs search tool backed by local SQLite indexes and OpenAI-compatible embeddings.
-
-```bash
-pi install npm:@howaboua/pi-semantic-grep
-```
-
-#### `pi-vent`
-
-Adds `vent`, a small tool for logging repeated workflow friction into `VENT.md`.
-
-```bash
-pi install npm:@howaboua/pi-vent
-```
-
-#### `pi-explore-subagents`
-
-Adds `explore_subagent`, discovery-only shallow/deep subagents for reading and summarizing code without editing files.
-
-```bash
-pi install npm:@howaboua/pi-explore-subagents
-```
-
-#### `pi-markdown-workflows`
-
-Adds `/skills`, `/workflows`, workflow capture, `/learn`, and nested `AGENTS.md` context loading.
-
-```bash
-pi install npm:@howaboua/pi-markdown-workflows
-```
-
-#### `pi-smart-btw`
-
-Side-session questions with explicit injection back into the main chat. Useful when you want a tangent without derailing the main thread.
-
-```bash
-pi install npm:@howaboua/pi-smart-btw
-```
-
-#### `pi-memories`
-
-KISS local memory for Pi based on global `AGENTS.md`.
-
-```bash
-pi install npm:@howaboua/pi-memories
-```
-
-### Skills
-
-#### `pi-skill-agent-native-hardening`
-
-Refactor/audit posture for agent-built code: fewer godfiles, clearer ownership, less duplication, better traversability.
-
-```bash
-pi install npm:@howaboua/pi-skill-agent-native-hardening
-```
-
-#### `pi-skill-anti-ai-copy`
-
-Rewrites text so it sounds specific, human, and less like a polite SaaS brochure.
-
-```bash
-pi install npm:@howaboua/pi-skill-anti-ai-copy
-```
-
-#### `pi-skill-chrome-cdp`
-
-Browser inspection/control through Chrome DevTools Protocol. Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local Pi packaging changes.
-
-```bash
-pi install npm:@howaboua/pi-skill-chrome-cdp
-```
-
-#### `pi-skill-gh-issue-pr-flow`
-
-A generic GitHub issue/PR workflow with `gh`, branches, validation, PR bodies, and review triage.
-
-```bash
-pi install npm:@howaboua/pi-skill-gh-issue-pr-flow
-```
-
-#### `pi-skill-agents-md`
-
-Writes, audits, and trims scoped `AGENTS.md` files without turning them into repo summaries.
-
-```bash
-pi install npm:@howaboua/pi-skill-agents-md
-```
-
-#### `pi-skill-model-facing-api-design`
-
-Helps design compact Pi tool names, descriptions, schemas, snippets, and guidelines that models call correctly.
-
-```bash
-pi install npm:@howaboua/pi-skill-model-facing-api-design
-```
-
-#### `pi-skill-project-reference-research`
-
-Looks up external or local repos as reference context, then returns evidence-backed findings.
-
-```bash
-pi install npm:@howaboua/pi-skill-project-reference-research
-```
-
-#### `pi-skill-skill-creator`
-
-Helps design, write, package, and tighten reusable agent skills.
-
-```bash
-pi install npm:@howaboua/pi-skill-skill-creator
-```
-
-#### `pi-skill-omarchy-help`
-
-Generic Arch + Omarchy workstation maintenance. Install separately and customize it for your own machine.
-
-```bash
-pi install npm:@howaboua/pi-skill-omarchy-help
-```
-
-## The workflow
-
-A normal session is not fancy:
-
-1. Start Pi and ask the agent to familiarise itself with the repo, usually with discovery subagents. (`pi-explore-subagents`, `pi-semantic-grep`)
-2. Pull in GitHub issues, or ask the agent to group open issues into something PR-sized. (`pi-skill-gh-issue-pr-flow`)
-3. Use `/marker` once the agent has enough baseline context. (`pi-auto-trees`)
-4. Work on one issue or feature. (`pi-codex-conversion`, `pi-auto-reasoning-tool`)
-5. Run `/review`, fix what is actually worth fixing, then review again if needed. (`pi-subagent-review`)
-6. Open a PR and use external review feedback as another pass. (`pi-skill-gh-issue-pr-flow`)
-7. Do manual QA and try to break the feature. (your eyes, sadly still required)
-8. Use `/end` to summarize what changed and advance the marker. (`pi-auto-trees`)
-9. Continue from the new marker for the next feature. (`pi-auto-trees`)
-10. After larger changes, ask for a hardening pass to modularise the result and remove obvious slop. (`pi-skill-agent-native-hardening`)
-
-The point is not loops, worker swarms, or pretending the agent is magic. It is a few raw Pi sessions, clear context boundaries, review passes, and enough tooling to stop long sessions from turning into archaeology.
-
-For UI work, I usually give the agent a reference frame first: apps to inspect, screenshots, bits of interface I like. The agent builds a mock, then I iterate with browser control, screenshots, and human taste. One-shotting a good frontend is mostly a party trick.
-
-## Other skills I use
-
-A few useful skills are intentionally not in the bundles because they are either very taste-specific, UI/design-specific, or better installed from their own source:
-
-- [`impeccable`](https://github.com/pbakaus/impeccable) by Peter Bakaus: high-quality frontend/interface generation.
-- [`make-interfaces-feel-better`](https://github.com/jakubkrehel/make-interfaces-feel-better) by Jakub Krehel: UI microdetails, interaction polish, spacing, shadows, motion, all the fiddly bits.
-- [`design-md`](https://github.com/google-labs-code/design.md): useful when working with Google Labs’ `DESIGN.md` spec and `@google/design.md` CLI.
-- [`agent-pages`](https://github.com/IgorWarzocha/agent-pages): useful for rich local proposal/report/mockup surfaces, but not something I want to force into the default bundle.
-- [React Grab](https://github.com/aidenybai/react-grab) by Aiden Bai is not a Pi skill here, but it is extremely useful for React UI iteration.
+`pi-codex-conversion` is separate because it changes Pi's tool surface for GPT/Codex models. `omarchy-help` is separate because it targets Arch desktops configured with Omarchy.
+
+## Extensions
+
+| Package | What it adds |
+|---|---|
+| [`pi-auto-reasoning-tool`](./packages/pi-auto-reasoning-tool) | An agent-callable `change_reasoning` tool with the user's selected level as its floor |
+| [`pi-auto-trees`](./packages/pi-auto-trees) | `/marker` and `/end` for rolling completed work into a compact branch summary |
+| [`pi-codex-conversion`](./packages/pi-codex-conversion) | Codex-shaped shell, patch, image, web, and Code Mode tools for GPT/Codex models |
+| [`pi-dynamic-tools`](./packages/pi-dynamic-tools) | TOML-defined command-line tools exposed through JavaScript Code Mode |
+| [`pi-explore-subagents`](./packages/pi-explore-subagents) | Isolated, discovery-only shallow and deep subagents |
+| [`pi-markdown-workflows`](./packages/pi-markdown-workflows) | Workflow/skill UI, `/learn`, workflow capture, and nested `AGENTS.md` loading |
+| [`pi-memories`](./packages/pi-memories) | Shutdown memory candidates in a plain Markdown inbox |
+| [`pi-semantic-grep`](./packages/pi-semantic-grep) | Meaning-based code and docs search backed by repo-local SQLite indexes |
+| [`pi-smart-btw`](./packages/pi-smart-btw) | Async side-session questions with explicit injection into the main chat |
+| [`pi-subagent-review`](./packages/pi-subagent-review) | `/review` through an isolated review subagent |
+| [`pi-vent`](./packages/pi-vent) | Batched notes about repeated workflow friction in `VENT.md` |
+
+## Skills
+
+| Package | Use it for |
+|---|---|
+| [`pi-skill-agent-native-hardening`](./packages/pi-skill-agent-native-hardening) | Architecture reviews and refactors for clearer ownership and safer changes |
+| [`pi-skill-agents-md`](./packages/pi-skill-agents-md) | Creating, auditing, and pruning scoped `AGENTS.md` files |
+| [`pi-skill-anti-ai-copy`](./packages/pi-skill-anti-ai-copy) | Specific, natural prose that preserves the author's voice |
+| [`pi-skill-chrome-cdp`](./packages/pi-skill-chrome-cdp) | Inspecting and controlling a local Chrome-family browser through CDP |
+| [`pi-skill-gh-issue-pr-flow`](./packages/pi-skill-gh-issue-pr-flow) | GitHub issue, branch, PR, release, and review workflows |
+| [`pi-skill-model-facing-api-design`](./packages/pi-skill-model-facing-api-design) | Tool contracts that models select and call correctly |
+| [`pi-skill-project-reference-research`](./packages/pi-skill-project-reference-research) | Evidence-backed research in local or external repositories |
+| [`pi-skill-skill-creator`](./packages/pi-skill-skill-creator) | Creating, auditing, and packaging reusable agent skills |
+| [`pi-skill-omarchy-help`](./packages/pi-skill-omarchy-help) | User-level maintenance for Arch desktops configured with Omarchy |
+
+Pi discovers installed skills automatically and loads them when a task matches. Use `/skill:<name>` when you want to invoke one explicitly.
+
+## How I use it
+
+Map an unfamiliar repo, set `/marker` once the useful context is in place, implement one coherent change, and run `/review`. After triage and QA, `/end` carries the accepted result forward. Broad changes get an `agent-native-hardening` pass.
+
+For UI work, I give the agent references first—apps, screenshots, and interface details I like—then iterate through browser inspection and screenshots. One-shotting a good frontend is mostly a party trick.
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md). Package-level changelogs remain next to their packages where they exist.
+See [CHANGELOG.md](./CHANGELOG.md). Package-level changelogs remain beside packages that have them.
 
 ## License
 
-Individual packages keep their own license files. Current packages are MIT-licensed unless noted in the package directory.
+Individual packages include their own license files. They are MIT-licensed unless noted in the package directory.

--- a/packages/pi-auto-reasoning-tool/README.md
+++ b/packages/pi-auto-reasoning-tool/README.md
@@ -12,7 +12,7 @@ Pi already supports reasoning levels. This package exposes a narrow agent-callab
 
 Agents cannot select `xhigh` or `max`. Users can still select either level themselves, and the extension preserves it.
 
-The prompt is conservative: agents are told to use the tool sparingly and preferably in parallel with other useful tool calls, avoiding standalone reasoning-change turns.
+The prompt tells agents to adjust reasoning by work phase rather than micromanaging individual tool calls.
 
 ## Install
 
@@ -57,29 +57,19 @@ Behavior:
 
 Description:
 
-> Temporarily adjust reasoning up to high without lowering below the user's turn baseline.
+> Adjust reasoning effort for the work ahead.
 
 Prompt snippet:
 
-> Adjust reasoning effort within the user's safe baseline.
+> Adjust reasoning effort.
 
 Guidelines:
 
-> Treat the user's current turn level as the baseline; call only to increase effort for harder work or return after an earlier increase.
-
-> Autonomous choices are low, medium, and high; the extension never lowers below the user baseline or selects xhigh/max.
-
-> Use change_reasoning sparingly; avoid standalone calls when another useful tool call can run in parallel.
-
-> Use medium for complex single tasks, feature planning, or multi-step implementation.
-
-> Use high for multi-area architecture work, hard debugging, or unexpectedly difficult tasks.
+> change_reasoning: Adjust by work phase, not per tool call.
 
 Parameter:
 
-`level`
-
-> Reasoning level to use for this task: low, medium, or high.
+`level: low | medium | high`
 
 ## Development
 

--- a/packages/pi-auto-reasoning-tool/README.md
+++ b/packages/pi-auto-reasoning-tool/README.md
@@ -1,18 +1,6 @@
-# pi-auto-reasoning-tool
+# @howaboua/pi-auto-reasoning-tool
 
-A small [Pi](https://pi.dev) package that lets agents adjust their own reasoning level with a `change_reasoning` tool.
-
-The tool is intentionally minimal: the agent chooses `low`, `medium`, or `high`. The user's level at the start of the turn is the floor, so an agent can spend more effort but cannot quietly reduce a user-selected `high`, `xhigh`, or `max` level.
-
-Pi restores the original level after the full run settles, including retries, overflow compaction, and queued continuations.
-
-## Why
-
-Pi already supports reasoning levels. This package exposes a narrow agent-callable tool so the agent can raise its budget when work becomes harder, return after an earlier increase, and then hand control back to the user's baseline.
-
-Agents cannot select `xhigh` or `max`. Users can still select either level themselves, and the extension preserves it.
-
-The prompt tells agents to adjust reasoning by work phase rather than micromanaging individual tool calls.
+Adds an agent-callable `change_reasoning` tool. The agent may raise its reasoning effort when the work gets harder, but the user's level at the start of the turn remains the minimum.
 
 ## Install
 
@@ -20,71 +8,25 @@ The prompt tells agents to adjust reasoning by work phase rather than micromanag
 pi install npm:@howaboua/pi-auto-reasoning-tool
 ```
 
-Or add it to your Pi settings:
+## Behavior
 
-```json
-{
-  "packages": ["npm:@howaboua/pi-auto-reasoning-tool"]
-}
+The tool accepts one parameter:
+
+```ts
+change_reasoning({ level: "low" | "medium" | "high" })
 ```
 
-Then restart Pi or run `/reload`.
+- Requests below the user's turn baseline keep the baseline.
+- Users may select `xhigh` or `max`; agents cannot select those levels or lower them.
+- Pi may clamp a requested level when the current model does not support it. The result reports the applied level.
+- After the full agent run settles—including retries, compaction recovery, and queued follow-ups—the extension restores the user's turn baseline.
 
-## Tool
+The model guidance asks agents to change reasoning by work phase, not around individual tool calls.
 
-Registers one tool:
-
-```text
-change_reasoning
-```
-
-Parameters:
-
-```text
-level: low | medium | high
-```
-
-Behavior:
-
-1. Agent chooses `level`.
-2. Extension keeps the higher of the requested level and the user's turn baseline.
-3. Extension calls `pi.setThinkingLevel()` with that safe level.
-4. Tool result reports the requested, previous, baseline, and applied levels.
-5. If Pi clamps the level because of model capability, the result says so.
-6. On `agent_settled`, the extension restores the original baseline.
-
-## Agent-facing prompt copy
-
-Description:
-
-> Adjust reasoning effort for the work ahead.
-
-Prompt snippet:
-
-> Adjust reasoning effort.
-
-Guidelines:
-
-> change_reasoning: Adjust by work phase, not per tool call.
-
-Parameter:
-
-`level: low | medium | high`
-
-## Development
+## Local development
 
 ```bash
-npm install
-npm run check
+bun install
+bun run check
 pi -e ./src/index.ts
 ```
-
-## Publish
-
-```bash
-npm publish --access public
-```
-
-## License
-
-MIT

--- a/packages/pi-auto-reasoning-tool/src/index.ts
+++ b/packages/pi-auto-reasoning-tool/src/index.ts
@@ -36,34 +36,50 @@ export function applyReasoningFloor(
 
 function formatModelNote(
 	ctx: ExtensionContext,
-	requestedLevel: ToolReasoningLevel,
 	appliedLevel: AppliedReasoningLevel,
 	effectiveLevel: AppliedReasoningLevel,
-	baselineLevel: AppliedReasoningLevel,
 ): string | undefined {
-	const notes: string[] = [];
-	if (effectiveLevel !== requestedLevel)
-		notes.push(
-			`Kept the user-selected ${baselineLevel} baseline instead of lowering it to ${requestedLevel}.`,
-		);
 	if (!ctx.model) {
-		notes.push(
-			"No model is selected yet; Pi may clamp this level after a model is selected.",
-		);
-		return notes.join("\n");
+		return "No model selected; Pi may clamp this level later.";
 	}
 	if (!ctx.model.reasoning && appliedLevel === "off") {
-		notes.push(
-			`Current model ${ctx.model.provider}/${ctx.model.id} does not advertise reasoning support, so Pi clamped the level to off.`,
-		);
-		return notes.join("\n");
+		return `Pi clamped reasoning to off: ${ctx.model.provider}/${ctx.model.id} does not advertise reasoning support.`;
 	}
 	if (effectiveLevel !== appliedLevel) {
-		notes.push(
-			`Pi clamped ${effectiveLevel} to ${appliedLevel} for ${ctx.model.provider}/${ctx.model.id}.`,
-		);
+		return `Pi clamped ${effectiveLevel} to ${appliedLevel} for ${ctx.model.provider}/${ctx.model.id}.`;
 	}
-	return notes.length > 0 ? notes.join("\n") : undefined;
+	return undefined;
+}
+
+function formatSelection(
+	requestedLevel: ToolReasoningLevel,
+	appliedLevel: AppliedReasoningLevel,
+	previousLevel: AppliedReasoningLevel,
+	baselineLevel: AppliedReasoningLevel,
+): string[] {
+	const requestedBelowBaseline =
+		REASONING_LEVELS.indexOf(requestedLevel) <
+		REASONING_LEVELS.indexOf(baselineLevel);
+	if (requestedBelowBaseline) {
+		return [
+			previousLevel === appliedLevel
+				? `Reasoning remains ${appliedLevel}.`
+				: `Reasoning: ${previousLevel} → ${appliedLevel}.`,
+			`The user set the minimum reasoning level to ${baselineLevel}; do not go below it.`,
+		];
+	}
+	if (requestedLevel === previousLevel && previousLevel === appliedLevel) {
+		return [
+			previousLevel === baselineLevel
+				? `Reasoning is already ${appliedLevel}, the user's preferred minimum.`
+				: `Reasoning is already ${appliedLevel}.`,
+		];
+	}
+	return [
+		previousLevel === appliedLevel
+			? `Reasoning remains ${appliedLevel}.`
+			: `Reasoning: ${previousLevel} → ${appliedLevel}.`,
+	];
 }
 
 export default function autoReasoningSelector(pi: ExtensionAPI) {
@@ -73,20 +89,13 @@ export default function autoReasoningSelector(pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "change_reasoning",
 		label: "Change Reasoning",
-		description:
-			"Temporarily adjust reasoning up to high without lowering below the user's turn baseline.",
-		promptSnippet: "Adjust reasoning effort within the user's safe baseline.",
+		description: "Adjust reasoning effort for the work ahead.",
+		promptSnippet: "Adjust reasoning effort.",
 		promptGuidelines: [
-			"change_reasoning: Treat the user's current turn level as the baseline; call only to increase effort for harder work or return after an earlier increase.",
-			"change_reasoning: Autonomous choices are low, medium, and high; the extension never lowers below the user baseline or selects xhigh/max.",
-			"change_reasoning: Use sparingly; avoid standalone calls when another useful tool call can run in parallel.",
-			"change_reasoning: Use medium for complex single tasks, feature planning, or multi-step implementation.",
-			"change_reasoning: Use high for multi-area architecture work, hard debugging, or unexpectedly difficult tasks.",
+			"change_reasoning: Adjust by work phase, not per tool call.",
 		],
 		parameters: Type.Object({
-			level: StringEnum(TOOL_REASONING_LEVELS, {
-				description: "low | medium | high",
-			}),
+			level: StringEnum(TOOL_REASONING_LEVELS),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const baselineLevel = turnBaselineReasoningLevel ?? pi.getThinkingLevel();
@@ -102,21 +111,18 @@ export default function autoReasoningSelector(pi: ExtensionAPI) {
 				baselineLevel,
 			};
 
-			const note = formatModelNote(
-				ctx,
-				params.level,
-				appliedLevel,
-				effectiveLevel,
-				baselineLevel,
-			);
+			const note = formatModelNote(ctx, appliedLevel, effectiveLevel);
 			return {
 				content: [
 					{
 						type: "text",
 						text: [
-							`Reasoning level: ${previousLevel} → ${appliedLevel}${params.level !== appliedLevel ? ` (requested ${params.level})` : ""}.`,
-							`Turn baseline: ${baselineLevel}.`,
-							"The new level applies to subsequent model calls.",
+							...formatSelection(
+								params.level,
+								appliedLevel,
+								previousLevel,
+								baselineLevel,
+							),
 							note,
 						]
 							.filter(Boolean)

--- a/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
+++ b/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
@@ -34,10 +34,6 @@ function setup(initialLevel: ThinkingLevel) {
 	};
 }
 
-function resultText(result: any): string {
-	return result.content[0].text;
-}
-
 describe("reasoning floor", () => {
 	test("never lowers below the user's baseline", () => {
 		expect(applyReasoningFloor("medium", "high")).toBe("high");
@@ -71,59 +67,5 @@ describe("reasoning floor", () => {
 		expect(state.level).toBe("medium");
 		await state.handler("agent_settled")({}, {});
 		expect(state.level).toBe("medium");
-	});
-
-	test("keeps the agent-facing contract terse", () => {
-		const tool = setup("low").tool();
-		expect(tool.description).toBe(
-			"Adjust reasoning effort for the work ahead.",
-		);
-		expect(tool.promptSnippet).toBe("Adjust reasoning effort.");
-		expect(tool.promptGuidelines).toEqual([
-			"change_reasoning: Adjust by work phase, not per tool call.",
-		]);
-		expect(tool.parameters.properties.level.description).toBeUndefined();
-	});
-
-	test("explains the user minimum when a request goes below it", async () => {
-		const state = setup("medium");
-		await state.handler("before_agent_start")({}, {});
-		const result = await state
-			.tool()
-			.execute("call", { level: "low" }, undefined, undefined, {
-				model: { provider: "openai", id: "test", reasoning: true },
-			});
-		expect(resultText(result)).toBe(
-			"Reasoning remains medium.\nThe user set the minimum reasoning level to medium; do not go below it.",
-		);
-	});
-
-	test("identifies the user's preferred minimum when already selected", async () => {
-		const state = setup("medium");
-		await state.handler("before_agent_start")({}, {});
-		const result = await state
-			.tool()
-			.execute("call", { level: "medium" }, undefined, undefined, {
-				model: { provider: "openai", id: "test", reasoning: true },
-			});
-		expect(resultText(result)).toBe(
-			"Reasoning is already medium, the user's preferred minimum.",
-		);
-	});
-
-	test("does not mislabel an elevated level as the user minimum", async () => {
-		const state = setup("medium");
-		await state.handler("before_agent_start")({}, {});
-		await state
-			.tool()
-			.execute("call", { level: "high" }, undefined, undefined, {
-				model: { provider: "openai", id: "test", reasoning: true },
-			});
-		const result = await state
-			.tool()
-			.execute("call", { level: "high" }, undefined, undefined, {
-				model: { provider: "openai", id: "test", reasoning: true },
-			});
-		expect(resultText(result)).toBe("Reasoning is already high.");
 	});
 });

--- a/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
+++ b/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
@@ -34,6 +34,10 @@ function setup(initialLevel: ThinkingLevel) {
 	};
 }
 
+function resultText(result: any): string {
+	return result.content[0].text;
+}
+
 describe("reasoning floor", () => {
 	test("never lowers below the user's baseline", () => {
 		expect(applyReasoningFloor("medium", "high")).toBe("high");
@@ -67,5 +71,59 @@ describe("reasoning floor", () => {
 		expect(state.level).toBe("medium");
 		await state.handler("agent_settled")({}, {});
 		expect(state.level).toBe("medium");
+	});
+
+	test("keeps the agent-facing contract terse", () => {
+		const tool = setup("low").tool();
+		expect(tool.description).toBe(
+			"Adjust reasoning effort for the work ahead.",
+		);
+		expect(tool.promptSnippet).toBe("Adjust reasoning effort.");
+		expect(tool.promptGuidelines).toEqual([
+			"change_reasoning: Adjust by work phase, not per tool call.",
+		]);
+		expect(tool.parameters.properties.level.description).toBeUndefined();
+	});
+
+	test("explains the user minimum when a request goes below it", async () => {
+		const state = setup("medium");
+		await state.handler("before_agent_start")({}, {});
+		const result = await state
+			.tool()
+			.execute("call", { level: "low" }, undefined, undefined, {
+				model: { provider: "openai", id: "test", reasoning: true },
+			});
+		expect(resultText(result)).toBe(
+			"Reasoning remains medium.\nThe user set the minimum reasoning level to medium; do not go below it.",
+		);
+	});
+
+	test("identifies the user's preferred minimum when already selected", async () => {
+		const state = setup("medium");
+		await state.handler("before_agent_start")({}, {});
+		const result = await state
+			.tool()
+			.execute("call", { level: "medium" }, undefined, undefined, {
+				model: { provider: "openai", id: "test", reasoning: true },
+			});
+		expect(resultText(result)).toBe(
+			"Reasoning is already medium, the user's preferred minimum.",
+		);
+	});
+
+	test("does not mislabel an elevated level as the user minimum", async () => {
+		const state = setup("medium");
+		await state.handler("before_agent_start")({}, {});
+		await state
+			.tool()
+			.execute("call", { level: "high" }, undefined, undefined, {
+				model: { provider: "openai", id: "test", reasoning: true },
+			});
+		const result = await state
+			.tool()
+			.execute("call", { level: "high" }, undefined, undefined, {
+				model: { provider: "openai", id: "test", reasoning: true },
+			});
+		expect(resultText(result)).toBe("Reasoning is already high.");
 	});
 });

--- a/packages/pi-auto-trees/README.md
+++ b/packages/pi-auto-trees/README.md
@@ -1,107 +1,41 @@
 # @howaboua/pi-auto-trees
 
-`@howaboua/pi-auto-trees` is a small [Pi](https://github.com/badlogic/pi-mono) package for long-running coding sessions.
+Adds two commands for carrying useful context through long Pi sessions without keeping every dead end and debugging turn.
 
-It helps you keep one session going without dragging all the implementation noise forward forever.
-
-## What it does
-
-### `/marker`
-Marks the current point in the conversation as your checkpoint.
-
-This is useful after repo familiarization, exploration, planning, or any other point you want to return to later.
-
-### `/end`
-Summarizes the work done since the last `/marker`, jumps back to that checkpoint, and carries the result forward as a compact branch summary.
-
-The marker is then advanced to the new summarized point, so you can keep working in increments.
-
-## Why this is useful
-
-A common Pi workflow looks like this:
-
-1. Explore a repo
-2. Make a plan
-3. Mark that point with `/marker`
-4. Implement a feature, fix bugs, open a PR, iterate
-5. Run `/end`
-
-After `/end`, you keep the useful context:
-- repo understanding
-- planning context
-- accepted outcome of the work
-
-And you drop the noisy context:
-- dead ends
-- temporary debugging
-- incidental churn
-
-So the session stays usable for much longer.
-
-## `/end` modes
-
-### `/end`
-Uses the extension's default summary behavior, tuned for completed work increments.
-
-### `/end git`
-Uses the default summary behavior and also asks the summary to capture the git commit that should be made for the completed changes.
-
-### `/end full`
-Uses Pi's normal branch-summary prompt.
-
-### `/end <custom prompt>`
-Adds your own focus instructions for the summary.
-
-Examples:
-
-- `/end focus on API changes and migration notes`
-- `/end focus on reviewer feedback and follow-up risks`
-
-## Install from npm
-
-Install it as a Pi package:
+## Install
 
 ```bash
 pi install npm:@howaboua/pi-auto-trees
 ```
 
-Or try it for one session without adding it to your settings:
+Try it for one session:
 
 ```bash
 pi -e npm:@howaboua/pi-auto-trees
 ```
 
-Then use `/marker` and `/end` inside Pi.
+## Usage
+
+1. Run `/marker` after repo exploration, planning, or another stable checkpoint.
+2. Complete a coherent chunk of work.
+3. Run `/end`.
+
+`/end` summarizes the branch since the marker, navigates back to that point, carries the summary forward, and advances the marker to the new compact point. The summary keeps accepted changes, decisions, constraints, and relevant follow-up while dropping temporary implementation noise.
+
+### `/end` modes
+
+- `/end` — use the extension's completed-work summary guidance
+- `/end git` — also capture the commit that should be made
+- `/end full` — use Pi's normal branch-summary prompt
+- `/end <guidance>` — add a custom focus, for example `/end focus on API changes and migration notes`
+
+The marker is stored in the session branch and restored when you return to it. Existing labels are preserved if the checkpoint already has one.
 
 ## Local development
 
-Add the extension path to your Pi settings or launch Pi with it directly:
-
 ```bash
-pi --extension ./index.ts
+bun install
+bun run check
+bun run pack:dry
+pi -e ./index.ts
 ```
-
-Validate the package before publishing:
-
-```bash
-npm install
-npm run typecheck
-npm run pack:dry-run
-```
-
-Publish as a public scoped npm package:
-
-```bash
-npm publish --access public
-```
-
-`publishConfig.access` is already set to `public`, so plain `npm publish` also publishes with public access when your npm account can publish under the `@howaboua` scope.
-
-## Result
-
-You get an incremental workflow inside a single Pi session:
-
-- mark a stable point
-- do a chunk of work
-- roll it back into durable context
-- continue from there

--- a/packages/pi-codex-conversion/AGENTS.md
+++ b/packages/pi-codex-conversion/AGENTS.md
@@ -1,14 +1,7 @@
-# pi-codex-conversion rules
-
-- Goal: make Pi behave as close as practical to Codex's toolkit.
-- Reference Codex repo for comparisons: `/home/igorw/Frameworks/codex`.
-- When explicitly preparing npm/publish/release/merge, compare `src/providers/openai-codex-custom-provider.ts` against Pi's stock `openai-codex-responses` provider.
-- Compatibility pass covers request shape, transport/headers, reasoning/service-tier handling, retry/stream terminal semantics, and touched code.
-- PATH mode structured tool surface is only `exec_command` + `write_stdin`; Codex extras live on PATH.
-- PATH tools: `apply_patch`, `view_image`, `web_run`, `imagegen`.
-- PATH tool build notes live in `PATH_TOOLS.md`.
-- For `GLIBC_* not found`, loader errors, `exec_bridge` startup failures, or bundled binary incompatibility: read `PATH_TOOLS.md`, rebuild the failing local-platform binary, and wire Pi to the checkout instead of patching installed npm files.
-- Vendored apply-patch engine, path-uri, and absolute-path Rust sources track one Codex commit exactly. Pi-owned boundaries are `standalone_executable.rs` for structured output and the small `pi-apply-patch-fs` local filesystem adapter; do not fork other upstream files.
-- Keep prompt guidance short and argv-shaped. Normal mode uses flat TS tools; PATH mode uses shell commands.
-- Call out intentional divergences: PATH web/image tools are local wrappers around Codex-backed requests, not provider-native function tools.
-- Do not accept review-bot drift from stock Pi behavior unless backend-verified or intentional.
+- Keep Pi behavior as close as practical to the Codex toolkit; document intentional differences.
+- Before npm, publish, release, or merge work, compare `src/providers/openai-codex-custom-provider.ts` with Pi's stock `openai-codex-responses` provider: request shape, transport/headers, reasoning/service tier, retry, stream termination, and touched behavior.
+- Normal mode uses flat TypeScript tools. PATH mode exposes only `exec_command` and `write_stdin` as structured tools; Codex extras run from PATH.
+- Keep prompt guidance short and argv-shaped.
+- Read `PATH_TOOLS.md` for PATH tool builds and binary failures. Rebuild for the local platform and use the checkout; never patch installed npm files.
+- Vendored apply-patch engine, path-uri, and absolute-path sources track one Codex commit. Pi-owned changes belong only in `standalone_executable.rs` and the `pi-apply-patch-fs` adapter.
+- Do not accept review-driven drift from stock Pi behavior unless backend-verified or intentional.

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -1,13 +1,6 @@
-# pi-codex-conversion
+# @howaboua/pi-codex-conversion
 
-> [!NOTE]
-> This version is a major rewrite. If you hit regressions, reinstall the last pre-rewrite build with `pi install npm:@howaboua/pi-codex-conversion@1.5.21` and please report the issue.
-
-GPT/Codex models are strongest when the tool surface looks like the Codex CLI they were trained around: shell commands, resumable terminal sessions, and patch-based edits. This extension brings that workflow to Pi while keeping Pi's runtime, sessions, project context, skills, and UI. For the brave, PATH mode shifts the toolkit into Pi's internal PATH, instead of the JSON-defined tool schema.
-
-Tool execution uses bundled Rust helpers for better process isolation and lower Pi runtime blast radius; see [Why bundled Rust tools?](#why-bundled-rust-tools). PATH mode exposes extra Codex tools as shell commands on an extension-injected internal PATH; see [PATH_TOOLS.md](./PATH_TOOLS.md).
-
-PATH mode is very likely to consume less tokens, but YMMV. The system prompt has been tweaked to enable GPT models to one-shot call tools, even when they don't have a JSON schema definition. Any suggestions or tweaks are welcome! The whole point is that if the agent fails a tool call because it "didn't know the tool", this mode loses its advantages. It's been tested and it's working, but edge cases may still exist.
+Adapts Pi's tools and prompt for GPT/Codex models. It keeps Pi's sessions, project context, skills, and UI while presenting the shell, patch, image, and web operations those models expect.
 
 ## Install
 
@@ -15,103 +8,62 @@ PATH mode is very likely to consume less tokens, but YMMV. The system prompt has
 pi install npm:@howaboua/pi-codex-conversion
 ```
 
-## What changes in Pi
+Requires Node.js 22.19 or newer. Native helpers are bundled. The adapter activates for OpenAI `gpt*` and `codex*` models and restores Pi's previous tools when you switch away.
 
-- Adapter mode activates automatically for OpenAI `gpt*` and `codex*` models, then restores the previous tool set when you switch away.
-- Pi's composed prompt is preserved; the extension only adds a small Codex-style tool-use nudge.
-- Shell activity is rendered with Codex-like labels such as `Ran`, `Explored`, `Read`, and background-terminal status.
-- PATH image outputs from `view_image` and `imagegen` render inline in chat.
-- Raw command output is still available by expanding the tool result.
+## Tool modes
 
-## Active tools in adapter mode
+### Normal mode
 
-Normal mode keeps the familiar Pi function-tool surface:
+Normal mode exposes Codex-shaped Pi tools:
 
-- `exec_command` — shell execution with Codex-style `cmd` parameters and resumable sessions
-- `write_stdin` — continue or poll a running exec session
-- `apply_patch` — patch edits through the bundled Rust patch tool
-- `view_image` — inspect local images through the bundled Rust image tool when the model supports image input
-- `web_run` — Codex-backed web search through the bundled Rust web tool when enabled and supported
-- `imagegen` — Codex-backed image generation and image edits through the bundled Rust image generation tool when enabled and supported
+- `exec_command` — shell execution with resumable sessions and optional PTY support
+- `write_stdin` — poll or interact with a running shell session
+- `apply_patch` — patch-based file edits
+- `view_image` — local image inspection when the model supports image input
+- `web_run` — Codex-backed web search when enabled and supported
+- `imagegen` — Codex-backed image generation and editing when enabled and supported
 
-PATH mode narrows the structured tool surface to shell control only:
+There is no separate text `read`, `edit`, or `write` tool. Use `exec_command` for file inspection and `apply_patch` for edits.
 
-- `exec_command` — shell execution with Codex-style `cmd` parameters and resumable sessions
-- `write_stdin` — continue or poll a running exec session
+### PATH mode
 
-GPT-5.6 Code Mode, available as an opt-in beta for Luna, Terra, and Sol, narrows the provider-visible surface further:
+PATH mode exposes only `exec_command` and `write_stdin` as structured adapter tools. `apply_patch`, `view_image`, `web_run`, and `imagegen` become commands on an extension-injected internal `PATH`.
 
-- `exec` — run isolated JavaScript that composes nested tools
-- `wait` — resume or terminate a yielded JavaScript cell
-
-Inside `exec`, Codex extras are nested native calls: `tools.apply_patch(patch)`, `tools.view_image(...)`, `tools.web__run(...)`, and `tools.image_gen__imagegen(...)`. `tools.exec_command(...)` and `tools.write_stdin(...)` use the same shell implementation as normal and PATH modes. Only outer `exec` and `wait` reach the provider, so nested schemas remain local to the V8 host. TOML tools from `~/.pi/agent/codex-conversion-custom-tools/` remain callable through `tools.*`; definitions are deferred by default and can be promoted with `defer_loading = false`. Working opt-in templates ship under `examples/custom-tools/`.
-
-Nested calls retain their structured Pi rendering—shell summaries, parallel outputs, patch diffs, resumable sessions, web/image results, partial updates, and generic TOML-tool output—without exposing extra provider tools.
-
-By default, Code Mode keeps the JavaScript machinery transparent and renders nested operations like direct Pi tools. Turn on **Code Mode details** for the outer `exec`/`wait` cells, expandable JavaScript, and printed runtime output. **Tool renaming** independently controls whether nested operations use polished Codex-style cells or their generic tool names.
-
-### Code Mode custom tools
-
-Put custom tool definitions in `~/.pi/agent/codex-conversion-custom-tools/`, or under `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/` when configured. Each top-level TOML filename becomes a method on `tools`. Definitions stay deferred unless they set `defer_loading = false`.
-
-The package includes disabled templates under `examples/custom-tools/` for `port_info`, `semantic_grep`, `spawn_agent`, `vent`, and `workflows_create`. To enable one, copy its TOML and matching companion directory into the custom-tools directory without changing their relative layout. Installing the package does not enable any example.
-
-In PATH mode, Codex-style extras live on the extension-injected internal PATH:
-
-- `apply_patch` — patch edits
-- `view_image` — inspect local images
-- `web_run` — Codex-backed web search
-- `imagegen` — Codex-backed image generation and image edits
-
-Notably:
-
-- there is **no** dedicated `read`, `edit`, or `write` tool in adapter mode
-- local text-file inspection should happen through `exec_command`
-- file creation and edits should default to `apply_patch`; in PATH mode that is the shell command
-- in PATH mode, image/web tools run through `exec_command` as PATH tools, not Pi function tools
-- Pi may still expose additional runtime tools such as `parallel`; the prompt is written to tolerate that
-
-## PATH mode examples
-
-These commands run inside `exec_command` when PATH mode is enabled.
+Run them inside `exec_command`:
 
 ```bash
 view_image '{"path":"/x.png"}'
 web_run '{"search_query":[{"q":"..."}],"response_length":"short"}'
 imagegen '{"prompt":"..."}'
-imagegen '{"action":"edit","prompt":"...","images":["https://... or /x.png"]}'
+imagegen '{"action":"edit","prompt":"...","images":["/x.png"]}'
 ```
 
-For quote-heavy JSON, pass JSON through stdin:
+Generated images are saved under `.pi/openai-codex-images/` at the workspace root, with the newest image mirrored to `latest.png`.
 
-```bash
-imagegen <<'JSON'
-{"prompt":"keep the creature's original style"}
-JSON
+### GPT-5.6 Code Mode
+
+Code Mode is an opt-in beta for OpenAI Codex Luna, Terra, and Sol. Only `exec` and `wait` reach the provider. `exec` composes nested tools locally:
+
+```js
+const status = await tools.exec_command({ cmd: "git status --short" });
+text(status);
 ```
 
-Generated images are saved under `.pi/openai-codex-images/` at the workspace/repo root, with the latest image mirrored to `latest.png`.
+Nested `apply_patch`, `view_image`, `web__run`, `image_gen__imagegen`, `exec_command`, and `write_stdin` calls keep normal Pi rendering without exposing their schemas to the provider. The first `exec` downloads and verifies the pinned V8 host.
+
+## Code Mode custom tools
+
+Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/`, or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`. Each filename becomes a method on `tools`.
+
+Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Disabled examples for `port_info`, `semantic_grep`, `spawn_agent`, `vent`, and `workflows_create` ship under `examples/custom-tools/`.
 
 ## Settings
 
-Use `/codex` to change adapter settings.
+Open `/codex` for the full settings UI. Settings are saved in `~/.pi/agent/pi-codex-conversion.json`.
 
-- `/codex all` — use the Codex tool and prompt adapter on every model
-- `/codex status` — toggle the footer/statusline entry
-- `/codex fast` — toggle priority service tier for the OpenAI Codex provider
-- `/codex compact` — open native compaction settings
-- `/codex usage` — show Codex subscription usage windows for the active OpenAI Codex model
-- `/codex reset` — open the Usage tab, where banked rate-limit resets can be used with Ctrl+R
-- `/codex low`, `/codex medium`, `/codex high` — set Responses API verbosity
-- `/codex ps` — show the background shell widget
+Direct routes include `/codex all` (cycle full adapter, extra tools only, and off), `/codex fast`, `/codex compact`, `/codex usage`, `/codex reset`, `/codex low|medium|high`, and `/codex ps` for background shells.
 
-Settings are saved globally in `~/.pi/agent/pi-codex-conversion.json`.
-
-The settings UI has **General**, **Tools**, **OpenAI**, **Beta**, **Usage**, and **About** tabs. **Usage** refreshes automatically when opened, can be refreshed manually with `R`, and shows banked Codex rate-limit resets with their expiry above the usage windows. When resets are available, press `Ctrl+R` in the Usage tab to use one. After a reset attempt, press `R` before using another reset.
-
-**General** controls PATH mode, scope, status UI, background shells, and whether native Responses compaction is enabled. Native compaction applies to OpenAI Codex and explicitly added providers; all-model scope only changes the tool and prompt adapter. PATH mode switches the adapter to the shell-only surface above.
-
-Advanced users with custom Codex-compatible providers can add provider ids in General, or by editing `~/.pi/agent/pi-codex-conversion.json`:
+To adapt an additional Codex-compatible provider without enabling all-model scope:
 
 ```json
 {
@@ -121,62 +73,25 @@ Advanced users with custom Codex-compatible providers can add provider ids in Ge
 }
 ```
 
-**Tools** shows required adapter behavior and optional web/image/apply-patch prompt features. General settings control tool renaming, compact tools, Code Mode details, and the background shell widget. **OpenAI** controls fast mode, verbosity, cached WebSocket upgrade, web search model, and compaction model/reasoning. Cached WebSockets are prewarmed at session startup. Web search and compaction default to `gpt-5.6-luna`.
+Native compaction applies to OpenAI Codex and providers listed in `additionalProviders`; the built-in OpenAI Responses endpoint is supported when added. Failed endpoint requests and invalid compaction outputs fall back to Pi's normal compaction. Unsupported preparation or compatibility states cancel compaction and report the error instead of silently discarding context.
 
-**Beta** contains GPT-5.6 Code Mode, off by default and limited to OpenAI Codex Luna, Terra, and Sol. It atomically enables Codex's Responses Lite transport and code-mode-only toolkit: instructions and client tools become input items, `exec` and `wait` are the only provider-visible tools, and JavaScript restores parallel composition through nested calls. The same Responses Lite transport applies to native compaction.
+Process control, PTYs, patching, images, and large outputs run through bundled Rust helpers, so failures normally become tool errors instead of crashing Pi. PATH image results render inline; recognized `web_run` and `imagegen` calls wait up to one hour before becoming resumable.
 
-Maintainers: see [`UPSTREAM_SYNC.md`](UPSTREAM_SYNC.md) for the provider parity checklist and intentional exclusions.
+## Binary compatibility
 
-The footer shows the active state, for example:
-
-```text
-Codex adapter V: low • fast
-```
-
-## Why bundled Rust tools?
-
-The bundled tools are not only for Codex-shaped PATH mode. They also reduce the blast radius of heavy tool work.
-
-If a Pi-native TypeScript tool allocates too much memory, blocks the runtime, or crashes badly, it can take the Pi process with it. When a bundled Rust tool fails, it usually fails as a child process: TypeScript reports a tool error, Pi stays alive, and the agent can retry or choose another path.
-
-That matters most for process control, PTYs, patch application, image handling, and large command outputs. TypeScript still owns the Pi-facing parts: JSON schemas, model/auth gating, result conversion, rendering, and deciding what enters chat history.
-
-## Details worth knowing
-
-- `exec_command` and `write_stdin` use a bundled Rust exec bridge; `tty: true` runs through a PTY for interactive commands.
-- GPT-5.6 Code Mode starts its isolated V8 host lazily; the first `exec` downloads and verifies the pinned host binary when needed.
-- PATH mode prepends the package `bin` directory to exec session `PATH` so bundled Codex tools are available in shell commands.
-- `imagegen` waits up to five minutes in a foreground `exec_command` call before falling back to a resumable session.
-- The package includes bundled binaries and vendored Rust source for the PATH tools.
-- If native compaction fails, the extension falls back to Pi's normal compaction flow. When an older native compacted window exists, it is included in that Pi fallback summarization request so OpenAI can still use the prior opaque context server-side.
-
-## Command rendering examples
-
-- `rg -n foo src` -> `Explored / Search foo in src`
-- `rg --files src | head -n 50` -> `Explored / List src`
-- `cat README.md` -> `Explored / Read README.md`
-- `npm test` -> `Ran npm test`
-- `write_stdin({ session_id, chars: "" })` -> `Waited for background terminal`
-- `write_stdin({ session_id, chars: "y\n" })` -> `Interacted with background terminal`
-
-## Development checkout
-
-The Git checkout is mostly for development and mirrors the maintainer workflow. It uses committed binaries; rebuild local-platform binaries only after changing Rust source.
-
-Published installs include prebuilt native binaries. For best compatibility on older Linux systems, or if a bundled tool fails with a loader error such as `GLIBC_2.39 not found`, use a Git checkout and build the tools on that machine instead of upgrading glibc manually:
+If a published binary fails with `GLIBC_* not found`, a loader error, or an `exec_bridge` startup failure, use a checkout and rebuild that helper on the target machine rather than changing system glibc or patching the installed package:
 
 ```bash
-cd /path/to/pi-codex-conversion
+git clone https://github.com/IgorWarzocha/howaboua-pi-stuff.git
+cd howaboua-pi-stuff
 bun install
-bun run build:path-tool codex-exec-shim exec_bridge
+bun run --cwd packages/pi-codex-conversion build:path-tool codex-exec-shim exec_bridge
+bun run --cwd packages/pi-codex-conversion build
+pi --no-extensions --no-skills -e ./packages/pi-codex-conversion
 ```
 
-Run the current checkout without installing globally:
-
-```bash
-pi --no-extensions --no-skills -e /path/to/pi-codex-conversion
-```
+See [`PATH_TOOLS.md`](./PATH_TOOLS.md) for helper details and [`UPSTREAM_SYNC.md`](./UPSTREAM_SYNC.md) for provider and vendored-source parity.
 
 ## License
 
-MIT
+MIT. Bundled and vendored third-party components retain their own licenses and notices.

--- a/packages/pi-codex-conversion/src/tools/code-mode/AGENTS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/AGENTS.md
@@ -1,9 +1,6 @@
-# Code mode runtime
-
-- This is a self-contained copy of the Pi-owned code-mode bridge from `pi-dynamic-tools`; do not add a runtime dependency on that extension package.
-- Keep the copied runtime behavior aligned deliberately, but conversion-specific activation and nested tools belong outside this directory.
-- Codex host source and protocol remain pinned under `code-mode/vendor/code-mode-src/`.
-- `host-client.ts` owns process/session transport; `host-protocol.ts` validates wire data; `delegate-runtime.ts` owns nested execution; `trace-*` owns bounded trace state.
-- `tools.ts` is the registration entrypoint; `shared-runtime.ts`, `public-tools.ts`, and `tool-events.ts` own provider state, Pi tools, and hooks respectively.
-- `custom-tools.ts`, `custom-tool-runner.ts`, and `custom-tool-prompt.ts` own TOML discovery, delegated commands, and prompt guidance.
-- `tool-result.ts`, `render-tracker.ts`, and `rendering.ts` own their respective output boundaries.
+- Keep this runtime self-contained; do not add a dependency on `pi-dynamic-tools`.
+- Conversion-specific activation and nested tool definitions stay outside this directory.
+- Codex host source stays pinned under `vendor/code-mode-src/`; keep Pi-owned changes outside its upstream source tree.
+- `host-client.ts` owns process/session transport; `host-protocol.ts` wire validation; `delegate-runtime.ts` nested execution; `trace-*` bounded trace state.
+- `tools.ts` registers the runtime. `shared-runtime.ts`, `public-tools.ts`, and `tool-events.ts` own provider state, Pi tools, and hooks.
+- `custom-tool-*` owns TOML discovery and execution. `tool-result.ts`, `render-tracker.ts`, and `rendering.ts` own output and rendering boundaries.

--- a/packages/pi-dynamic-tools/AGENTS.md
+++ b/packages/pi-dynamic-tools/AGENTS.md
@@ -1,7 +1,3 @@
-# pi-dynamic-tools rules
-
-- Keep this package independent from `pi-codex-conversion` while code mode is experimental.
+- Keep this package independent from `pi-codex-conversion` while Code Mode remains experimental.
 - Vendored Codex runtime sources track `vendor/code-mode-src/UPSTREAM`; keep Pi-owned changes outside upstream `src` trees.
-- Dynamic tools are one TOML file each under `~/.pi/agent/dynamic-tools/`.
-- Runtime JavaScript is Codex-shaped: `exec`, `wait`, and freeform methods on `tools`.
-- `examples/spawn-agent/reviewer.prompt.md` mirrors `../pi-subagent-review/review.prompt.md`; keep them aligned.
+- Keep `examples/spawn-agent/reviewer.prompt.md` aligned with `packages/pi-subagent-review/review.prompt.md`.

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -1,6 +1,6 @@
-# pi-dynamic-tools
+# @howaboua/pi-dynamic-tools
 
-Expose small command-line tools to Pi through Codex-style JavaScript code mode. Each tool is a separate TOML file; Pi gives the model one `exec` environment where those tools can be composed with normal JavaScript.
+Exposes command-line programs to Pi through Codex-style JavaScript Code Mode. Tools are small TOML definitions; the model composes them inside one isolated `exec` environment.
 
 ## Install
 
@@ -8,11 +8,13 @@ Expose small command-line tools to Pi through Codex-style JavaScript code mode. 
 pi install npm:@howaboua/pi-dynamic-tools
 ```
 
-The first startup with at least one definition downloads OpenAI Codex's code-mode host for the current platform and verifies its pinned SHA-256 checksum. Installing the extension alone does not download the host.
+Definitions live in `~/.pi/agent/dynamic-tools/`, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when that variable is set. Installing the package does not enable the bundled examples.
+
+The first `exec` with at least one definition downloads the pinned OpenAI Codex Code Mode host for the current platform and verifies its SHA-256 checksum. No host is downloaded while the definitions directory is empty.
 
 ## Define a tool
 
-Each definition must state the exact invocation contract. The bundled `spawn_agent` example uses:
+Create one top-level TOML file per tool. Its filename becomes the method on `tools`, so use letters, numbers, `_`, or `$`.
 
 ```toml
 usage = '''await tools.spawn_agent(JSON.stringify({ agent_type: "explorer" | "reviewer", message: string, cwd?: string }))'''
@@ -21,57 +23,20 @@ command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
 ```
 
-The filename becomes the JavaScript method name, so use letters, numbers, `_`, or `$`. `usage` is required; the agent should never need to guess the input. `description` and `output` are optional on-demand help text for details not already clear from the name and usage. `output` documents a reliable contract but does not control the command's result. Tools are deferred by default; set `defer_loading = false` to add a commonly used tool's name and usage to the system prompt. Full help remains local until requested through `ALL_TOOLS`.
+- `usage` is required and shows the exact JavaScript call.
+- `command` may be on `PATH` or relative to the TOML file.
+- `input` is `"arg"` (default) or `"stdin"`.
+- `description` and `output` are optional on-demand help.
+- Set `defer_loading = false` to put a frequent tool in the prompt.
 
-`input` can be:
+Definitions are rediscovered before each `exec`, so additions and edits take effect during the session. Deferred help stays local until the model looks up the tool through `ALL_TOOLS`.
 
-- `"arg"` — append the string input as the final command argument; this is the default
-- `"stdin"` — write the string input to standard input
+Use dynamic tools for command-backed capabilities. Use a full Pi extension when the capability needs lifecycle hooks, UI, session state, provider integration, or a provider-visible schema.
 
-Bare command names resolve through `PATH`. Relative command paths resolve from the TOML file's directory.
+Disabled examples cover `spawn_agent`, `port_info`, `semantic_grep`, `vent`, and `workflows_create`. See [`DYNAMIC-TOOLS.md`](./DYNAMIC-TOOLS.md) for setup and troubleshooting.
 
-Definitions are rediscovered before every `exec`, so deferred tools can be added, changed, or removed during a session. Promoted tools enter the system prompt on the next agent turn.
+## Runtime boundary
 
-The extension adds the resolved bundled `DYNAMIC-TOOLS.md` path to the system prompt. Agents read that file only when asked to configure or explain dynamic tools.
+`exec` runs in OpenAI Codex's isolated V8 host with output, state, timer, and resumable-cell helpers. It does not expose Node.js, filesystem, network, or console APIs directly.
 
-For command-backed capabilities, dynamic tools are the lightweight default: keep occasional tools deferred and promote stable frequent ones. Use a full Pi extension when the capability needs lifecycle hooks, UI, session state, provider integration, or a directly exposed structured schema.
-
-## Bundled examples
-
-`examples/spawn_agent.toml` and `examples/spawn-agent/` demonstrate a promoted, dual-role subagent without enabling it. The example accepts JSON containing a required `agent_type` (`explorer` or `reviewer`), required `message`, and optional `cwd`. Explorer uses GPT-5.6 Luna at low reasoning. Reviewer uses GPT-5.6 Sol at medium reasoning and prepares Git base, merge-base, status, and diff context before starting Pi. See `DYNAMIC-TOOLS.md` for the invocation and opt-in copy step.
-
-`examples/port_info.toml` and `examples/port-info/` demonstrate a one-argument system integration without enabling it. The example turns a port number into normalized listener, connection, process, service, and container diagnostics across Linux, macOS, and Windows.
-
-Three promoted examples package common agent operations without enabling them:
-
-- `vent` appends batched workflow-friction notes to `VENT.md`.
-- `workflows_create` writes repo-local `.pi/workflows/<slug>/SKILL.md` procedures.
-- `semantic_grep` searches an index maintained by `@howaboua/pi-semantic-grep`; that package remains responsible for configuration and indexing lifecycle.
-
-## Model-facing shape
-
-Tools are discovered on demand without changing the stable `exec` schema:
-
-```js
-text(ALL_TOOLS.map(({ name }) => name));
-text(ALL_TOOLS.find(({ name }) => name === "spawn_agent"));
-```
-
-With both bundled examples enabled, `exec` can compose unrelated system and agent work without intermediate model turns:
-
-```js
-const [port, review] = await Promise.all([
-  tools.port_info("3000"),
-  tools.spawn_agent(JSON.stringify({
-    agent_type: "reviewer",
-    message: "Review the current branch.",
-  })),
-]);
-text({ port, review });
-```
-
-The runtime is OpenAI Codex's isolated V8 code-mode host. It provides `text`, `image`, `store`, `load`, `notify`, `yield_control`, timers, resumable cells, and the companion `wait` tool. It does not expose Node, filesystem, network, or console APIs to JavaScript.
-
-## Source boundary
-
-The Pi extension, TOML loader, command runner, and host client are MIT licensed. Vendored OpenAI Codex sources and downloaded code-mode host binaries are Apache-2.0; see `THIRD_PARTY_LICENSES.md` and `UPSTREAM_SYNC.md`.
+The Pi integration is MIT-licensed. Vendored Codex source and downloaded host binaries are Apache-2.0; see [`THIRD_PARTY_LICENSES.md`](./THIRD_PARTY_LICENSES.md) and [`UPSTREAM_SYNC.md`](./UPSTREAM_SYNC.md).

--- a/packages/pi-explore-subagents/README.md
+++ b/packages/pi-explore-subagents/README.md
@@ -1,46 +1,6 @@
-# pi-explore-subagents
+# @howaboua/pi-explore-subagents
 
-Give Pi a second set of eyes. `pi-explore-subagents` adds an isolated discovery tool that lets Pi send focused reconnaissance work to a child agent before the main agent edits anything. It is built for the moment when a codebase is unfamiliar, the right files are not obvious, or you want evidence gathered without dragging all of that exploration into the primary session.
-
-## What it does
-
-This package gives Pi agents a dedicated `explore_subagent` tool. It is not meant to be called directly by users; agents use it when they need isolated reconnaissance before acting.
-
-The tool starts a separate, no-session Pi subprocess with a discovery-only prompt. The subagent can inspect files, trace relationships, and report back with paths, line ranges, unknowns, and suggested next reads. It does not inherit the parent conversation, and it is instructed not to edit files.
-
-Use it for:
-
-- finding the right entry points in an unfamiliar repo
-- tracing a behavior across nearby files
-- surveying a subsystem before implementation
-- collecting evidence before making a change
-- keeping broad exploration out of the main context
-
-## Modes
-
-`explore_subagent` has two modes:
-
-### `shallow`
-
-Fast, bounded reconnaissance. Use it with cheaper, faster, or less capable models when you only need hotspots, entry points, and the next few files to read.
-
-Good for:
-
-- quick orientation
-- finding likely files
-- narrow questions
-- stopping early before the search sprawls
-
-### `deep`
-
-Wider reconnaissance for longer investigations. Use it with a stronger model when the task needs cross-file synthesis, triage, or a more complete map.
-
-Good for:
-
-- repo or subsystem surveys
-- following call paths
-- compare/rank/select work
-- tracing config, scripts, tests, and boundaries
+Adds an agent-callable `explore_subagent` tool for isolated, discovery-only codebase research. The child receives a standalone brief rather than the parent conversation and is instructed to inspect and report, not edit.
 
 ## Install
 
@@ -48,11 +8,20 @@ Good for:
 pi install npm:@howaboua/pi-explore-subagents
 ```
 
-You can also clone the package and install your local copy if you want to tune the prompts or mode behavior for your own workflow.
+## Modes
+
+- `shallow` — bounded reconnaissance for hotspots, entry points, narrow questions, and best next reads
+- `deep` — broader surveys, cross-file tracing, triage, and compare/rank work
+
+The tool accepts a required `task`, a required `mode`, and an optional `cwd`. Agents should include the background, exact question, scope, constraints, and expected evidence because the child has no inherited conversation.
+
+Users normally ask Pi for an exploration rather than calling the tool directly:
+
+> Use a shallow explore subagent to find where authentication errors are rendered. Stay discovery-only and return likely files, line ranges, and the best next reads.
 
 ## Configuration
 
-On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with separate model settings for each mode. If an older local install already has a tuned package-local `config.json`, those settings are copied into the new user-local file first. A good starting point is to keep `shallow` fast and inexpensive, and reserve `deep` for longer work:
+On first use, the extension creates `~/.pi/agent/pi-explore-subagents.json`, or the equivalent path under `$PI_CODING_AGENT_DIR`.
 
 ```json
 {
@@ -67,25 +36,4 @@ On first use, the package creates `~/.pi/agent/pi-explore-subagents.json` with s
 }
 ```
 
-Edit that user-local file to tune models or thinking levels. Pi levels through `max` are accepted and clamped to the selected model's capabilities. The file lives outside the installed package, so reinstalls and updates will not wipe your changes.
-
-## Usage
-
-Ask Pi naturally. The tool is for agents, not for direct user calls. When an agent uses it, it should provide a complete standalone brief, choose `shallow` or `deep`, and optionally set the working directory.
-
-Because the subagent is isolated, the agent should include the context it needs in the task itself: project path, the exact question, relevant files or symbols, constraints, and the kind of evidence you want back.
-
-Example:
-
-> Use a shallow explore subagent to find where authentication errors are rendered. Stay discovery-only. Return likely files, line ranges, and the best next reads.
-
-For broader work:
-
-> Use a deep explore subagent to map the flow from CLI argument parsing to command execution. Include config and test boundaries. Stay discovery-only and return evidence by file and line range.
-
-## In short
-
-- `shallow` is for fast, bounded scans.
-- `deep` is for wider, longer investigations.
-- Subagents are isolated and discovery-only.
-- Better briefs produce better evidence.
+Those are the package defaults; both models must be available in your Pi setup. Thinking levels through `max` are accepted and clamped to model capability. Existing package-local settings from older installs are migrated to the user config when possible.

--- a/packages/pi-extensions/README.md
+++ b/packages/pi-extensions/README.md
@@ -1,9 +1,26 @@
 # @howaboua/pi-extensions
 
-Aggregate Pi package for all Howaboua Pi extensions.
+The general-purpose extension bundle from this repository.
 
-Install:
+## Install
 
 ```bash
 pi install npm:@howaboua/pi-extensions
 ```
+
+## Included extensions
+
+- `pi-auto-reasoning-tool` — agent-controlled reasoning levels with the user's level as a floor
+- `pi-auto-trees` — `/marker` and `/end` for incremental long sessions
+- `pi-dynamic-tools` — TOML-defined command tools through JavaScript Code Mode
+- `pi-explore-subagents` — isolated, discovery-only subagents
+- `pi-markdown-workflows` — workflow/skill UI and nested `AGENTS.md` loading
+- `pi-memories` — shutdown memory candidates in a Markdown inbox
+- `pi-semantic-grep` — semantic code and docs search
+- `pi-smart-btw` — async side-session questions
+- `pi-subagent-review` — isolated review subagents through `/review`
+- `pi-vent` — repeated workflow-friction notes in `VENT.md`
+
+`pi-codex-conversion` is not included because it changes the tool surface for GPT/Codex models. Install it separately when you want that behavior.
+
+Installing this bundle loads every extension above. Install individual packages instead if you only want part of the set.

--- a/packages/pi-markdown-workflows/AGENTS.md
+++ b/packages/pi-markdown-workflows/AGENTS.md
@@ -1,4 +1,1 @@
-# pi-markdown-workflows rules
-
-- This package owns workflow/skill UI, `/learn`, `workflows_create`, and nested `AGENTS.md` autoloading.
-- Do not edit `dist/` manually; build it from source.
+Do not edit `dist/` manually; build it from source.

--- a/packages/pi-markdown-workflows/README.md
+++ b/packages/pi-markdown-workflows/README.md
@@ -1,116 +1,38 @@
-# pi-markdown-workflows
+# @howaboua/pi-markdown-workflows
 
-> Why download crappy skills when you can make god tier skills yourself?
-
-Pi extension for building, refining, and using **workflows** (repo SOPs) and **skills** (global capabilities) from one unified GUI.
-
-<img width="1024" height="559" alt="image" src="https://github.com/user-attachments/assets/a9124b44-eb29-4159-83fa-27df40c8825a" />
-
-## Key features
-
-### Unified GUI for workflows and skills
-A single interface powers both `/workflows` and `/skills`.
-
-- Tab between both views with `Tab` / `Shift+Tab`
-- Search, preview details, and run actions from the same UX model
-- Create skills using the bundled `skill-creator` skill
-- Keep command surface clean while still supporting advanced actions
-
-### UI primitives SDK (npm)
-This extension now consumes UI primitives from npm via:
-
-- `@howaboua/pi-howaboua-extensions-primitives-sdk`
-
-The SDK is no longer vendored in this repository under `sdk/`.
-
-### Three user commands
-This extension exposes three user-facing commands:
-
-- `/workflows` — workflow list and actions
-- `/skills` — skill list and actions
-- `/learn [optional guidance]` — capture concise session findings into the most appropriate `AGENTS.md`
-
-### Skill and workflow creation + refinement
-Creation and refinement are first-class flows in the UI.
-
-- Workflows: create, use, refine, append-to-agents, promote-to-skill, delete
-- Skills: create, use, refine, delete
-- Refinement prompts enforce strong structure, RFC language semantics, and actionable quality criteria
-
-### Agent tool for automatic workflow documentation
-Agents can document reusable process knowledge while they work via:
-
-- `workflows_create`
-
-The tool writes workflow files to:
-
-- `./.pi/workflows/<slug>/SKILL.md`
-
-This makes workflow capture deterministic and reusable across future sessions.
-
-### Nested AGENTS.md context autoload with periodic refresh
-The extension auto-loads nested `AGENTS.md` files when relevant files/paths are accessed.
-
-- triggers on `read`
-- also triggers for discovery/listing/read-ish shell tool commands (`bash`, `exec`, `exec_command`, `shell`) using `command` or `cmd` input (`ls`, `find`, `rg`, `grep`, `fd`, `tree`, `cat`, `sed`, `head`, `tail`, `nl`, `wc`, `stat`, `file`, `du`, `git ls-files`, `git grep`)
-- loads full nested chain (excluding cwd root `AGENTS.md` reinjection)
-- periodic refresh cadence: every **10** qualifying operations
-
-## Workflows vs skills
-
-- **Workflows**: repository SOPs that evolve with project conventions
-- **Skills**: broader reusable capabilities, usually global
-
-Recommended global skills location:
-
-- `~/.pi/agent/skills/`
+Manages repository workflows and reusable skills from one Pi interface, and loads nested `AGENTS.md` context when work enters a subdirectory.
 
 ## Install
-
-From npm:
 
 ```bash
 pi install npm:@howaboua/pi-markdown-workflows
 ```
 
-From Git:
-
-```bash
-pi install git+https://github.com/IgorWarzocha/pi-markdown-workflows.git
-```
-
 For local development:
 
 ```bash
-pi -e /absolute/path/to/pi-markdown-workflows/index.ts
+pi -e ./packages/pi-markdown-workflows/index.ts
 ```
 
-## Publishing
+## Commands
 
-```bash
-npm run publish:dry-run
-```
+- `/workflows` — browse, create, use, refine, promote, reference, or delete repository workflows
+- `/skills` — browse, create, use, refine, or delete skills
+- `/learn [guidance]` — ask the agent to capture a small durable lesson in the narrowest useful `AGENTS.md`
 
-Dev tag publish:
+Use `Tab` and `Shift+Tab` to switch between workflows and skills in the shared UI. If Pi's generated `/skill:<name>` commands clutter the command palette, disable **skill commands** in `/settings` and use `/skills` instead.
 
-```bash
-npm run publish:dev
-```
+## Workflows and skills
 
-Bump prerelease + publish dev tag:
+- Workflows are repository procedures stored at `.pi/workflows/<slug>/SKILL.md`.
+- Skills are broader reusable capabilities, commonly stored at `~/.pi/agent/skills/`.
 
-```bash
-npm run release:dev
-```
+The agent-callable `workflows_create` tool writes or updates confirmed repeatable procedures under `.pi/workflows/`. The UI can also append a compact workflow reference to the relevant `AGENTS.md` or promote a workflow into a skill.
 
-## Recommended setting to reduce clutter
+## Nested `AGENTS.md` loading
 
-If `/skill:<name>` commands clutter your command palette, disable skill command registration and use `/skills` instead:
+The extension detects file reads and read-like shell or Code Mode operations. When a path enters a subtree, it injects the applicable nested `AGENTS.md` chain without reinjecting the repository root file Pi already loaded. It refreshes known context every 10 qualifying operations so edits made during a long session take effect.
 
-`/settings` => `skill commands: false`
+The package uses `@howaboua/pi-howaboua-extensions-primitives-sdk` for its UI. Published installs load compiled `dist/`; repository development runs the TypeScript entrypoint above.
 
-## Repository
-
-- https://github.com/IgorWarzocha/pi-markdown-workflows
-
-Markdown Is All You Need™
+Repository: <https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-markdown-workflows>

--- a/packages/pi-markdown-workflows/src/core/subdir.ts
+++ b/packages/pi-markdown-workflows/src/core/subdir.ts
@@ -18,6 +18,10 @@ import {
 	shellOutputToolName,
 	shellTargets,
 } from "./subdir/shell-targets.js";
+import {
+	codeModeDiscoveryEvents,
+	type DiscoveryEvent,
+} from "./subdir/tool-events.js";
 
 export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 	const loadedAgents = new Set<string>();
@@ -54,13 +58,14 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 		}
 	}
 
-	function targetsForEvent(event: {
-		toolName: string;
-		input: Record<string, unknown>;
-		content: Array<{ type: string; text?: string }>;
-	}): string[] {
+	function targetsForEvent(event: DiscoveryEvent): string[] {
 		const isRead = event.toolName === "read";
 		const isPathDiscoveryTool = ["grep", "find", "ls"].includes(event.toolName);
+		const workdir = ["workdir", "cwd", "working_directory"]
+			.map((key) => event.input[key])
+			.find((value): value is string => typeof value === "string");
+		const eventCwd =
+			workdir !== undefined ? resolvePath(workdir, currentCwd) : currentCwd;
 		const shellInput =
 			typeof event.input["command"] === "string"
 				? event.input["command"]
@@ -81,17 +86,17 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 		if (!isRead && !isPathDiscoveryTool && !isDiscoveryShell) return [];
 
 		if (isRead)
-			return pathInput ? [resolvePath(pathInput, currentCwd)] : [currentCwd];
+			return pathInput ? [resolvePath(pathInput, eventCwd)] : [eventCwd];
 		if (isPathDiscoveryTool) {
-			const base = pathInput ? resolvePath(pathInput, currentCwd) : currentCwd;
+			const base = pathInput ? resolvePath(pathInput, eventCwd) : eventCwd;
 			return [base, ...pathsFromToolText(event.content, base, event.toolName)];
 		}
 		if (!shellInput) return [];
-		const base = shellOutputBase(shellInput, currentCwd);
+		const base = shellOutputBase(shellInput, eventCwd);
 		const outputPaths = isPathOutputShellCommand(shellInput)
 			? pathsFromToolText(event.content, base, shellOutputToolName(shellInput))
 			: [];
-		return [...shellTargets(shellInput, currentCwd), ...outputPaths];
+		return [...shellTargets(shellInput, eventCwd), ...outputPaths];
 	}
 
 	function pathsFromToolText(
@@ -198,10 +203,11 @@ export function registerSubdirContextAutoload(pi: ExtensionAPI): void {
 	pi.on("session_tree", handleSessionChange);
 
 	pi.on("tool_result", async (event, ctx) => {
-		if (event.isError) return undefined;
 		ensureSession(ctx.cwd);
 
-		const targets = targetsForEvent(event);
+		const discoveryEvents = codeModeDiscoveryEvents(event);
+		if (event.isError) discoveryEvents.shift();
+		const targets = discoveryEvents.flatMap(targetsForEvent);
 		if (!targets.length) return undefined;
 
 		const branchContext = collectBranchContext(ctx, currentCwd, cwdAgentsPath);

--- a/packages/pi-markdown-workflows/src/core/subdir/tool-events.ts
+++ b/packages/pi-markdown-workflows/src/core/subdir/tool-events.ts
@@ -1,0 +1,46 @@
+export type DiscoveryEvent = {
+	toolName: string;
+	input: Record<string, unknown>;
+	content: Array<{ type: string; text?: string }>;
+};
+
+type ToolResultEvent = DiscoveryEvent & { details?: unknown };
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function contentItems(value: unknown): DiscoveryEvent["content"] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	return value.filter((item): item is { type: string; text?: string } => {
+		const record = objectRecord(item);
+		return Boolean(
+			record &&
+				typeof record["type"] === "string" &&
+				(record["text"] === undefined || typeof record["text"] === "string"),
+		);
+	});
+}
+
+export function codeModeDiscoveryEvents(
+	event: ToolResultEvent,
+): DiscoveryEvent[] {
+	const events: DiscoveryEvent[] = [event];
+	const details = objectRecord(event.details);
+	if (details?.["codeMode"] !== true || !Array.isArray(details["traces"]))
+		return events;
+
+	for (const value of details["traces"]) {
+		const trace = objectRecord(value);
+		if (trace?.["status"] !== "done" || typeof trace["name"] !== "string")
+			continue;
+		const input = objectRecord(trace["input"]);
+		const result = objectRecord(trace["result"]);
+		const content = contentItems(result?.["content"]);
+		if (!input || !content) continue;
+		events.push({ toolName: trace["name"], input, content });
+	}
+	return events;
+}

--- a/packages/pi-markdown-workflows/tests/subdir-context.test.mjs
+++ b/packages/pi-markdown-workflows/tests/subdir-context.test.mjs
@@ -530,6 +530,109 @@ async function run() {
 	);
 	assert.match(textContent(escapedAppendix), /&lt;\/agents_file&gt;/);
 
+	await fs.mkdir(path.join(cwd, "a", "code-mode"), { recursive: true });
+	await fs.writeFile(
+		path.join(cwd, "a", "code-mode", "AGENTS.md"),
+		"CODE MODE",
+	);
+	await fs.writeFile(
+		path.join(cwd, "a", "code-mode", "file.ts"),
+		"export const codeMode = 1;\n",
+	);
+
+	const codeModeTrace = {
+		id: "nested-exec-command",
+		name: "exec_command",
+		status: "done",
+		input: {
+			cmd: "sed -n '1,5p' file.ts",
+			workdir: "./a/code-mode",
+		},
+		result: {
+			content: [{ type: "text", text: "export const codeMode = 1;" }],
+			details: { output: "export const codeMode = 1;", exit_code: 0 },
+		},
+	};
+	const freshNestedViaCodeMode = await toolResult(
+		{
+			toolName: "exec",
+			isError: false,
+			input: { code: "await tools.exec_command(...)" },
+			content: [{ type: "text", text: "Script completed" }],
+			details: { codeMode: true, traces: [codeModeTrace] },
+		},
+		ctx,
+	);
+
+	assert.ok(
+		freshNestedViaCodeMode,
+		"Code Mode exec_command traces should persist nested AGENTS updates",
+	);
+	assert.equal(persistedFiles(freshNestedViaCodeMode.details).length, 1);
+	assert.equal(
+		persistedFiles(freshNestedViaCodeMode.details)[0].path,
+		"a/code-mode/AGENTS.md",
+	);
+	assert.deepEqual(
+		freshNestedViaCodeMode.details.traces,
+		[codeModeTrace],
+		"persisted context should preserve Code Mode trace details",
+	);
+	assert.match(
+		textContent(freshNestedViaCodeMode),
+		/<agents_file path="a\/code-mode\/AGENTS\.md">/,
+	);
+
+	await fs.mkdir(path.join(cwd, "a", "code-mode-error"), {
+		recursive: true,
+	});
+	await fs.writeFile(
+		path.join(cwd, "a", "code-mode-error", "AGENTS.md"),
+		"CODE MODE ERROR",
+	);
+	await fs.writeFile(
+		path.join(cwd, "a", "code-mode-error", "file.ts"),
+		"export const beforeError = true;\n",
+	);
+
+	const codeModeScriptError = await toolResult(
+		{
+			toolName: "exec",
+			isError: true,
+			input: { code: "await tools.exec_command(...); throw new Error(...)" },
+			content: [{ type: "text", text: "Script error: expected" }],
+			details: {
+				codeMode: true,
+				scriptError: "expected",
+				traces: [
+					{
+						...codeModeTrace,
+						id: "nested-before-script-error",
+						input: {
+							cmd: "cat file.ts",
+							working_directory: "./a/code-mode-error",
+						},
+					},
+				],
+			},
+		},
+		ctx,
+	);
+
+	assert.ok(
+		codeModeScriptError,
+		"successful nested traces should load AGENTS after a Code Mode script error",
+	);
+	assert.equal(persistedFiles(codeModeScriptError.details).length, 1);
+	assert.equal(
+		persistedFiles(codeModeScriptError.details)[0].path,
+		"a/code-mode-error/AGENTS.md",
+	);
+	assert.match(
+		textContent(codeModeScriptError),
+		/<agents_file path="a\/code-mode-error\/AGENTS\.md">/,
+	);
+
 	await fs.rm(root, { recursive: true, force: true });
 	console.log("subdir-context test passed");
 }

--- a/packages/pi-memories/README.md
+++ b/packages/pi-memories/README.md
@@ -1,122 +1,44 @@
-# pi-memories
+# @howaboua/pi-memories
 
-A tiny Pi extension that writes memory candidates when Pi exits.
-
-pi-memories expects you to use Pi's global `AGENTS.md` as your long-term memory file. If you do not have one yet, see [Recommended AGENTS.md setup](#recommended-agentsmd-setup).
-
-It does not try to maintain a database, vector store, or hidden profile. It runs one short, no-tools/no-skills Pi session after shutdown, asks for a few durable things worth remembering, and appends the result to a plain markdown inbox.
-
-You review the inbox later and decide what, if anything, belongs in `AGENTS.md`.
-
-## How it works
-
-On an actual Pi shutdown (`session_shutdown` with reason `quit`), pi-memories collects the best context it can find. Reloading, switching, creating, or forking sessions does not run the memory worker.
-
-1. OpenAI native compaction blob, if the session has one.
-2. Normal Pi compaction summary, if the session has one.
-3. Recent conversation tail, if there is no compaction.
-
-Then it starts an ephemeral Pi run with:
-
-```txt
---no-session --no-skills --no-tools
-```
-
-That run still gets your normal Pi context files, so global/project `AGENTS.md` can help it decide what is actually new. The output is appended to:
-
-```txt
-~/.pi/agent/memory-inbox.md
-```
-
-Short no-compaction sessions are skipped by default, so opening Pi for one quick question should not create memory noise.
+Writes a small set of memory candidates when Pi exits, then leaves the final decision to you. There is no database, vector store, or hidden profile: candidates go to a plain Markdown inbox for manual review.
 
 ## Install
 
-Clone or install this package, then add it to your Pi packages list.
-
-For a local checkout:
-
-```json
-{
-  "packages": [
-    "/path/to/pi-memories"
-  ]
-}
+```bash
+pi install npm:@howaboua/pi-memories
 ```
 
-Pi will load the extension from the package manifest.
+## How it works
 
-## Config
+The worker runs only for a real Pi shutdown (`session_shutdown` with reason `quit`), not reloads, new sessions, resumes, or forks. It uses the best context available:
 
-The extension creates this file on first load:
+1. an OpenAI native compaction window
+2. a normal Pi compaction summary
+3. the recent conversation when no compaction exists
 
-```txt
-~/.pi/agent/pi-memories.json
-```
+It starts an ephemeral Pi process with `--no-session --no-skills --no-tools`. Normal context files remain available unless disabled in config, which lets the worker compare candidates with existing global and project instructions.
 
-Edit it if you want to change the defaults.
+Candidates are appended to `~/.pi/agent/memory-inbox.md`. Short sessions without compaction are skipped by default, and output equal to `No durable memories.` is not written.
 
-Example:
+## Review
 
-```json
-{
-  "enabled": true,
-  "model": "openai-codex/gpt-5.4-mini",
-  "thinking": "low",
-  "inboxPath": "/home/you/.pi/agent/memory-inbox.md",
-  "timeoutMs": 120000,
-  "includeProjectContext": true,
-  "minUserMessagesWithoutBlob": 3
-}
-```
+Run `/memory-review`. The command fills the editor with a review prompt that asks the agent to promote only durable, non-sensitive information into the appropriate global or project `AGENTS.md`, merge duplicates, and empty the inbox when finished.
 
-### Options
+The review is deliberately manual. Inbox entries are candidates, not truth.
 
-| Option | Default | What it does |
-|---|---:|---|
-| `enabled` | `true` | Turn the extension on/off. |
-| `model` | `gpt-5.4` | Model used for the shutdown memory pass. |
-| `thinking` | `low` | Thinking level for the memory pass. Use `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. |
-| `inboxPath` | `~/.pi/agent/memory-inbox.md` | Where memory candidates are appended. |
-| `timeoutMs` | `120000` | Max time to wait for the ephemeral Pi run. |
-| `includeProjectContext` | `true` | Keep project `AGENTS.md` / `CLAUDE.md` context. Set false to use only the explicit memory prompt. |
-| `minUserMessagesWithoutBlob` | `3` | If there is no compaction, skip sessions with fewer user messages than this. |
+## Configuration
 
-## Recommended AGENTS.md setup
+The extension creates `~/.pi/agent/pi-memories.json` on first load.
 
-pi-memories is designed around Pi's global `AGENTS.md`. It can still append candidates to the inbox without one, but `/memory-review` is meant to promote useful memories into this file.
+| Option | Default | Purpose |
+|---|---|---|
+| `enabled` | `true` | Enable shutdown distillation. |
+| `model` | `gpt-5.4` | Model passed to the ephemeral Pi process. |
+| `thinking` | `low` | Thinking level, from `off` through `max`. |
+| `inboxPath` | `~/.pi/agent/memory-inbox.md` | Destination for candidates and failure comments. |
+| `prompt` | built-in distillation prompt | Replace the worker prompt. |
+| `timeoutMs` | `120000` | Maximum worker runtime. |
+| `includeProjectContext` | `true` | Include Pi's normal context files; `false` passes `--no-context-files`. |
+| `minUserMessagesWithoutBlob` | `3` | Skip shorter sessions when no compaction exists. |
 
-Pi loads global instructions from:
-
-```txt
-~/.pi/agent/AGENTS.md
-```
-
-The shutdown worker receives those instructions too. That means it can use your existing preferences when deciding what belongs in the inbox, and `/memory-review` can use them when deciding what to promote.
-
-A starter section is included here:
-
-```txt
-templates/AGENTS.memory-template.md
-```
-
-Copy the parts you like into your global `AGENTS.md`. Keep it short. The inbox is allowed to be messy; `AGENTS.md` should not be.
-
-## Review memories
-
-Run:
-
-```txt
-/memory-review
-```
-
-This fills the editor with a prompt to review `memory-inbox.md` and promote only the useful bits into global or project `AGENTS.md`.
-
-The review step is intentionally manual. The inbox can have duplicates. That is fine. The point is to avoid silently poisoning your long-term instructions.
-
-## Notes
-
-- The shutdown worker runs without tools and without skills.
-- It uses existing compaction context when available, but does not store compaction blobs.
-- If `pi-codex-conversion` native compaction is present, the opaque OpenAI blob is used only for that one ephemeral run.
-- If there is no compaction, the extension falls back to conversation text and applies the short-session gate.
+Use a provider/model string available in your Pi setup when overriding `model`.

--- a/packages/pi-semantic-grep/README.md
+++ b/packages/pi-semantic-grep/README.md
@@ -1,124 +1,18 @@
-# pi-semantic-grep
+# @howaboua/pi-semantic-grep
 
-Semantic search for pi. This extension gives the agent a `semantic_grep` tool that finds relevant code or documentation by meaning, not just by exact words. It indexes each repository into a local SQLite database under `.pi/`, embeds code chunks through your configured OpenAI-compatible embeddings endpoint, and incrementally refreshes the index at the start of each pi session.
+Adds an agent-callable `semantic_grep` tool for finding code and documentation by meaning rather than exact text. Each repository gets a local SQLite index under `.pi/`; embeddings come from an OpenAI-compatible endpoint you control.
 
-Package: `@howaboua/pi-semantic-grep`  
-Repository: <https://github.com/IgorWarzocha/pi-semantic-grep>
-
-## What it is good for
-
-Use it when a normal text search is too literal:
-
-- “Where is auth/session state handled?”
-- “Find the code that formats tool results.”
-- “Where do we build prompts for the model?”
-- “What files are involved in indexing documents?”
-- “Find docs or examples for adding a custom renderer.”
-
-The agent receives ranked matches with file paths, line ranges, scores, and snippets. By default the result renders compactly in pi and expands with the normal tool expand keybinding.
-
-## Requirements
-
-- pi
-- Node.js compatible with pi extensions
-- An OpenAI-compatible embeddings endpoint
-
-The endpoint must accept:
-
-```http
-POST /v1/embeddings
-Content-Type: application/json
-
-{
-  "model": "your-embedding-model",
-  "input": "text to embed"
-}
-```
-
-and return an OpenAI-style response containing:
-
-```json
-{
-  "data": [
-    { "embedding": [0.1, 0.2, 0.3] }
-  ]
-}
-```
-
-This has been designed for OpenAI-compatible local servers such as LM Studio, llama.cpp-style servers, or any service that exposes the same embeddings response shape. It should also work with hosted OpenAI-compatible embedding APIs when configured with the right URL/model/API key.
-
-## Installation
-
-Install as a pi package:
+## Install
 
 ```bash
 pi install npm:@howaboua/pi-semantic-grep
 ```
 
-Or run directly from a local checkout:
-
-```bash
-git clone https://github.com/IgorWarzocha/pi-semantic-grep.git
-cd pi-semantic-grep
-npm install
-pi -e ./src/index.ts
-```
+The package depends on the native `better-sqlite3` module and requires an environment where npm can install or load its binary.
 
 ## Configuration
 
-On first load, the extension creates:
-
-```text
-~/.pi/agent/semantic-grep.json
-```
-
-Default config:
-
-```json
-{
-  "embeddings": {
-    "url": "http://127.0.0.1:1234/v1/embeddings",
-    "model": "text-embedding-embeddinggemma-300m-qat"
-  },
-  "indexing": {
-    "chunkLines": 80,
-    "chunkOverlap": 20,
-    "maxFileBytes": 512000,
-    "maxChunkChars": 12000,
-    "skipOversizedChunks": false,
-    "followSymlinks": false,
-    "includeExtensions": [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".lua", ".rs", ".go", ".java", ".cs", ".cpp", ".c", ".h", ".hpp", ".md", ".json", ".yaml", ".yml", ".toml", ".css", ".scss", ".html", ".svelte", ".vue"],
-    "excludeDirs": [".git", ".pi", "node_modules", "dist", "build", "target", ".venv", "venv", "vendor", ".next", ".cache"]
-  },
-  "search": {
-    "defaultTopK": 8,
-    "maxTopK": 30
-  },
-  "autoIndex": {
-    "enabled": true,
-    "mode": "incremental"
-  },
-  "safety": {
-    "requireProjectMarker": true,
-    "projectMarkers": [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "deno.json", "bun.lock", "pnpm-lock.yaml", "yarn.lock"],
-    "denyRootBasenames": ["Desktop", "Documents", "Downloads", "Pictures", "Music", "Movies", "Videos", "Public", "Templates", "Applications", "Library", "System", "Volumes", "Users", "Program Files", "Program Files (x86)", "ProgramData", "Windows", "PerfLogs", "AppData", "OneDrive", "Dropbox", "Google Drive", "iCloud Drive"],
-    "denyRootPaths": ["~", "/", "C:\\", "C:/"]
-  }
-}
-```
-
-For your example local endpoint:
-
-```bash
-curl http://127.0.0.1:1234/v1/embeddings \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "text-embedding-embeddinggemma-300m-qat",
-    "input": "Some text to embed"
-  }'
-```
-
-use:
+On first load, the extension creates `~/.pi/agent/semantic-grep.json`. The endpoint must accept OpenAI-style `/v1/embeddings` requests and return `data[].embedding` vectors.
 
 ```json
 {
@@ -129,53 +23,27 @@ use:
 }
 ```
 
-For an endpoint requiring a bearer token:
+Local servers such as LM Studio and llama.cpp work when they expose that shape. For hosted endpoints, set `embeddings.apiKey`.
 
-```json
-{
-  "embeddings": {
-    "url": "https://example.com/v1/embeddings",
-    "model": "my-embedding-model",
-    "apiKey": "YOUR_API_KEY"
-  }
-}
-```
+A repository may override global settings in `.pi/semantic-grep.json`. Nested objects merge; arrays replace the global array, so repeat any default exclusions or extensions you still need.
 
-## Indexing behavior
+## Indexing
 
-The index is stored per repository:
+The index is stored at `<repo>/.pi/semantic-grep.sqlite`. With `autoIndex.enabled` (the default), it syncs at session start.
 
-```text
-<repo>/.pi/semantic-grep.sqlite
-```
+`autoIndex.mode` controls the work:
 
-Global config lives at `~/.pi/agent/semantic-grep.json`. A repository may also define a project override at:
+- `incremental` — embed new and changed files, remove deleted files
+- `missing` — build only when the SQLite file does not exist
+- `always` — rebuild the entire index on every session start
 
-```text
-<repo>/.pi/semantic-grep.json
-```
-
-Project config is merged over the global config. Nested objects are merged; arrays such as `indexing.excludeDirs` replace the global array, so include the defaults you still want.
-
-By default the file walker does not follow or index symlinks. Set `indexing.followSymlinks` to `true` globally or in a project config if a repository intentionally keeps indexable code behind symlinks.
-
-At session start, the extension syncs the index automatically.
-
-`autoIndex.mode` options:
-
-- `incremental` — default; only embed new or changed files and remove deleted files
-- `missing` — build only if the SQLite index does not exist
-- `always` — force a full rebuild at every session start
-
-A full rebuild is also triggered when indexing settings change, such as embedding model, chunk size, included extensions, excluded directories, max chunk size, or schema version. Oversized chunks are split by default instead of failing the whole indexing run; tune `indexing.maxChunkChars` for your embedder.
+Indexing or schema changes force a rebuild. Symlinks are ignored unless `indexing.followSymlinks` is enabled.
 
 ## Safety defaults
 
-The extension intentionally avoids indexing broad system or user directories. By default it requires a project marker such as `.git`, `package.json`, `pyproject.toml`, `Cargo.toml`, or `go.mod`, and refuses protected roots like `~`, `/`, `C:\\`, plus common Windows/macOS/Linux home folders such as Desktop, Documents, Downloads, Pictures, Applications, Library, Program Files, Windows, AppData, OneDrive, Dropbox, Google Drive, and iCloud Drive.
+The indexer requires a project marker and refuses broad filesystem, home, system, and common personal-data roots. These checks are configurable under `safety`.
 
-You can adjust these rules in `~/.pi/agent/semantic-grep.json` under `safety`.
-
-## Tool available to the agent
+## Tool
 
 ```ts
 semantic_grep({
@@ -184,21 +52,14 @@ semantic_grep({
 })
 ```
 
-Examples:
+Results include ranked paths, line ranges, scores, and snippets. The default count is 8 and maximum is 30.
 
 ```ts
-semantic_grep({ query: "where are tool calls dispatched?" })
-semantic_grep({ query: "code that formats markdown output", top_k: 5 })
-semantic_grep({ query: "configuration loading and defaults", top_k: 10 })
+semantic_grep({ query: "where are tool calls dispatched?", top_k: 5 })
 ```
 
-## Tech stack
+Use normal text search when you need an exact symbol or literal occurrence.
 
-- TypeScript pi extension
-- `better-sqlite3` for repo-local storage
-- OpenAI-compatible `/v1/embeddings` HTTP API for vectors
-- Simple line-window chunking with overlap
-- SHA256 per-file tracking for incremental indexing
-- Brute-force cosine similarity over vectors loaded from SQLite
+## Current limits
 
-The implementation is intentionally simple and portable. It does not require Python, FAISS, a background service, or a separate vector database. For very large repositories, an approximate nearest-neighbor index may be added later.
+Ranking uses brute-force cosine similarity over SQLite vectors. It needs no Python, FAISS, background service, or separate vector database, but is not aimed at very large repositories.

--- a/packages/pi-skill-agent-native-hardening/README.md
+++ b/packages/pi-skill-agent-native-hardening/README.md
@@ -1,11 +1,13 @@
 # @howaboua/pi-skill-agent-native-hardening
 
-Pi skill package for `agent-native-hardening`.
+Audits and improves codebase architecture for safe human and agent changes: ownership, feature boundaries, contracts, state, duplication, traversability, test fit, and parallel-change readiness.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-agent-native-hardening
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for structural reviews, scorecards, plans, or refactors. It is not intended for ordinary bug fixes with no architecture concern.
+
+The skill loads language-specific guidance and its scoring, work-lane, or dependency-safety references only when the task needs them.

--- a/packages/pi-skill-agents-md/README.md
+++ b/packages/pi-skill-agents-md/README.md
@@ -1,11 +1,11 @@
 # @howaboua/pi-skill-agents-md
 
-Pi skill package for `agents-md`.
+Creates, audits, prunes, and maintains scoped `AGENTS.md` files without turning them into repository summaries or duplicating human-facing documentation.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-agents-md
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for repository instructions, nested subtree guidance, global context, or separating agent rules from README content. The skill favors terse, non-obvious rules at the narrowest useful scope.

--- a/packages/pi-skill-anti-ai-copy/README.md
+++ b/packages/pi-skill-anti-ai-copy/README.md
@@ -1,11 +1,11 @@
 # @howaboua/pi-skill-anti-ai-copy
 
-Pi skill package for `anti-ai-copy`.
+Writes and rewrites specific, natural prose while preserving the author's stance, voice, and uncertainty.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-anti-ai-copy
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for documentation, product copy, emails, posts, bios, essays, and UI text that feels generic, inflated, corporate, or model-polished. It is not an AI detector or a mechanical proofreading skill.

--- a/packages/pi-skill-chrome-cdp/README.md
+++ b/packages/pi-skill-chrome-cdp/README.md
@@ -1,13 +1,20 @@
 # @howaboua/pi-skill-chrome-cdp
 
-Pi skill package for `chrome-cdp`.
+Controls a local Chrome-family browser through the Chrome DevTools Protocol. It can inspect rendered pages and authenticated tabs, navigate, click, type, evaluate JavaScript, and capture screenshots.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-chrome-cdp
 ```
 
-This skill is based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with local changes for this Pi package.
+## Requirements
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+- Node.js 22 or newer
+- Chrome, Chromium, Brave, Edge, or Vivaldi with remote debugging enabled at `chrome://inspect/#remote-debugging`
+
+The bundled CLI is `scripts/cdp.mjs`. It discovers Chrome on `CDP_PORT` or port `9222`, then falls back to `DevToolsActivePort`; set `CDP_PORT_FILE` for a non-standard port-file location.
+
+Use the skill when an agent needs a real rendered page or existing browser state. It includes commands for tab listing, accessibility snapshots, HTML, navigation, network timing, clicks, typing, screenshots, and raw CDP calls.
+
+Based on [`pasky/chrome-cdp-skill`](https://github.com/pasky/chrome-cdp-skill), with Pi packaging and local changes.

--- a/packages/pi-skill-gh-issue-pr-flow/README.md
+++ b/packages/pi-skill-gh-issue-pr-flow/README.md
@@ -1,11 +1,13 @@
 # @howaboua/pi-skill-gh-issue-pr-flow
 
-Pi skill package for `gh-issue-pr-flow`.
+Runs an opinionated GitHub workflow with `gh`: issues, branches, commits, pushes, PR creation and updates, release hygiene, review requests, and feedback triage.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-gh-issue-pr-flow
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it as a portable fallback. Repository instructions and explicit user direction take precedence.
+
+The skill checks branch and worktree state before history operations, keeps unrelated changes out of PRs, avoids unsafe force pushes, and reads its release-hygiene reference when package work is meant to ship.

--- a/packages/pi-skill-model-facing-api-design/README.md
+++ b/packages/pi-skill-model-facing-api-design/README.md
@@ -1,11 +1,13 @@
 # @howaboua/pi-skill-model-facing-api-design
 
-Pi skill package for `model-facing-api-design`.
+Designs and reviews Pi tool contracts that models select, call, and recover from correctly.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-model-facing-api-design
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for tool names, descriptions, TypeBox schemas, `promptSnippet`, `promptGuidelines`, results, errors, continuation handles, truncation, or prompt-cost reduction. It checks for obsolete Pi APIs before tuning copy.
+
+The package also includes `scripts/tool-token-lines.mjs` for measuring the token and line cost of tool definitions.

--- a/packages/pi-skill-omarchy-help/README.md
+++ b/packages/pi-skill-omarchy-help/README.md
@@ -1,11 +1,13 @@
 # @howaboua/pi-skill-omarchy-help
 
-Pi skill package for `omarchy-help`.
+Maintains user-level Arch Linux desktops configured with Omarchy: Hyprland, Waybar, Walker, Mako, terminals, themes, keybindings, displays, screenshots, updates, packages, Bluetooth, and audio.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-omarchy-help
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for workstation configuration and troubleshooting, not for developing or patching Omarchy itself. The skill treats `~/.local/share/omarchy/` as upstream-managed, read-only reference and prefers user-owned configuration or official Omarchy commands.
+
+This machine-specific skill is intentionally excluded from `@howaboua/pi-skills` and `@howaboua/pi-stuff`.

--- a/packages/pi-skill-project-reference-research/README.md
+++ b/packages/pi-skill-project-reference-research/README.md
@@ -1,11 +1,11 @@
 # @howaboua/pi-skill-project-reference-research
 
-Pi skill package for `project-reference-research`.
+Researches local or external codebases as reference context and returns evidence-backed findings.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-project-reference-research
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it to inspect, compare, or learn from another repository or project. The skill resolves existing checkouts or GitHub references, updates clean repositories when useful, preserves dirty worktrees, and verifies important findings in source before making precise claims.

--- a/packages/pi-skill-skill-creator/README.md
+++ b/packages/pi-skill-skill-creator/README.md
@@ -1,11 +1,13 @@
 # @howaboua/pi-skill-skill-creator
 
-Pi skill package for `skill-creator`.
+Designs, audits, refactors, validates, and packages reusable agent skills.
 
-Install:
+## Install
 
-```sh
+```bash
 pi install npm:@howaboua/pi-skill-skill-creator
 ```
 
-This package is part of the [Howaboua Pi Stuff](https://github.com/IgorWarzocha/howaboua-pi-stuff) monorepo.
+Use it for `SKILL.md` trigger descriptions, progressive disclosure, supporting references/scripts/assets, consolidation, or porting between agent harnesses. It is not for one-off prompt edits or passive documentation with no repeatable workflow.
+
+The package includes a full authoring reference and `scripts/skill-efficiency-check.py` for validating a skill directory.

--- a/packages/pi-skills/README.md
+++ b/packages/pi-skills/README.md
@@ -1,20 +1,22 @@
 # @howaboua/pi-skills
 
-Aggregate Pi package for all Howaboua Pi skills.
+The shareable skill bundle from this repository. Pi discovers the skills after installation and loads them when a task matches; `/skill:<name>` invokes one explicitly.
 
-Includes:
-
-- `agent-native-hardening`
-- `agents-md`
-- `anti-ai-copy`
-- `chrome-cdp`
-- `gh-issue-pr-flow`
-- `model-facing-api-design`
-- `project-reference-research`
-- `skill-creator`
-
-Install:
+## Install
 
 ```bash
 pi install npm:@howaboua/pi-skills
 ```
+
+## Included skills
+
+- `agent-native-hardening` — architecture reviews and structural refactors
+- `agents-md` — scoped `AGENTS.md` authoring and maintenance
+- `anti-ai-copy` — specific, natural prose that preserves voice
+- `chrome-cdp` — local browser inspection and control through CDP
+- `gh-issue-pr-flow` — GitHub issue, branch, PR, release, and review work
+- `model-facing-api-design` — Pi tool contracts that models can use reliably
+- `project-reference-research` — evidence-backed research in other repositories
+- `skill-creator` — reusable skill design, validation, and packaging
+
+`omarchy-help` is not included because it targets Arch desktops configured with Omarchy. Install `@howaboua/pi-skill-omarchy-help` separately when that matches your workstation.

--- a/packages/pi-smart-btw/README.md
+++ b/packages/pi-smart-btw/README.md
@@ -1,24 +1,11 @@
-# pi-smart-btw
+# @howaboua/pi-smart-btw
 
-`@howaboua/pi-smart-btw` adds `/btw` side sessions to Pi: async, ephemeral child Pi RPC processes for questions you do not want to derail the main chat. Answers live in the transcript; the widget is status and controls only.
-
-- Fresh context per slot: `pi --mode rpc --no-session` (full tools/extensions; this extension disables itself in the child).
-- Multiple numbered slots: `/btw 1 …`, `/btw 2 …`, `/btw` to open the panel, `/btw 1` to switch.
-- Per-slot queue and child: a slow slot 1 does not block slot 2.
-- Transcript is canonical: display-only `BTW SESSION` entries with generation tombstones on clear/inject.
-- Restore from JSONL after restart; restored follow-ups seed the child with prior Q&A when needed.
-- BTW entries stay out of the main LLM context until you inject. Old custom-message sessions remain readable.
+Adds `/btw` for questions you do not want to derail the main chat. Each numbered slot runs an async, ephemeral child Pi RPC process. Its answers stay out of the main model context until you inject them.
 
 ## Install
 
 ```bash
 pi install npm:@howaboua/pi-smart-btw
-```
-
-One-off:
-
-```bash
-pi -e npm:@howaboua/pi-smart-btw
 ```
 
 ## Usage
@@ -30,44 +17,23 @@ pi -e npm:@howaboua/pi-smart-btw
 /btw
 ```
 
-While a slot is active:
+- `/btw N <question>` sends to slot N.
+- `/btw <question>` sends to the active slot.
+- `/btw N` switches slots; `/btw` opens the panel.
+- Each slot has its own queue and child, so a slow answer in one does not block another.
 
-- another `/btw …` (or `/btw N …`) continues that slot's child when targeted
-- **alt+c** — inject answers into the main chat and clear the slot
-- **alt+x** — clear the slot (hidden tombstone in JSONL)
-- **alt+z** — prefill `/btw ` in the editor
-- **alt+h/l** — previous/next slot; **alt+1..9** — jump to slot
-- **alt+j/k** — fold/unfold the widget
-- **/btw config** — settings UI (model, thinking, shortcuts, links)
+Answers live in the transcript and survive restarts, but stay outside the main model context until injected. The widget only shows status and controls.
 
-In **General**: **Edit shortcuts** opens `~/.pi/agent/pi-smart-btw.json` in `$VISUAL` or `$EDITOR`. Use it for shortcuts and advanced JSON-only settings like `command`. Run `/reload` after editing shortcuts. **Esc** closes and saves (merges file + provider/model/thinking).
+## Controls
+
+- `Alt+C` — inject the active slot's answers into the main chat, then clear it
+- `Alt+X` — clear the active slot without injection
+- `Alt+Z` — prefill `/btw `
+- `Alt+H` / `Alt+L` — previous/next slot
+- `Alt+1` … `Alt+9` — jump to a slot
+- `Alt+J` / `Alt+K` — fold/unfold the widget
+- `/btw config` — model, thinking, shortcut, and link settings
 
 ## Configuration
 
-`~/.pi/agent/pi-smart-btw.json`:
-
-```json
-{
-  "provider": "openai-codex",
-  "modelId": "gpt-5.6-luna",
-  "command": "pi",
-  "thinking": "low",
-  "injectShortcut": "alt+c",
-  "dismissShortcut": "alt+x",
-  "composeShortcut": "alt+z",
-  "foldShortcut": "alt+j",
-  "unfoldShortcut": "alt+k",
-  "previousShortcut": "alt+h",
-  "nextShortcut": "alt+l"
-}
-```
-
-`thinking` accepts Pi levels through `max` and is clamped to the selected model's capabilities.
-
-## Development
-
-```bash
-npm install
-npm run check
-npm run pack:dry-run
-```
+Settings live at `~/.pi/agent/pi-smart-btw.json`. `/btw config` edits provider, model, and thinking. **Edit shortcuts** opens the JSON file in `$VISUAL` or `$EDITOR`; reload after changing shortcuts or advanced options such as `command`. Thinking is clamped to the selected model.

--- a/packages/pi-stuff/README.md
+++ b/packages/pi-stuff/README.md
@@ -1,11 +1,18 @@
 # @howaboua/pi-stuff
 
-Aggregate Pi package for all Howaboua Pi extensions and skills.
+The full general-purpose bundle: all 10 extensions from `@howaboua/pi-extensions` and all 8 skills from `@howaboua/pi-skills`.
 
-Includes the general extension bundle plus shareable skills such as `agents-md`, `model-facing-api-design`, `skill-creator`, `gh-issue-pr-flow`, `semantic_grep`, `vent`, and workflow tooling.
-
-Install:
+## Install
 
 ```bash
 pi install npm:@howaboua/pi-stuff
 ```
+
+This installs:
+
+- extensions: `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
+- skills: `agent-native-hardening`, `agents-md`, `anti-ai-copy`, `chrome-cdp`, `gh-issue-pr-flow`, `model-facing-api-design`, `project-reference-research`, and `skill-creator`
+
+`pi-codex-conversion` and `omarchy-help` are intentionally separate because they depend on model and workstation choices.
+
+Install `@howaboua/pi-extensions`, `@howaboua/pi-skills`, or an individual package when you want a smaller setup.

--- a/packages/pi-subagent-review/README.md
+++ b/packages/pi-subagent-review/README.md
@@ -1,77 +1,40 @@
-# pi-subagent-review
+# @howaboua/pi-subagent-review
 
-`@howaboua/pi-subagent-review` is a Pi extension that adds one slash command:
+Adds `/review`, which sends the current repository state to an isolated review subagent and injects its findings back into the main session for triage.
 
-- `/review`
-- `/review loop`
+## Install
 
-It runs an isolated review subagent against your current repo, optionally prepares a compact conversation-context summary first, injects the findings back into the session as a user message, and asks the main agent to triage those advisory findings before deciding what to address. It is modelled after Codex CLI's /review command.
+```bash
+pi install npm:@howaboua/pi-subagent-review
+```
 
-## What it does
+Run `/reload` after installation if Pi is already open.
 
-`/review`:
-- detects the current git repo
-- chooses a base branch automatically
-- computes the merge base with `HEAD`
-- if no usable base branch or merge base exists, reviews the current checkout as-is
-- if the checkout is clean and has no diff against the selected base, reviews the latest commit instead of stopping early
-- inspects committed and dirty worktree changes
-- summarizes the current Pi session branch as review context, when enabled
-- runs an isolated review subagent
-- sends the findings back into the current Pi session as a user message
-- makes clear that the findings are advisory, not direct user instructions, so the main agent should triage them against prior context before editing
-
-`/review loop` starts a review loop. It sets a review-specific marker at the current conversation point, strips the `loop` word from the review guidance, and then runs the normal review.
-
-The first `/review` in a session branch also adds a visible advisory preface without starting an agent turn. The preface tells the main agent not to treat review findings as a TODO list, and to summarize and triage them against session context and the current implementation before changing code.
-
-After that, plain `/review` detects the active review marker, summarizes the work since that marker back into a compact review-fix increment, advances the review marker, and then runs the next isolated review pass from the compacted point. If the stored marker is gone, `/review` simply behaves like a normal review.
-
-The review marker is separate from `@howaboua/pi-auto-trees`' generic `/marker`, so both extensions can be used in the same session.
-
-While `/review` is running, the extension shows a small review widget above the editor with one of two states:
-
-- `Preparing review context…`
-- `Reviewing changes…`
-
-The widget is UI-only and is cleared when the command finishes, fails, or is cancelled.
-
-## Automatic base branch selection
-
-The command chooses the base branch automatically:
-
-- if you are on a branch other than `main`, `master`, or `dev`, it reviews against `dev`
-- if no local `dev` exists, it falls back to `main`, then `master`
-- if you are on `dev`, it reviews against `main`, then `master`
-- if you are on `main` or `master`, it prefers `dev` when available
-
-This means you usually never need to specify the diff base manually.
-
-## User arguments
-
-Anything after `/review` is treated as extra review guidance.
-
-If the first word is `loop` in any casing, it starts review-loop mode and that word is removed from the review guidance.
-
-Examples:
+## Usage
 
 ```text
 /review
+/review focus on migrations and tests
 /review loop
-/review LoOp focus extra attention on migrations and tests
-/review focus extra attention on migrations and tests
-/review assess whether we introduced new UI elements instead of reusing established components and existing CSS patterns
 ```
 
-## Config
+Anything after `/review` becomes additional reviewer guidance. A leading `loop` starts review-loop mode and is removed from that guidance.
 
-On first load, the extension creates:
+Findings are advisory. The command tells the main agent to verify and categorize them against the current implementation and session context rather than treating them as a TODO list.
 
-- `~/.pi/agent/pi-subagent-review.json`
+## Review scope
 
-If Pi is using a custom agent directory via `PI_CODING_AGENT_DIR`, the file is created there instead.
+The extension chooses among local `dev`, `main`, and `master` branches, then reviews from the merge base so committed and dirty changes are included without base-only commits. With no usable base it reviews the checkout; with no changes it reviews the latest commit.
 
-Edit that file to change the default review model or thinking level, and the model used to summarize conversation context before review:
+When enabled, a separate model summarizes the current Pi branch for the reviewer; raw turns are not sent. Review continues diff-only if summarization fails.
+
+## Review loops
+
+`/review loop` records a review-specific marker. The next `/review` compacts fixes since that point, advances the marker, and starts another pass. It does not conflict with `pi-auto-trees`' `/marker`.
+
+## Configuration
+
+On first load, the extension creates `~/.pi/agent/pi-subagent-review.json`, or the equivalent path under `$PI_CODING_AGENT_DIR`.
 
 ```json
 {
@@ -85,35 +48,6 @@ Edit that file to change the default review model or thinking level, and the mod
 }
 ```
 
-The summary model uses the same `provider/model` string format as the reviewer model. Thinking levels through `max` are accepted and clamped to model capabilities. The generated summary is injected into the isolated review task as branch-style context; raw conversation turns are not sent to the review subagent. If the configured review or summary model is not available for the user, `/review` falls back to the current session model automatically. If conversation summarization still fails, `/review` continues with a diff-only review.
+Models use Pi's `provider/model` format. Thinking levels through `max` are accepted and clamped. If a configured model is unavailable, the command falls back to the current session model.
 
-Existing config files from older versions are migrated on load. If a config has `model` and `thinking` but no `summary` block, the extension adds one using the same model and low thinking:
-
-```json
-{
-  "summary": {
-    "enabled": true,
-    "model": "<existing review model>",
-    "thinking": "low"
-  }
-}
-```
-
-If a `summary` block already exists, it is left unchanged.
-
-## Install
-
-Installation methods:
-
-```bash
-pi install /absolute/path/to/pi-subagent-review
-pi install npm:@howaboua/pi-subagent-review
-pi install git:github.com/IgorWarzocha/pi-subagent-review
-```
-
-Then reload or restart Pi.
-
-## Notes
-
-- This extension registers `/review`.
-- Do not load it together with another extension that also registers `/review` unless you intentionally want that command collision.
+Do not load another extension that registers `/review` unless the command collision is intentional.

--- a/packages/pi-vent/README.md
+++ b/packages/pi-vent/README.md
@@ -1,48 +1,24 @@
-# pi-vent
+# @howaboua/pi-vent
 
-A tiny [Pi](https://pi.dev) extension that gives the agent a `vent` tool.
+Adds an agent-callable `vent` tool for recording repeated or systemic workflow friction in the current workspace's `VENT.md`.
 
-When the agent notices **repeated or systemic workflow friction**, it can leave a note in `VENT.md` in your current workspace. This is less about complaining and more about capturing patterns that should become future automation, docs, or workflow fixes.
+Use it for recurring tool failures, repeated manual workarounds, noisy output that forces the same retries, or instructions that repeatedly cause backtracking. Ordinary lint errors, one-off mistakes, and routine debugging do not belong there.
 
-The tool is meant for cases like repeated hook/tool failures with the same root cause, manually applying the same cleanup workaround more than once, tool output that forces the same retry sequence, or project instructions that cause avoidable backtracking. It should not be used for one-off lint/type errors or ordinary coding mistakes that are simply part of normal development.
-
-Entries are batched and appended near the end of an agent turn, so you get a useful feedback log without constant tool chatter.
-
-## What it writes
-
-If `VENT.md` does not exist, pi-vent creates it. Each entry is appended with a human-readable local timestamp:
-
-```md
-## 26-04-29 10:42 — tool_error
-
-Symptom: a hook failed twice for the same generated artifact. Repeated workaround: manually deleted the artifact and reran the same command sequence. Suggested fix: add cleanup to the hook or document the generated-file lifecycle.
-```
+Entries are batched near the end of an agent turn to avoid constant tool chatter.
 
 ## Install
-
-Install globally for all Pi projects:
 
 ```bash
 pi install npm:@howaboua/pi-vent
 ```
 
-Install only for the current project:
+Project-only install:
 
 ```bash
 pi install -l npm:@howaboua/pi-vent
 ```
 
-Try it for one run without installing:
-
-```bash
-pi -e npm:@howaboua/pi-vent
-```
-
-Pi packages run with your full system permissions. Only install extensions from sources you trust.
-
 ## Tool
-
-pi-vent registers one tool:
 
 ```ts
 vent({
@@ -51,7 +27,13 @@ vent({
 })
 ```
 
-- `thought` — the repeated/systemic friction note. Good entries include what failed, what workaround was repeated, and what would prevent it next time.
-- `trigger` — optional short label, for example `tool_error`, `bad_docs`, or `confusing_task`.
+- `thought` describes the failure, repeated workaround, and useful preventative fix.
+- `trigger` is an optional short label such as `tool_error`, `bad_docs`, or `confusing_task`.
 
-The tool description tells the agent to use it for repeated workflow friction, batch feedback, and call it near the end of the turn after completing the task.
+The extension creates `VENT.md` when needed and appends each note under a local timestamp:
+
+```md
+## 26-04-29 10:42 — tool_error
+
+Symptom: a hook failed twice for the same generated artifact. Repeated workaround: deleted the artifact and reran the same command sequence. Suggested fix: add cleanup to the hook or document the generated-file lifecycle.
+```


### PR DESCRIPTION
## Summary
- tighten the `change_reasoning` agent-facing contract and user-minimum messaging
- load nested `AGENTS.md` context from successful pi-codex Code Mode tool traces
- rewrite package documentation around current installation, configuration, usage, and behavior

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- isolated `/review` against `dev`: no actionable issues

## Release
- Changeset: yes
- Packages: `@howaboua/pi-auto-reasoning-tool`, `@howaboua/pi-markdown-workflows`, and the directly documented packages
- Aggregates: generated by release automation
