### PR TITLE
Fix pi-codex-conversion extension startup

### DIFF
--- a/.changeset/solid-mangos-sing.md
+++ b/.changeset/solid-mangos-sing.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Fix extension startup in Pi by avoiding a runtime pi-ai API subpath import.

--- a/.changeset/solid-mangos-sing.md
+++ b/.changeset/solid-mangos-sing.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Fix extension startup in Pi by avoiding a runtime pi-ai API subpath import.
+Fix extension startup in Pi by using its modern root API factory instead of a runtime pi-ai subpath import.

--- a/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
@@ -9,7 +9,6 @@ import {
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 import { getApiProvider } from "@earendil-works/pi-ai/compat";
-import { streamSimple as standardResponsesStream } from "@earendil-works/pi-ai/api/openai-responses";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
@@ -158,7 +157,6 @@ export function registerCodeModeProxyProvider(
 	getConfig: () => CodexConversionConfig,
 ): CodeModeProxyProviderRegistration {
 	let registered = false;
-	let fallbackStream = standardResponsesStream;
 	const shutdown = () => {
 		if (!registered) return;
 		pi.unregisterProvider(BRIDGE_PROVIDER);
@@ -174,7 +172,8 @@ export function registerCodeModeProxyProvider(
 			shutdown();
 			return;
 		}
-		fallbackStream = getApiProvider("openai-responses")?.streamSimple ?? standardResponsesStream;
+		const fallbackStream = getApiProvider("openai-responses")?.streamSimple;
+		if (!fallbackStream) throw new Error("No built-in openai-responses provider is registered");
 		pi.registerProvider(BRIDGE_PROVIDER, {
 			api: "openai-responses",
 			streamSimple: (model, context, options) =>

--- a/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
@@ -1,14 +1,15 @@
 import OpenAI, { APIError } from "openai";
 import {
 	createAssistantMessageEventStream,
+	lazyApi,
 	type Api,
 	type AssistantMessage,
 	type Context,
 	type Model,
 	type ProviderHeaders,
+	type ProviderStreams,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
-import { getApiProvider } from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
@@ -19,6 +20,10 @@ import { processCodexResponsesStream } from "./openai-codex/stream-events.ts";
 import type { OpenAICodexStreamOptions, ResponsesBody, StreamEventShape } from "./openai-codex/types.ts";
 
 const BRIDGE_PROVIDER = "@howaboua/pi-codex-conversion:responses-proxy";
+const OPENAI_RESPONSES_API_MODULE = "@earendil-works/pi-ai/api/openai-responses";
+const standardResponsesStream = lazyApi(async () =>
+	await import(OPENAI_RESPONSES_API_MODULE) as ProviderStreams
+).streamSimple;
 
 function initialAssistantMessage<TApi extends Api>(model: Model<TApi>): AssistantMessage {
 	return {
@@ -172,14 +177,12 @@ export function registerCodeModeProxyProvider(
 			shutdown();
 			return;
 		}
-		const fallbackStream = getApiProvider("openai-responses")?.streamSimple;
-		if (!fallbackStream) throw new Error("No built-in openai-responses provider is registered");
 		pi.registerProvider(BRIDGE_PROVIDER, {
 			api: "openai-responses",
 			streamSimple: (model, context, options) =>
 				shouldUseGpt56CodeMode({ model }, getConfig())
 					? streamCodeModeResponsesProxy(model, context, options)
-					: fallbackStream(model as never, context, options),
+					: standardResponsesStream(model as never, context, options),
 		});
 		registered = true;
 	};


### PR DESCRIPTION
## Summary
- remove the loader-breaking static pi-ai API subpath import
- keep the extension on modern Pi surfaces: pi.registerProvider and the direct Responses API module, loaded lazily so Jiti does not rewrite its package subpath
- preserve ordinary Responses delegation without using the compat registry
- add a patch changeset for @howaboua/pi-codex-conversion

## Validation
- bun run check:changed (108 tests)
- bun run changeset:check
- built extension loaded and streamed an ordinary Responses request through Pi's actual Jiti loader
- clean npm tarball install loaded and streamed through Pi's actual Jiti loader
- installed package starts Pi successfully
- post-commit reviewer found no actionable issues before the modern fallback correction; the correction was then covered by the package suite and loader/package smoke tests

## Release
- Changeset: yes
- Packages: @howaboua/pi-codex-conversion
- Aggregates: generated by release automation
