### PR TITLE
Add pi-ask human-in-the-loop extension

### DIFF
--- a/.changeset/calm-mice-ask.md
+++ b/.changeset/calm-mice-ask.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-ask": patch
 ---
 
-Add interactive human input, review triage, and handoff prompts through the `ask` tool, plus `/fold` and `/grill` workflows.
+Add interactive human input, review triage, and handoff prompts through the `ask` tool, plus configurable `/fold` and `/grill` workflows.

--- a/.changeset/calm-mice-ask.md
+++ b/.changeset/calm-mice-ask.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-ask": patch
+---
+
+Add interactive human input, review triage, and handoff prompts through the `ask` tool, plus `/fold` and `/grill` workflows.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 | Package | Includes | Deliberate exclusions |
 |---|---|---|
-| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 10 general extensions and 8 shareable skills | Codex conversion and Omarchy support |
-| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 10 general extensions | Codex conversion |
+| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 11 general extensions and 8 shareable skills | Codex conversion and Omarchy support |
+| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 11 general extensions | Codex conversion |
 | [`@howaboua/pi-skills`](./packages/pi-skills) | 8 shareable skills | Omarchy support |
 
 ```bash
@@ -27,6 +27,7 @@ pi install npm:@howaboua/pi-skills
 
 | Package | What it adds |
 |---|---|
+| [`pi-ask`](./packages/pi-ask) | Interactive user decisions, review triage, and human handoffs |
 | [`pi-auto-reasoning-tool`](./packages/pi-auto-reasoning-tool) | An agent-callable `change_reasoning` tool with the user's selected level as its floor |
 | [`pi-auto-trees`](./packages/pi-auto-trees) | `/marker` and `/end` for rolling completed work into a compact branch summary |
 | [`pi-codex-conversion`](./packages/pi-codex-conversion) | Codex-shaped shell, patch, image, web, and Code Mode tools for GPT/Codex models |

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,22 @@
         "web-tree-sitter": "^0.26.7",
       },
     },
+    "packages/pi-ask": {
+      "name": "@howaboua/pi-ask",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
+        "@earendil-works/pi-coding-agent": "0.80.7",
+        "@earendil-works/pi-tui": "0.80.7",
+        "typebox": "1.1.38",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.7",
+        "@earendil-works/pi-tui": ">=0.80.7",
+        "typebox": "*",
+      },
+    },
     "packages/pi-auto-reasoning-tool": {
       "name": "@howaboua/pi-auto-reasoning-tool",
       "version": "0.1.9",
@@ -133,6 +149,7 @@
       "name": "@howaboua/pi-extensions",
       "version": "0.0.22",
       "dependencies": {
+        "@howaboua/pi-ask": "0.0.0",
         "@howaboua/pi-auto-reasoning-tool": "0.1.9",
         "@howaboua/pi-auto-trees": "0.1.8",
         "@howaboua/pi-dynamic-tools": "0.0.5",
@@ -279,6 +296,7 @@
       "name": "@howaboua/pi-stuff",
       "version": "0.0.22",
       "dependencies": {
+        "@howaboua/pi-ask": "0.0.0",
         "@howaboua/pi-auto-reasoning-tool": "0.1.9",
         "@howaboua/pi-auto-trees": "0.1.8",
         "@howaboua/pi-dynamic-tools": "0.0.5",
@@ -510,6 +528,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@howaboua/pi-ask": ["@howaboua/pi-ask@workspace:packages/pi-ask"],
 
     "@howaboua/pi-auto-reasoning-tool": ["@howaboua/pi-auto-reasoning-tool@workspace:packages/pi-auto-reasoning-tool"],
 
@@ -1122,6 +1142,8 @@
     "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "@howaboua/pi-ask/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "@howaboua/pi-auto-reasoning-tool/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/packages/pi-ask/.gitignore
+++ b/packages/pi-ask/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/packages/pi-ask/AGENTS.md
+++ b/packages/pi-ask/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent notes
+
+- This is a pi extension; `index.ts` is only the entrypoint.
+- `ask` is the single human-in-the-loop surface for input, review, and handoff.
+- Feature code lives under `ask/`: constants, contracts, normalize, state, pi-ui, tui, tool.
+- Keep LLM-facing tool text short and user-facing.
+- Preserve the blank `Other/rephrase` contract: it means the agent should rephrase or follow up.
+- Keep response state in named objects, not parallel arrays.
+- When changing TUI behavior, check pi extension/TUI docs and examples first.

--- a/packages/pi-ask/LICENSE
+++ b/packages/pi-ask/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Igor Warzocha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-ask/README.md
+++ b/packages/pi-ask/README.md
@@ -1,0 +1,38 @@
+# @howaboua/pi-ask
+
+Adds one agent-callable `ask` tool for human input. It handles free-text prompts, batched choices, review dispositions, and user-only handoffs without making the agent dump a report into chat first.
+
+## Install
+
+```bash
+pi install npm:@howaboua/pi-ask
+```
+
+Try it for one session:
+
+```bash
+pi -e npm:@howaboua/pi-ask
+```
+
+## How it behaves
+
+The agent can present several independently decidable prompts in one tabbed panel. Each prompt supports a short title, supporting evidence, one or more choices, free text, and an optional comment. Review findings become one prompt each, so you can fix, defer, or reject them without translating a wall of prose back into instructions.
+
+For work only you can complete—sign-in, authorization, hardware access, or another manual step—the agent can open a handoff and wait until you mark it done or unable to complete.
+
+`Other/rephrase` is always available. Submit it blank when the prompt needs to be rephrased, split, or followed up instead of answered as written.
+
+## Prompt commands
+
+- `/fold [report]` turns a long report or structured list into one interactive disposition prompt per item.
+- `/grill [idea]` investigates an idea, asks successive decisions, and keeps the agreed plan in `docs/`.
+
+## TUI controls
+
+- `Up` / `Down` — move through choices, free text, and comments
+- `Enter` — choose or edit the focused item
+- `Left` / `Right` — move between prompts and the review tab
+- `Tab` — advance, using `Other/rephrase` when the current prompt is unanswered
+- `Esc` — dismiss the panel
+
+The tool requires Pi's interactive TUI or RPC UI. It returns dismissal as a distinct result so the agent can stop asking rather than guessing.

--- a/packages/pi-ask/README.md
+++ b/packages/pi-ask/README.md
@@ -27,6 +27,17 @@ For work only you can complete—sign-in, authorization, hardware access, or ano
 - `/fold [report]` turns a long report or structured list into one interactive disposition prompt per item.
 - `/grill [idea]` investigates an idea, asks successive decisions, and keeps the agreed plan in `docs/`.
 
+Both templates are enabled by default. The extension creates `~/.pi/agent/ask.json` on first load:
+
+```json
+{
+  "grill": true,
+  "fold": true
+}
+```
+
+Set either value to `false`, then run `/reload`, to hide that template. The same configuration applies when pi-ask is installed through `@howaboua/pi-extensions` or `@howaboua/pi-stuff`.
+
 ## TUI controls
 
 - `Up` / `Down` — move through choices, free text, and comments

--- a/packages/pi-ask/ask/config.ts
+++ b/packages/pi-ask/ask/config.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+interface AskConfig {
+	grill: boolean;
+	fold: boolean;
+}
+
+const DEFAULT_CONFIG: AskConfig = {
+	grill: true,
+	fold: true,
+};
+
+function askConfigPath(): string {
+	return join(getAgentDir(), "ask.json");
+}
+
+export function loadAskConfig(path = askConfigPath()): AskConfig {
+	if (!existsSync(path)) {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`, "utf8");
+		return { ...DEFAULT_CONFIG };
+	}
+
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<AskConfig>;
+		return {
+			grill: typeof raw.grill === "boolean" ? raw.grill : DEFAULT_CONFIG.grill,
+			fold: typeof raw.fold === "boolean" ? raw.fold : DEFAULT_CONFIG.fold,
+		};
+	} catch {
+		return { ...DEFAULT_CONFIG };
+	}
+}

--- a/packages/pi-ask/ask/config.ts
+++ b/packages/pi-ask/ask/config.ts
@@ -18,8 +18,16 @@ function askConfigPath(): string {
 
 export function loadAskConfig(path = askConfigPath()): AskConfig {
 	if (!existsSync(path)) {
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`, "utf8");
+		try {
+			mkdirSync(dirname(path), { recursive: true });
+			writeFileSync(
+				path,
+				`${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,
+				"utf8",
+			);
+		} catch {
+			// A read-only agent directory must not disable default prompt resources.
+		}
 		return { ...DEFAULT_CONFIG };
 	}
 

--- a/packages/pi-ask/ask/constants.ts
+++ b/packages/pi-ask/ask/constants.ts
@@ -1,0 +1,7 @@
+export const OTHER_OPTION_LABEL = "Other/rephrase";
+export const REPHRASE_REQUEST_RESPONSE =
+	"User asked for rephrase, split, or follow-up.";
+export const HANDOFF_CHOICES = [
+	{ label: "Done" },
+	{ label: "Could not complete" },
+];

--- a/packages/pi-ask/ask/contracts.ts
+++ b/packages/pi-ask/ask/contracts.ts
@@ -1,0 +1,48 @@
+import { type Static, Type } from "typebox";
+
+export { OTHER_OPTION_LABEL, REPHRASE_REQUEST_RESPONSE } from "./constants.js";
+
+export const ChoiceSchema = Type.Object({
+	label: Type.String({ description: "Short choice." }),
+	description: Type.Optional(Type.String({ description: "Optional detail." })),
+});
+
+export const PromptSchema = Type.Object({
+	title: Type.String({ description: "Short prompt." }),
+	body: Type.Optional(Type.String({ description: "Context or evidence." })),
+	multiple: Type.Optional(Type.Boolean({ description: "Allow multiple." })),
+	choices: Type.Optional(
+		Type.Array(ChoiceSchema, { description: "Choices; omit for free text." }),
+	),
+});
+
+export const AskParameters = Type.Object({
+	handoff: Type.Optional(
+		Type.Boolean({ description: "Wait for user action." }),
+	),
+	prompts: Type.Array(PromptSchema, { description: "Prompts." }),
+});
+
+export type AskInput = Static<typeof AskParameters>;
+export type PromptChoice = Static<typeof ChoiceSchema>;
+
+export interface AskPrompt {
+	id: string;
+	title: string;
+	body?: string;
+	multiple: boolean;
+	choices: PromptChoice[];
+}
+
+export interface AskResponse {
+	id: string;
+	selections: string[];
+	comment?: string;
+}
+
+export interface PromptState {
+	selections: string[];
+	customText: string;
+	customEnabled: boolean;
+	comment: string;
+}

--- a/packages/pi-ask/ask/normalize.ts
+++ b/packages/pi-ask/ask/normalize.ts
@@ -1,0 +1,107 @@
+import { HANDOFF_CHOICES, OTHER_OPTION_LABEL } from "./constants.js";
+import type {
+	AskInput,
+	AskPrompt,
+	AskResponse,
+	PromptChoice,
+} from "./contracts.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function textContent(text: string): { type: "text"; text: string } {
+	return { type: "text", text };
+}
+
+export function normalizePromptChoice(choice: unknown): PromptChoice | null {
+	if (!isRecord(choice)) return null;
+	const label =
+		typeof choice["label"] === "string" ? choice["label"].trim() : "";
+	if (!label || label === OTHER_OPTION_LABEL) return null;
+	const description =
+		typeof choice["description"] === "string"
+			? choice["description"].trim()
+			: "";
+	return { label, ...(description ? { description } : {}) };
+}
+
+export function normalizePrompt(
+	input: unknown,
+	index: number,
+	handoff = false,
+): AskPrompt | null {
+	if (!isRecord(input)) return null;
+	const title = typeof input["title"] === "string" ? input["title"].trim() : "";
+	if (!title) return null;
+	const body = typeof input["body"] === "string" ? input["body"].trim() : "";
+	const choices = Array.isArray(input["choices"])
+		? input["choices"]
+				.map(normalizePromptChoice)
+				.filter((choice) => choice !== null)
+		: [];
+	return {
+		id: `p${index + 1}`,
+		title,
+		...(body ? { body } : {}),
+		multiple: input["multiple"] === true,
+		choices: handoff && choices.length === 0 ? [...HANDOFF_CHOICES] : choices,
+	};
+}
+
+export function normalizeAskInput(params: AskInput | null | undefined): {
+	handoff: boolean;
+	prompts: AskPrompt[];
+} {
+	const handoff = params?.handoff === true;
+	const prompts = Array.isArray(params?.prompts)
+		? params.prompts
+				.map((prompt, index) => normalizePrompt(prompt, index, handoff))
+				.filter((prompt) => prompt !== null)
+		: [];
+	return { handoff, prompts };
+}
+
+export function normalizeResponses(
+	prompts: AskPrompt[],
+	responses: unknown,
+): AskResponse[] | null {
+	if (!Array.isArray(responses)) return null;
+	return prompts.map((prompt, index) => {
+		const response: unknown = responses[index];
+		const rawSelections = Array.isArray(response)
+			? response
+			: isRecord(response) && Array.isArray(response["selections"])
+				? response["selections"]
+				: [];
+		const selections = rawSelections.filter(
+			(selection): selection is string => {
+				return typeof selection === "string";
+			},
+		);
+		const comment =
+			isRecord(response) && typeof response["comment"] === "string"
+				? response["comment"].trim()
+				: "";
+		return {
+			id: prompt.id,
+			selections,
+			...(comment ? { comment } : {}),
+		};
+	});
+}
+
+export function summarizeResponses(
+	prompts: AskPrompt[],
+	responses: AskResponse[],
+): string {
+	return responses
+		.map((response, index) => {
+			const prompt = prompts[index];
+			const selection = `${prompt?.title ?? `Prompt ${index + 1}`}: ${response.selections.join(", ") || "No selection"}`;
+			return response.comment
+				? `${selection}\n  Comment: ${response.comment}`
+				: selection;
+		})
+		.join("\n");
+}

--- a/packages/pi-ask/ask/pi-ui.ts
+++ b/packages/pi-ask/ask/pi-ui.ts
@@ -31,13 +31,13 @@ async function askComment(
 	ctx: ExtensionContext,
 	prompt: AskPrompt,
 	signal?: AbortSignal,
-): Promise<string> {
+): Promise<string | null> {
 	const value = await ctx.ui.input(
 		`${prompt.title} — comment`,
 		"Optional comment",
 		dialogOptions(signal),
 	);
-	return typeof value === "string" ? value.trim() : "";
+	return value === undefined ? null : value.trim();
 }
 
 function finishSelectionLabelFor(choices: string[]): string {
@@ -122,7 +122,7 @@ export async function askWithPiUi(
 			: await askSingleWithPiUi(ctx, prompt, handoff, signal);
 		if (!selections) return null;
 		const comment = await askComment(ctx, prompt, signal);
-		if (signal?.aborted) return null;
+		if (comment === null || signal?.aborted) return null;
 		responses.push({
 			id: prompt.id,
 			selections,

--- a/packages/pi-ask/ask/pi-ui.ts
+++ b/packages/pi-ask/ask/pi-ui.ts
@@ -3,13 +3,21 @@ import { OTHER_OPTION_LABEL } from "./constants.js";
 import type { AskPrompt, AskResponse } from "./contracts.js";
 import { customSelectionFor } from "./state.js";
 
+function dialogOptions(
+	signal?: AbortSignal,
+): { signal: AbortSignal } | undefined {
+	return signal ? { signal } : undefined;
+}
+
 async function askOther(
 	ctx: ExtensionContext,
 	prompt: AskPrompt,
+	signal?: AbortSignal,
 ): Promise<string | null> {
 	const value = await ctx.ui.input(
 		prompt.title,
 		"Alternative; blank = rephrase",
+		dialogOptions(signal),
 	);
 	return value === undefined ? null : customSelectionFor(value);
 }
@@ -22,30 +30,51 @@ function promptText(prompt: AskPrompt, handoff: boolean): string {
 async function askComment(
 	ctx: ExtensionContext,
 	prompt: AskPrompt,
+	signal?: AbortSignal,
 ): Promise<string> {
 	const value = await ctx.ui.input(
 		`${prompt.title} — comment`,
 		"Optional comment",
+		dialogOptions(signal),
 	);
 	return typeof value === "string" ? value.trim() : "";
+}
+
+function finishSelectionLabelFor(choices: string[]): string {
+	const base = "Finish selection";
+	const unavailable = new Set([...choices, OTHER_OPTION_LABEL]);
+	let label = base;
+	let suffix = 2;
+	while (unavailable.has(label)) {
+		label = `${base} (${suffix})`;
+		suffix++;
+	}
+	return label;
 }
 
 async function askSingleWithPiUi(
 	ctx: ExtensionContext,
 	prompt: AskPrompt,
 	handoff: boolean,
+	signal?: AbortSignal,
 ): Promise<string[] | null> {
 	const choices = prompt.choices.map((choice) => choice.label);
 	const picked =
 		choices.length > 0
-			? await ctx.ui.select(promptText(prompt, handoff), [
-					...choices,
-					OTHER_OPTION_LABEL,
-				])
-			: await ctx.ui.input(promptText(prompt, handoff), "Response");
-	if (!picked) return null;
+			? await ctx.ui.select(
+					promptText(prompt, handoff),
+					[...choices, OTHER_OPTION_LABEL],
+					dialogOptions(signal),
+				)
+			: await ctx.ui.input(
+					promptText(prompt, handoff),
+					"Response",
+					dialogOptions(signal),
+				);
+	if (picked === undefined) return null;
+	if (choices.length === 0) return [customSelectionFor(picked)];
 	if (picked !== OTHER_OPTION_LABEL) return [picked];
-	const other = await askOther(ctx, prompt);
+	const other = await askOther(ctx, prompt, signal);
 	return other === null ? null : [other];
 }
 
@@ -53,19 +82,25 @@ async function askMultipleWithPiUi(
 	ctx: ExtensionContext,
 	prompt: AskPrompt,
 	handoff: boolean,
+	signal?: AbortSignal,
 ): Promise<string[] | null> {
 	const choices = prompt.choices.map((choice) => choice.label);
+	const finishSelectionLabel = finishSelectionLabelFor(choices);
 	const picked: string[] = [];
 	while (true) {
-		const next = await ctx.ui.select(promptText(prompt, handoff), [
-			...choices.filter((choice) => !picked.includes(choice)),
-			OTHER_OPTION_LABEL,
-			"Done",
-		]);
-		if (!next) return null;
-		if (next === "Done") return picked;
+		const next = await ctx.ui.select(
+			promptText(prompt, handoff),
+			[
+				...choices.filter((choice) => !picked.includes(choice)),
+				OTHER_OPTION_LABEL,
+				finishSelectionLabel,
+			],
+			dialogOptions(signal),
+		);
+		if (next === undefined) return null;
+		if (next === finishSelectionLabel) return picked;
 		if (next === OTHER_OPTION_LABEL) {
-			const other = await askOther(ctx, prompt);
+			const other = await askOther(ctx, prompt, signal);
 			if (other === null) return null;
 			picked.push(other);
 		} else {
@@ -77,16 +112,17 @@ async function askMultipleWithPiUi(
 export async function askWithPiUi(
 	ctx: ExtensionContext,
 	prompts: AskPrompt[],
-	{ handoff = false }: { handoff?: boolean } = {},
+	{ handoff = false, signal }: { handoff?: boolean; signal?: AbortSignal } = {},
 ): Promise<AskResponse[] | null> {
-	if (!ctx.hasUI) return null;
+	if (!ctx.hasUI || signal?.aborted) return null;
 	const responses: AskResponse[] = [];
 	for (const prompt of prompts) {
 		const selections = prompt.multiple
-			? await askMultipleWithPiUi(ctx, prompt, handoff)
-			: await askSingleWithPiUi(ctx, prompt, handoff);
+			? await askMultipleWithPiUi(ctx, prompt, handoff, signal)
+			: await askSingleWithPiUi(ctx, prompt, handoff, signal);
 		if (!selections) return null;
-		const comment = await askComment(ctx, prompt);
+		const comment = await askComment(ctx, prompt, signal);
+		if (signal?.aborted) return null;
 		responses.push({
 			id: prompt.id,
 			selections,

--- a/packages/pi-ask/ask/pi-ui.ts
+++ b/packages/pi-ask/ask/pi-ui.ts
@@ -1,0 +1,97 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { OTHER_OPTION_LABEL } from "./constants.js";
+import type { AskPrompt, AskResponse } from "./contracts.js";
+import { customSelectionFor } from "./state.js";
+
+async function askOther(
+	ctx: ExtensionContext,
+	prompt: AskPrompt,
+): Promise<string | null> {
+	const value = await ctx.ui.input(
+		prompt.title,
+		"Alternative; blank = rephrase",
+	);
+	return value === undefined ? null : customSelectionFor(value);
+}
+
+function promptText(prompt: AskPrompt, handoff: boolean): string {
+	const text = prompt.body ? `${prompt.title}\n\n${prompt.body}` : prompt.title;
+	return handoff ? `Human action needed\n\n${text}` : text;
+}
+
+async function askComment(
+	ctx: ExtensionContext,
+	prompt: AskPrompt,
+): Promise<string> {
+	const value = await ctx.ui.input(
+		`${prompt.title} — comment`,
+		"Optional comment",
+	);
+	return typeof value === "string" ? value.trim() : "";
+}
+
+async function askSingleWithPiUi(
+	ctx: ExtensionContext,
+	prompt: AskPrompt,
+	handoff: boolean,
+): Promise<string[] | null> {
+	const choices = prompt.choices.map((choice) => choice.label);
+	const picked =
+		choices.length > 0
+			? await ctx.ui.select(promptText(prompt, handoff), [
+					...choices,
+					OTHER_OPTION_LABEL,
+				])
+			: await ctx.ui.input(promptText(prompt, handoff), "Response");
+	if (!picked) return null;
+	if (picked !== OTHER_OPTION_LABEL) return [picked];
+	const other = await askOther(ctx, prompt);
+	return other === null ? null : [other];
+}
+
+async function askMultipleWithPiUi(
+	ctx: ExtensionContext,
+	prompt: AskPrompt,
+	handoff: boolean,
+): Promise<string[] | null> {
+	const choices = prompt.choices.map((choice) => choice.label);
+	const picked: string[] = [];
+	while (true) {
+		const next = await ctx.ui.select(promptText(prompt, handoff), [
+			...choices.filter((choice) => !picked.includes(choice)),
+			OTHER_OPTION_LABEL,
+			"Done",
+		]);
+		if (!next) return null;
+		if (next === "Done") return picked;
+		if (next === OTHER_OPTION_LABEL) {
+			const other = await askOther(ctx, prompt);
+			if (other === null) return null;
+			picked.push(other);
+		} else {
+			picked.push(next);
+		}
+	}
+}
+
+export async function askWithPiUi(
+	ctx: ExtensionContext,
+	prompts: AskPrompt[],
+	{ handoff = false }: { handoff?: boolean } = {},
+): Promise<AskResponse[] | null> {
+	if (!ctx.hasUI) return null;
+	const responses: AskResponse[] = [];
+	for (const prompt of prompts) {
+		const selections = prompt.multiple
+			? await askMultipleWithPiUi(ctx, prompt, handoff)
+			: await askSingleWithPiUi(ctx, prompt, handoff);
+		if (!selections) return null;
+		const comment = await askComment(ctx, prompt);
+		responses.push({
+			id: prompt.id,
+			selections,
+			...(comment ? { comment } : {}),
+		});
+	}
+	return responses;
+}

--- a/packages/pi-ask/ask/state.ts
+++ b/packages/pi-ask/ask/state.ts
@@ -1,0 +1,90 @@
+import { REPHRASE_REQUEST_RESPONSE } from "./constants.js";
+import type {
+	AskPrompt,
+	AskResponse,
+	PromptChoice,
+	PromptState,
+} from "./contracts.js";
+
+export function customSelectionFor(value: unknown): string {
+	const trimmed = typeof value === "string" ? value.trim() : "";
+	return trimmed || REPHRASE_REQUEST_RESPONSE;
+}
+
+export function createPromptState(): PromptState {
+	return { selections: [], customText: "", customEnabled: false, comment: "" };
+}
+
+export function promptStateResponded(
+	promptState: PromptState | undefined,
+): boolean {
+	return (
+		(promptState?.selections.length ?? 0) > 0 ||
+		promptState?.customEnabled === true ||
+		Boolean(promptState?.comment.trim())
+	);
+}
+
+export function promptStatesToResponses(
+	prompts: Array<Pick<AskPrompt, "id">>,
+	promptStates: PromptState[],
+): AskResponse[] {
+	return promptStates.map((promptState, index) => {
+		const comment = promptState.comment.trim();
+		return {
+			id: prompts[index]?.id ?? `p${index + 1}`,
+			selections: promptState.selections,
+			...(comment ? { comment } : {}),
+		};
+	});
+}
+
+export function saveComment(
+	promptState: PromptState,
+	submittedText: unknown,
+): void {
+	promptState.comment = typeof submittedText === "string" ? submittedText : "";
+}
+
+export function saveCustomSelection(
+	prompt: Pick<AskPrompt, "multiple"> | undefined,
+	promptState: PromptState,
+	submittedText: unknown,
+): void {
+	const previous = promptState.customEnabled
+		? customSelectionFor(promptState.customText)
+		: null;
+	const value = typeof submittedText === "string" ? submittedText : "";
+	const next = customSelectionFor(value);
+
+	promptState.customText = value;
+	promptState.customEnabled = true;
+
+	if (prompt?.multiple) {
+		promptState.selections = [
+			...promptState.selections.filter(
+				(item) => item !== next && item !== previous,
+			),
+			next,
+		];
+	} else {
+		promptState.selections = [next];
+	}
+}
+
+export function pickChoiceSelection(
+	prompt: Pick<AskPrompt, "multiple"> | undefined,
+	promptState: PromptState,
+	choice: PromptChoice | undefined,
+): void {
+	if (!choice) return;
+	if (prompt?.multiple) {
+		promptState.selections = promptState.selections.includes(choice.label)
+			? promptState.selections.filter((item) => item !== choice.label)
+			: [...promptState.selections, choice.label];
+		return;
+	}
+
+	promptState.selections = [choice.label];
+	promptState.customEnabled = false;
+}

--- a/packages/pi-ask/ask/state.ts
+++ b/packages/pi-ask/ask/state.ts
@@ -72,6 +72,16 @@ export function saveCustomSelection(
 	}
 }
 
+export function clearCustomSelection(promptState: PromptState): void {
+	if (!promptState.customEnabled) return;
+	const customSelection = customSelectionFor(promptState.customText);
+	promptState.selections = promptState.selections.filter(
+		(item) => item !== customSelection,
+	);
+	promptState.customText = "";
+	promptState.customEnabled = false;
+}
+
 export function pickChoiceSelection(
 	prompt: Pick<AskPrompt, "multiple"> | undefined,
 	promptState: PromptState,

--- a/packages/pi-ask/ask/tool.ts
+++ b/packages/pi-ask/ask/tool.ts
@@ -32,6 +32,7 @@ export function createAskTool({
 			"ask: For reviews, make each finding a prompt with disposition choices; do not report first.",
 			"ask: Do not add Other/rephrase; it is automatic.",
 		],
+		executionMode: "sequential",
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const { handoff, prompts } = normalizeAskInput(params);
 			if (prompts.length === 0) {
@@ -45,8 +46,14 @@ export function createAskTool({
 			const rawResponses = askInComposer
 				? await askInComposer(prompts, signal)
 				: ctx.mode === "tui"
-					? await askInTui(ctx, prompts, { handoff })
-					: await askWithPiUi(ctx, prompts, { handoff });
+					? await askInTui(ctx, prompts, {
+							handoff,
+							...(signal ? { signal } : {}),
+						})
+					: await askWithPiUi(ctx, prompts, {
+							handoff,
+							...(signal ? { signal } : {}),
+						});
 			const responses = normalizeResponses(prompts, rawResponses);
 			if (!responses) {
 				return {

--- a/packages/pi-ask/ask/tool.ts
+++ b/packages/pi-ask/ask/tool.ts
@@ -1,0 +1,83 @@
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { AskParameters, type AskPrompt } from "./contracts.js";
+import {
+	normalizeAskInput,
+	normalizeResponses,
+	summarizeResponses,
+	textContent,
+} from "./normalize.js";
+import { askWithPiUi } from "./pi-ui.js";
+import { askInTui } from "./tui.js";
+
+type AskInComposer = (
+	prompts: AskPrompt[],
+	signal: AbortSignal | undefined,
+) => Promise<unknown>;
+
+export function createAskTool({
+	askInComposer,
+}: {
+	askInComposer?: AskInComposer;
+} = {}) {
+	return defineTool({
+		name: "ask",
+		label: "Ask",
+		description:
+			"Request user input or action and return the response. Requires interactive UI.",
+		parameters: AskParameters,
+		promptSnippet: "ask: Request human input or action.",
+		promptGuidelines: [
+			"ask: Use for needed user decisions or input; set handoff true for a user-only action and state its completion signal.",
+			"ask: For reviews, make each finding a prompt with disposition choices; do not report first.",
+			"ask: Do not add Other/rephrase; it is automatic.",
+		],
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const { handoff, prompts } = normalizeAskInput(params);
+			if (prompts.length === 0) {
+				throw new Error(
+					"ask requires at least one prompt with a non-empty title.",
+				);
+			}
+			if (!askInComposer && !ctx.hasUI)
+				throw new Error("ask requires an interactive UI.");
+
+			const rawResponses = askInComposer
+				? await askInComposer(prompts, signal)
+				: ctx.mode === "tui"
+					? await askInTui(ctx, prompts, { handoff })
+					: await askWithPiUi(ctx, prompts, { handoff });
+			const responses = normalizeResponses(prompts, rawResponses);
+			if (!responses) {
+				return {
+					content: [
+						textContent(
+							handoff ? "Handoff dismissed by user." : "Dismissed by user.",
+						),
+					],
+					details: { dismissed: true, kind: handoff ? "handoff" : "prompt" },
+				};
+			}
+			return {
+				content: [textContent(summarizeResponses(prompts, responses))],
+				details: { kind: handoff ? "handoff" : "prompt", responses },
+			};
+		},
+		renderCall(args, theme) {
+			const count = Array.isArray(args.prompts) ? args.prompts.length : 0;
+			return new Text(
+				theme.fg(
+					"toolTitle",
+					theme.bold(args.handoff === true ? "ask handoff " : "ask "),
+				) + theme.fg("muted", `${count} prompt${count === 1 ? "" : "s"}`),
+				0,
+				0,
+			);
+		},
+		renderResult(result, _options, theme) {
+			const text =
+				result.content[0]?.type === "text" ? result.content[0].text : "";
+			return new Text(theme.fg("success", text), 0, 0);
+		},
+	});
+}

--- a/packages/pi-ask/ask/tui.ts
+++ b/packages/pi-ask/ask/tui.ts
@@ -1,0 +1,516 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	Editor,
+	Key,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { OTHER_OPTION_LABEL } from "./constants.js";
+import type {
+	AskPrompt,
+	AskResponse,
+	PromptChoice,
+	PromptState,
+} from "./contracts.js";
+import {
+	createPromptState,
+	pickChoiceSelection,
+	promptStateResponded,
+	promptStatesToResponses,
+	saveComment,
+	saveCustomSelection,
+} from "./state.js";
+
+type AskTheme = ExtensionContext["ui"]["theme"];
+type AddLine = (line?: string) => void;
+type EditingKind = "other" | "comment";
+
+interface AskUiState {
+	tab: number;
+	focus: number;
+	editing: EditingKind | null;
+}
+
+interface RenderTabsOptions {
+	handoff: boolean;
+	prompts: AskPrompt[];
+	responded: (index: number) => boolean;
+	tab: number;
+	theme: AskTheme;
+}
+
+interface RenderReviewOptions {
+	add: AddLine;
+	handoff: boolean;
+	promptStates: PromptState[];
+	prompts: AskPrompt[];
+	theme: AskTheme;
+	width: number;
+}
+
+interface RenderChoiceOptions {
+	add: AddLine;
+	checked: boolean | undefined;
+	choice: PromptChoice;
+	selected: boolean;
+	theme: AskTheme;
+	width: number;
+}
+
+interface RenderPromptOptions {
+	add: AddLine;
+	editor: Editor;
+	handoff: boolean;
+	isEditing: EditingKind | null;
+	choices: PromptChoice[];
+	prompt: AskPrompt;
+	promptState: PromptState | undefined;
+	state: AskUiState;
+	theme: AskTheme;
+	width: number;
+}
+
+function addWrapped(
+	add: AddLine,
+	text: string,
+	width: number,
+	indent = "",
+): void {
+	for (const line of wrapTextWithAnsi(
+		text,
+		Math.max(1, width - indent.length),
+	)) {
+		add(`${indent}${line}`);
+	}
+}
+
+function renderAskTabs({
+	handoff,
+	prompts,
+	responded,
+	tab,
+	theme,
+}: RenderTabsOptions): string {
+	return ` ${Array.from({ length: prompts.length + 1 }, (_, index) => {
+		const active = index === tab;
+		const label =
+			index === prompts.length
+				? handoff
+					? "Resume"
+					: "Review"
+				: `${responded(index) ? "■" : "□"} ${index + 1}`;
+		return active
+			? theme.bg("selectedBg", theme.fg("text", ` ${label} `))
+			: theme.fg("muted", ` ${label} `);
+	}).join(" ")}`;
+}
+
+function renderAskReview({
+	add,
+	handoff,
+	promptStates,
+	prompts,
+	theme,
+	width,
+}: RenderReviewOptions): void {
+	add(
+		theme.fg(
+			handoff ? "warning" : "accent",
+			handoff ? " Resume agent" : " Review",
+		),
+	);
+	add();
+	prompts.forEach((prompt, index) => {
+		const promptState = promptStates[index];
+		const selections = promptState?.selections ?? [];
+		addWrapped(
+			add,
+			theme.fg("muted", `${index + 1}. ${prompt.title}`),
+			width,
+			" ",
+		);
+		addWrapped(
+			add,
+			theme.fg("text", selections.join(", ") || "No selection"),
+			width,
+			"    ",
+		);
+		if (promptState?.comment.trim()) {
+			addWrapped(
+				add,
+				theme.fg("muted", `Comment: ${promptState.comment.trim()}`),
+				width,
+				"    ",
+			);
+		}
+	});
+	add();
+	add(
+		theme.fg(
+			"dim",
+			handoff
+				? " Enter returns control • ←/→ prompts • Esc dismisses"
+				: " Enter submits • ←/→ prompts • Esc dismisses",
+		),
+	);
+}
+
+function renderAskChoice({
+	add,
+	checked,
+	choice,
+	selected,
+	theme,
+	width,
+}: RenderChoiceOptions): void {
+	add(
+		`${selected ? theme.fg("accent", "> ") : "  "}${checked ? theme.fg("success", "✓ ") : "  "}${theme.fg(selected ? "accent" : "text", choice.label)}`,
+	);
+	if (choice.description) {
+		addWrapped(add, theme.fg("muted", choice.description), width, "    ");
+	}
+}
+
+function renderAskPrompt({
+	add,
+	editor,
+	handoff,
+	isEditing,
+	choices,
+	prompt,
+	promptState,
+	state,
+	theme,
+	width,
+}: RenderPromptOptions): void {
+	if (handoff) {
+		add(theme.fg("warning", " Human action needed"));
+		add();
+	}
+	addWrapped(add, theme.fg("text", prompt.title), width, " ");
+	add(
+		theme.fg(
+			"muted",
+			` ${prompt.multiple ? "Choose any that apply" : "Choose one"}`,
+		),
+	);
+	if (prompt.body) {
+		add();
+		addWrapped(add, theme.fg("muted", prompt.body), width, "   ");
+	}
+	add();
+	choices.forEach((choice, index) => {
+		renderAskChoice({
+			add,
+			checked: promptState?.selections.includes(choice.label),
+			choice,
+			selected: state.focus === index,
+			theme,
+			width,
+		});
+	});
+	const selectedOther = state.focus === choices.length;
+	add(
+		`${selectedOther ? theme.fg("accent", "> ") : "  "}${promptState?.customEnabled ? theme.fg("success", "✓ ") : "  "}${theme.fg(selectedOther ? "accent" : "muted", OTHER_OPTION_LABEL)}${promptState?.customText.trim() ? theme.fg("text", `: ${promptState.customText.trim()}`) : ""}`,
+	);
+	if (isEditing === "other") {
+		add();
+		for (const line of editor.render(width - 2)) add(` ${line}`);
+	}
+	const selectedComment = state.focus === choices.length + 1;
+	add();
+	add(
+		`${selectedComment ? theme.fg("accent", "> ") : "  "}${theme.fg(selectedComment ? "accent" : "text", "Comment (optional)")}`,
+	);
+	if (promptState?.comment.trim()) {
+		addWrapped(
+			add,
+			theme.fg("muted", promptState.comment.trim()),
+			width,
+			"    ",
+		);
+	}
+	if (isEditing === "comment") {
+		add();
+		for (const line of editor.render(width - 2)) add(` ${line}`);
+	}
+	add();
+	add(
+		theme.fg(
+			"dim",
+			" ↑↓ select • Enter choose/type • Tab next/default • blank Other/rephrase = follow-up • Esc close",
+		),
+	);
+}
+
+interface EditingInputOptions {
+	advance: () => void;
+	editor: Editor;
+	refresh: () => void;
+	saveEditing: (submittedText?: string) => void;
+	state: AskUiState;
+}
+
+function handleAskEditingInput(
+	data: string,
+	{ advance, editor, refresh, saveEditing, state }: EditingInputOptions,
+): void {
+	if (matchesKey(data, Key.tab)) {
+		saveEditing(editor.getText());
+		state.editing = null;
+		advance();
+		return;
+	}
+	if (matchesKey(data, Key.escape)) {
+		state.editing = null;
+		refresh();
+		return;
+	}
+	editor.handleInput(data);
+	refresh();
+}
+
+interface PromptInputOptions {
+	advanceWithDefault: () => void;
+	choices: () => PromptChoice[];
+	count: () => number;
+	pick: (index: number) => void;
+	refresh: () => void;
+	startEditing: (kind: EditingKind) => void;
+	state: AskUiState;
+}
+
+function handleAskPromptInput(
+	data: string,
+	{
+		advanceWithDefault,
+		choices,
+		count,
+		pick,
+		refresh,
+		startEditing,
+		state,
+	}: PromptInputOptions,
+): void {
+	if (matchesKey(data, Key.up)) {
+		state.focus = Math.max(0, state.focus - 1);
+		refresh();
+		return;
+	}
+	if (matchesKey(data, Key.down)) {
+		state.focus = Math.min(count() - 1, state.focus + 1);
+		refresh();
+		return;
+	}
+	if (matchesKey(data, Key.tab)) {
+		advanceWithDefault();
+		return;
+	}
+	if (!matchesKey(data, Key.enter)) return;
+	if (state.focus === choices().length) {
+		startEditing("other");
+		return;
+	}
+	if (state.focus === choices().length + 1) {
+		startEditing("comment");
+		return;
+	}
+	pick(state.focus);
+}
+
+interface NavigationInputOptions {
+	done: (responses: AskResponse[] | null) => void;
+	isReview: () => boolean;
+	promptStates: PromptState[];
+	prompts: AskPrompt[];
+	setTab: (next: number) => void;
+	state: AskUiState;
+}
+
+function handleAskNavigationInput(
+	data: string,
+	{
+		done,
+		isReview,
+		promptStates,
+		prompts,
+		setTab,
+		state,
+	}: NavigationInputOptions,
+): boolean {
+	if (matchesKey(data, Key.escape)) {
+		done(null);
+		return true;
+	}
+	if (matchesKey(data, Key.left)) {
+		setTab(state.tab - 1);
+		return true;
+	}
+	if (matchesKey(data, Key.right)) {
+		setTab(state.tab + 1);
+		return true;
+	}
+	if (!isReview()) return false;
+	if (matchesKey(data, Key.enter)) {
+		done(promptStatesToResponses(prompts, promptStates));
+	}
+	return true;
+}
+
+export async function askInTui(
+	ctx: ExtensionContext,
+	prompts: AskPrompt[],
+	{ handoff = false }: { handoff?: boolean } = {},
+): Promise<AskResponse[] | null> {
+	if (!ctx.hasUI) return null;
+	return await ctx.ui.custom<AskResponse[] | null>((tui, theme, _kb, done) => {
+		const state: AskUiState = { tab: 0, focus: 0, editing: null };
+		let cached: string[] | undefined;
+		// Keep response lifecycle in one object per prompt. Parallel arrays made tab/default
+		// transitions easy to desynchronise as this tool grows.
+		const promptStates = prompts.map(createPromptState);
+		const editor = new Editor(tui, {
+			borderColor: (text) => theme.fg(handoff ? "warning" : "accent", text),
+			selectList: {
+				selectedPrefix: (text) => theme.fg("accent", text),
+				selectedText: (text) => theme.fg("accent", text),
+				description: (text) => theme.fg("muted", text),
+				scrollInfo: (text) => theme.fg("dim", text),
+				noMatch: (text) => theme.fg("warning", text),
+			},
+		});
+
+		const reviewTab = () => prompts.length;
+		const current = () => prompts[state.tab];
+		const currentPromptState = () => promptStates[state.tab];
+		const choices = () => current()?.choices ?? [];
+		const isReview = () => state.tab === reviewTab();
+		const count = () => choices().length + 2;
+		const refresh = () => {
+			cached = undefined;
+			tui.requestRender();
+		};
+		const responded = (index: number) =>
+			promptStateResponded(promptStates[index]);
+		const setTab = (next: number) => {
+			state.tab = Math.max(0, Math.min(reviewTab(), next));
+			state.focus = 0;
+			state.editing = null;
+			editor.setText(promptStates[state.tab]?.customText ?? "");
+			refresh();
+		};
+		const saveCustom = (submittedText = editor.getText()) => {
+			const prompt = current();
+			const promptState = currentPromptState();
+			if (!prompt || !promptState) return;
+			saveCustomSelection(prompt, promptState, submittedText);
+		};
+		const saveEditing = (submittedText = editor.getText()) => {
+			const promptState = currentPromptState();
+			if (!promptState) return;
+			if (state.editing === "comment") saveComment(promptState, submittedText);
+			else saveCustom(submittedText);
+		};
+		const startEditing = (kind: EditingKind) => {
+			const promptState = currentPromptState();
+			if (!promptState) return;
+			state.editing = kind;
+			editor.setText(
+				kind === "comment" ? promptState.comment : promptState.customText,
+			);
+			refresh();
+		};
+		const advance = () => setTab(state.tab + 1);
+		const advanceWithDefault = () => {
+			if (!isReview() && !responded(state.tab)) saveCustom("");
+			advance();
+		};
+		editor.onSubmit = (value) => {
+			saveEditing(value);
+			state.editing = null;
+			refresh();
+		};
+		const pick = (index: number) => {
+			const choice = choices()[index];
+			const prompt = current();
+			const promptState = currentPromptState();
+			if (!choice || !promptState) return;
+			pickChoiceSelection(prompt, promptState, choice);
+			refresh();
+		};
+		const handleInput = (data: string) => {
+			if (state.editing) {
+				handleAskEditingInput(data, {
+					advance,
+					editor,
+					refresh,
+					saveEditing,
+					state,
+				});
+				return;
+			}
+			if (
+				handleAskNavigationInput(data, {
+					done,
+					isReview,
+					promptStates,
+					prompts,
+					setTab,
+					state,
+				})
+			) {
+				return;
+			}
+			handleAskPromptInput(data, {
+				advanceWithDefault,
+				count,
+				choices,
+				pick,
+				refresh,
+				startEditing,
+				state,
+			});
+		};
+		const render = (width: number) => {
+			if (cached) return cached;
+			const lines: string[] = [];
+			const add: AddLine = (line = "") =>
+				lines.push(truncateToWidth(line, width));
+			add(theme.fg(handoff ? "warning" : "accent", "─".repeat(width)));
+			add(
+				renderAskTabs({ handoff, prompts, responded, tab: state.tab, theme }),
+			);
+			add();
+			if (isReview()) {
+				renderAskReview({ add, handoff, promptStates, prompts, theme, width });
+			} else {
+				const prompt = current();
+				if (prompt) {
+					renderAskPrompt({
+						add,
+						editor,
+						handoff,
+						isEditing: state.editing,
+						choices: choices(),
+						prompt,
+						promptState: currentPromptState(),
+						state,
+						theme,
+						width,
+					});
+				}
+			}
+			add(theme.fg(handoff ? "warning" : "accent", "─".repeat(width)));
+			cached = lines;
+			return lines;
+		};
+		return {
+			render,
+			handleInput,
+			invalidate: () => {
+				cached = undefined;
+			},
+		};
+	});
+}

--- a/packages/pi-ask/ask/tui.ts
+++ b/packages/pi-ask/ask/tui.ts
@@ -361,10 +361,20 @@ function handleAskNavigationInput(
 export async function askInTui(
 	ctx: ExtensionContext,
 	prompts: AskPrompt[],
-	{ handoff = false }: { handoff?: boolean } = {},
+	{ handoff = false, signal }: { handoff?: boolean; signal?: AbortSignal } = {},
 ): Promise<AskResponse[] | null> {
-	if (!ctx.hasUI) return null;
+	if (!ctx.hasUI || signal?.aborted) return null;
 	return await ctx.ui.custom<AskResponse[] | null>((tui, theme, _kb, done) => {
+		let settled = false;
+		const finish = (result: AskResponse[] | null) => {
+			if (settled) return;
+			settled = true;
+			signal?.removeEventListener("abort", abort);
+			done(result);
+		};
+		const abort = () => finish(null);
+		signal?.addEventListener("abort", abort, { once: true });
+		if (signal?.aborted) queueMicrotask(abort);
 		const state: AskUiState = { tab: 0, focus: 0, editing: null };
 		let cached: string[] | undefined;
 		// Keep response lifecycle in one object per prompt. Parallel arrays made tab/default
@@ -452,7 +462,7 @@ export async function askInTui(
 			}
 			if (
 				handleAskNavigationInput(data, {
-					done,
+					done: finish,
 					isReview,
 					promptStates,
 					prompts,
@@ -508,6 +518,7 @@ export async function askInTui(
 		return {
 			render,
 			handleInput,
+			dispose: () => signal?.removeEventListener("abort", abort),
 			invalidate: () => {
 				cached = undefined;
 			},

--- a/packages/pi-ask/ask/tui.ts
+++ b/packages/pi-ask/ask/tui.ts
@@ -14,6 +14,7 @@ import type {
 	PromptState,
 } from "./contracts.js";
 import {
+	clearCustomSelection,
 	createPromptState,
 	pickChoiceSelection,
 	promptStateResponded,
@@ -277,7 +278,8 @@ interface PromptInputOptions {
 	count: () => number;
 	pick: (index: number) => void;
 	refresh: () => void;
-	startEditing: (kind: EditingKind) => void;
+	selectOther: () => void;
+	startEditingComment: () => void;
 	state: AskUiState;
 }
 
@@ -289,7 +291,8 @@ function handleAskPromptInput(
 		count,
 		pick,
 		refresh,
-		startEditing,
+		selectOther,
+		startEditingComment,
 		state,
 	}: PromptInputOptions,
 ): void {
@@ -309,11 +312,11 @@ function handleAskPromptInput(
 	}
 	if (!matchesKey(data, Key.enter)) return;
 	if (state.focus === choices().length) {
-		startEditing("other");
+		selectOther();
 		return;
 	}
 	if (state.focus === choices().length + 1) {
-		startEditing("comment");
+		startEditingComment();
 		return;
 	}
 	pick(state.focus);
@@ -431,6 +434,17 @@ export async function askInTui(
 			);
 			refresh();
 		};
+		const selectOther = () => {
+			const prompt = current();
+			const promptState = currentPromptState();
+			if (!prompt || !promptState) return;
+			if (prompt.multiple && promptState.customEnabled) {
+				clearCustomSelection(promptState);
+				refresh();
+				return;
+			}
+			startEditing("other");
+		};
 		const advance = () => setTab(state.tab + 1);
 		const advanceWithDefault = () => {
 			if (!isReview() && !responded(state.tab)) saveCustom("");
@@ -478,7 +492,8 @@ export async function askInTui(
 				choices,
 				pick,
 				refresh,
-				startEditing,
+				selectOther,
+				startEditingComment: () => startEditing("comment"),
 				state,
 			});
 		};

--- a/packages/pi-ask/biome.json
+++ b/packages/pi-ask/biome.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": [
+			"**",
+			"!node_modules",
+			"!dist",
+			"!coverage",
+			"!package-lock.json"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/packages/pi-ask/index.ts
+++ b/packages/pi-ask/index.ts
@@ -1,0 +1,8 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createAskTool } from "./ask/tool.js";
+
+export { createAskTool } from "./ask/tool.js";
+
+export default function humanInTheLoop(pi: ExtensionAPI): void {
+	pi.registerTool(createAskTool());
+}

--- a/packages/pi-ask/index.ts
+++ b/packages/pi-ask/index.ts
@@ -1,8 +1,22 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { loadAskConfig } from "./ask/config.js";
 import { createAskTool } from "./ask/tool.js";
 
 export { createAskTool } from "./ask/tool.js";
 
+const PROMPTS_DIR = join(dirname(fileURLToPath(import.meta.url)), "prompts");
+
 export default function humanInTheLoop(pi: ExtensionAPI): void {
 	pi.registerTool(createAskTool());
+	pi.on("resources_discover", () => {
+		const config = loadAskConfig();
+		return {
+			promptPaths: [
+				...(config.grill ? [join(PROMPTS_DIR, "grill.md")] : []),
+				...(config.fold ? [join(PROMPTS_DIR, "fold.md")] : []),
+			],
+		};
+	});
 }

--- a/packages/pi-ask/package.json
+++ b/packages/pi-ask/package.json
@@ -40,9 +40,6 @@
 	"pi": {
 		"extensions": [
 			"./index.ts"
-		],
-		"prompts": [
-			"./prompts"
 		]
 	},
 	"peerDependencies": {

--- a/packages/pi-ask/package.json
+++ b/packages/pi-ask/package.json
@@ -1,0 +1,71 @@
+{
+	"name": "@howaboua/pi-ask",
+	"version": "0.0.0",
+	"description": "Interactive decisions, review triage, and human handoffs for Pi.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-ask"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-ask#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-coding-agent",
+		"human-in-the-loop",
+		"review",
+		"handoff"
+	],
+	"engines": {
+		"node": ">=20.6.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"index.ts",
+		"ask",
+		"prompts",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		],
+		"prompts": [
+			"./prompts"
+		]
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.80.7",
+		"@earendil-works/pi-tui": ">=0.80.7",
+		"typebox": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "0.80.7",
+		"@earendil-works/pi-tui": "0.80.7",
+		"typebox": "1.1.38",
+		"typescript": "^6.0.3"
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck && bun run test",
+		"prepack": "bun run check",
+		"test": "bun test",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run"
+	},
+	"main": "index.ts",
+	"exports": "./index.ts"
+}

--- a/packages/pi-ask/prompts/fold.md
+++ b/packages/pi-ask/prompts/fold.md
@@ -1,0 +1,17 @@
+---
+description: Fold a long report or list into interactive review
+argument-hint: "[report or instructions]"
+---
+Fold this material into `ask` instead of replying with another long report:
+
+$ARGUMENTS
+
+If no material follows the command, use the most recent lengthy report or structured list in the conversation.
+
+Call `ask` once with one prompt per independently decidable item:
+- Keep the title short.
+- Preserve concrete evidence, consequences, and recommendations in the body.
+- Use the source's natural choices. For review findings, default to Fix, Defer, and Reject.
+- Keep coupled points together; do not manufacture decisions from explanatory bullets.
+
+Do not repeat the report before or after the tool call. Once the responses return, summarize the dispositions briefly and continue only when the surrounding task already authorizes action.

--- a/packages/pi-ask/prompts/grill.md
+++ b/packages/pi-ask/prompts/grill.md
@@ -1,0 +1,33 @@
+---
+description: Grill an idea into an agreed plan
+argument-hint: "[idea or plan]"
+---
+Grill this into an agreed plan:
+
+$ARGUMENTS
+
+Use the working directory, web search, available skills, and any relevant tools to understand the thing before asking. Prefer finding answers yourself over asking me.
+
+Loop until ask is dismissed. There is no round limit:
+1. Investigate the relevant context.
+2. Use ask for the next set of decisions.
+3. After the first answer round, create docs/<short-name>.md.
+4. Keep asking better questions, using tools between rounds as needed.
+5. Keep updating the markdown file after each round.
+
+The markdown file is the current plan, not a transcript. Keep it ready to use if I stop at any point. Include:
+- goal
+- agreed decisions
+- important tradeoffs
+- relevant user reasoning
+- open questions
+- proposed next steps
+
+Do not log every question and answer.
+
+When ask is dismissed, the grilling session is done. Then:
+- give a short summary of what was agreed
+- open the markdown file with $EDITOR if available
+- print the file path
+
+Do not start implementation unless I explicitly choose to proceed.

--- a/packages/pi-ask/tests/normalize.test.ts
+++ b/packages/pi-ask/tests/normalize.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+	normalizeAskInput,
+	normalizeResponses,
+	summarizeResponses,
+} from "../ask/normalize.js";
+
+describe("review prompt normalization", () => {
+	test("keeps a trimmed body and choices", () => {
+		const { handoff, prompts } = normalizeAskInput({
+			prompts: [
+				{
+					title: " Delivery can duplicate ",
+					body: " Evidence and recommendation. ",
+					choices: [{ label: " Fix " }],
+				},
+			],
+		});
+
+		expect(handoff).toBe(false);
+		expect(prompts).toEqual([
+			{
+				id: "p1",
+				title: "Delivery can duplicate",
+				body: "Evidence and recommendation.",
+				multiple: false,
+				choices: [{ label: "Fix" }],
+			},
+		]);
+	});
+
+	test("gives handoffs default statuses without replacing custom choices", () => {
+		expect(
+			normalizeAskInput({
+				handoff: true,
+				prompts: [{ title: "Authorize GitHub" }],
+			}),
+		).toEqual({
+			handoff: true,
+			prompts: [
+				{
+					id: "p1",
+					title: "Authorize GitHub",
+					multiple: false,
+					choices: [{ label: "Done" }, { label: "Could not complete" }],
+				},
+			],
+		});
+
+		expect(
+			normalizeAskInput({
+				handoff: true,
+				prompts: [
+					{
+						title: "Authorize GitHub",
+						choices: [{ label: "Authorized" }, { label: "Cancel" }],
+					},
+				],
+			}).prompts[0]?.choices,
+		).toEqual([{ label: "Authorized" }, { label: "Cancel" }]);
+	});
+});
+
+describe("response normalization", () => {
+	const prompts = [{ id: "p1", title: "Delivery", choices: [] }];
+
+	test("accepts structured responses with comments", () => {
+		const responses = normalizeResponses(prompts, [
+			{ id: "ignored", selections: ["Defer"], comment: " after logging " },
+		]);
+
+		expect(responses).toEqual([
+			{ id: "p1", selections: ["Defer"], comment: "after logging" },
+		]);
+		expect(summarizeResponses(prompts, responses)).toBe(
+			"Delivery: Defer\n  Comment: after logging",
+		);
+	});
+
+	test("accepts selection arrays from injected composers", () => {
+		expect(normalizeResponses(prompts, [["Fix"]])).toEqual([
+			{ id: "p1", selections: ["Fix"] },
+		]);
+	});
+});

--- a/packages/pi-ask/tests/pi-ui.test.ts
+++ b/packages/pi-ask/tests/pi-ui.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { REPHRASE_REQUEST_RESPONSE } from "../ask/constants.js";
+import type { AskPrompt } from "../ask/contracts.js";
+import { askWithPiUi } from "../ask/pi-ui.js";
+
+const prompt = (overrides: Partial<AskPrompt> = {}): AskPrompt => ({
+	id: "p1",
+	title: "Decision",
+	multiple: false,
+	choices: [],
+	...overrides,
+});
+
+describe("Pi UI ask fallback", () => {
+	test("keeps blank free text as a rephrase request and forwards cancellation", async () => {
+		const controller = new AbortController();
+		const signals: Array<AbortSignal | undefined> = [];
+		const values: Array<string | undefined> = ["", undefined];
+		const ctx = {
+			hasUI: true,
+			ui: {
+				input: async (
+					_title: string,
+					_placeholder: string,
+					options: { signal?: AbortSignal },
+				) => {
+					signals.push(options.signal);
+					return values.shift();
+				},
+			},
+		} as unknown as ExtensionContext;
+
+		const result = await askWithPiUi(ctx, [prompt()], {
+			signal: controller.signal,
+		});
+
+		expect(result?.[0]?.selections).toEqual([REPHRASE_REQUEST_RESPONSE]);
+		expect(signals).toEqual([controller.signal, controller.signal]);
+	});
+
+	test("allows a multi-select choice labeled Done", async () => {
+		const shownOptions: string[][] = [];
+		let call = 0;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				select: async (_title: string, options: string[]) => {
+					shownOptions.push(options);
+					call++;
+					return call === 1 ? "Done" : options.at(-1);
+				},
+				input: async () => undefined,
+			},
+		} as unknown as ExtensionContext;
+
+		const result = await askWithPiUi(ctx, [
+			prompt({
+				multiple: true,
+				choices: [{ label: "Done" }, { label: "Finish selection" }],
+			}),
+		]);
+
+		expect(result?.[0]?.selections).toEqual(["Done"]);
+		expect(shownOptions[0]?.at(-1)).toBe("Finish selection (2)");
+	});
+});

--- a/packages/pi-ask/tests/pi-ui.test.ts
+++ b/packages/pi-ask/tests/pi-ui.test.ts
@@ -13,10 +13,10 @@ const prompt = (overrides: Partial<AskPrompt> = {}): AskPrompt => ({
 });
 
 describe("Pi UI ask fallback", () => {
-	test("keeps blank free text as a rephrase request and forwards cancellation", async () => {
+	test("keeps blank free text as a rephrase request and forwards the signal", async () => {
 		const controller = new AbortController();
 		const signals: Array<AbortSignal | undefined> = [];
-		const values: Array<string | undefined> = ["", undefined];
+		const values: Array<string | undefined> = ["", ""];
 		const ctx = {
 			hasUI: true,
 			ui: {
@@ -39,6 +39,18 @@ describe("Pi UI ask fallback", () => {
 		expect(signals).toEqual([controller.signal, controller.signal]);
 	});
 
+	test("treats closing the optional comment as dismissal", async () => {
+		const values: Array<string | undefined> = ["Answer", undefined];
+		const ctx = {
+			hasUI: true,
+			ui: {
+				input: async () => values.shift(),
+			},
+		} as unknown as ExtensionContext;
+
+		expect(await askWithPiUi(ctx, [prompt()])).toBeNull();
+	});
+
 	test("allows a multi-select choice labeled Done", async () => {
 		const shownOptions: string[][] = [];
 		let call = 0;
@@ -50,7 +62,7 @@ describe("Pi UI ask fallback", () => {
 					call++;
 					return call === 1 ? "Done" : options.at(-1);
 				},
-				input: async () => undefined,
+				input: async () => "",
 			},
 		} as unknown as ExtensionContext;
 

--- a/packages/pi-ask/tests/state.test.ts
+++ b/packages/pi-ask/tests/state.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createPromptState,
+	promptStateResponded,
+	promptStatesToResponses,
+	saveComment,
+} from "../ask/state.js";
+
+describe("prompt comments", () => {
+	test("are optional but count as a response when present", () => {
+		const state = createPromptState();
+		expect(promptStateResponded(state)).toBe(false);
+
+		saveComment(state, " Needs a smaller first pass. ");
+
+		expect(promptStateResponded(state)).toBe(true);
+		expect(promptStatesToResponses([{ id: "scope" }], [state])).toEqual([
+			{
+				id: "scope",
+				selections: [],
+				comment: "Needs a smaller first pass.",
+			},
+		]);
+	});
+
+	test("omits blank comments from the result", () => {
+		const state = createPromptState();
+		saveComment(state, "   ");
+
+		expect(promptStatesToResponses([{ id: "scope" }], [state])).toEqual([
+			{ id: "scope", selections: [] },
+		]);
+	});
+});

--- a/packages/pi-ask/tests/tool.test.ts
+++ b/packages/pi-ask/tests/tool.test.ts
@@ -4,6 +4,10 @@ import { createAskTool } from "../ask/tool.js";
 const context = { hasUI: false, mode: "print" } as never;
 
 describe("ask tool results", () => {
+	test("serializes interactive calls", () => {
+		expect(createAskTool().executionMode).toBe("sequential");
+	});
+
 	test("returns review dispositions in model-visible content", async () => {
 		const tool = createAskTool({
 			askInComposer: async () => [

--- a/packages/pi-ask/tests/tool.test.ts
+++ b/packages/pi-ask/tests/tool.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { createAskTool } from "../ask/tool.js";
+
+const context = { hasUI: false, mode: "print" } as never;
+
+describe("ask tool results", () => {
+	test("returns review dispositions in model-visible content", async () => {
+		const tool = createAskTool({
+			askInComposer: async () => [
+				{ selections: ["Defer"], comment: "After the release." },
+			],
+		});
+
+		const result = await tool.execute(
+			"call-1",
+			{
+				prompts: [
+					{
+						title: "Delivery can duplicate",
+						body: "Two paths enqueue the same delivery.",
+						choices: [{ label: "Fix" }, { label: "Defer" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.content).toEqual([
+			{
+				type: "text",
+				text: "Delivery can duplicate: Defer\n  Comment: After the release.",
+			},
+		]);
+		expect(result.details).toEqual({
+			kind: "prompt",
+			responses: [
+				{
+					id: "p1",
+					selections: ["Defer"],
+					comment: "After the release.",
+				},
+			],
+		});
+	});
+
+	test("keeps a dismissed handoff distinct from a response", async () => {
+		const tool = createAskTool({ askInComposer: async () => null });
+
+		const result = await tool.execute(
+			"call-2",
+			{ handoff: true, prompts: [{ title: "Authorize GitHub" }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.content).toEqual([
+			{ type: "text", text: "Handoff dismissed by user." },
+		]);
+		expect(result.details).toEqual({
+			dismissed: true,
+			kind: "handoff",
+		});
+	});
+});

--- a/packages/pi-ask/tests/tui.test.ts
+++ b/packages/pi-ask/tests/tui.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { askInTui } from "../ask/tui.js";
+
+describe("TUI ask cancellation", () => {
+	test("dismisses the custom panel when execution aborts", async () => {
+		const controller = new AbortController();
+		const theme = {
+			fg: (_color: string, value: string) => value,
+			bg: (_color: string, value: string) => value,
+		};
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: async <T>(
+					factory: (
+						tui: { requestRender(): void },
+						theme: unknown,
+						keybindings: unknown,
+						done: (result: T) => void,
+					) => Component & { dispose?(): void },
+				) =>
+					await new Promise<T>((resolve) => {
+						let component: (Component & { dispose?(): void }) | undefined;
+						component = factory({ requestRender() {} }, theme, {}, (result) => {
+							component?.dispose?.();
+							resolve(result);
+						});
+						controller.abort();
+					}),
+			},
+		} as unknown as ExtensionContext;
+
+		const result = await askInTui(
+			ctx,
+			[
+				{
+					id: "p1",
+					title: "Decision",
+					multiple: false,
+					choices: [],
+				},
+			],
+			{ signal: controller.signal },
+		);
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/pi-ask/tsconfig.json
+++ b/packages/pi-ask/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "ask/**/*.ts"]
+}

--- a/packages/pi-extensions/README.md
+++ b/packages/pi-extensions/README.md
@@ -10,6 +10,7 @@ pi install npm:@howaboua/pi-extensions
 
 ## Included extensions
 
+- `pi-ask` — interactive decisions, review triage, and human handoffs
 - `pi-auto-reasoning-tool` — agent-controlled reasoning levels with the user's level as a floor
 - `pi-auto-trees` — `/marker` and `/end` for incremental long sessions
 - `pi-dynamic-tools` — TOML-defined command tools through JavaScript Code Mode

--- a/packages/pi-extensions/README.md
+++ b/packages/pi-extensions/README.md
@@ -10,7 +10,7 @@ pi install npm:@howaboua/pi-extensions
 
 ## Included extensions
 
-- `pi-ask` — interactive decisions, review triage, and human handoffs
+- `pi-ask` — interactive decisions, review triage, human handoffs, and optional `/fold` and `/grill` prompts
 - `pi-auto-reasoning-tool` — agent-controlled reasoning levels with the user's level as a floor
 - `pi-auto-trees` — `/marker` and `/end` for incremental long sessions
 - `pi-dynamic-tools` — TOML-defined command tools through JavaScript Code Mode

--- a/packages/pi-extensions/index.ts
+++ b/packages/pi-extensions/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import howabouaPiAsk from "@howaboua/pi-ask";
 import howabouaPiAutoReasoningTool from "@howaboua/pi-auto-reasoning-tool";
 import howabouaPiAutoTrees from "@howaboua/pi-auto-trees";
 import howabouaPiDynamicTools from "@howaboua/pi-dynamic-tools";
@@ -11,6 +12,7 @@ import howabouaPiSubagentReview from "@howaboua/pi-subagent-review";
 import howabouaPiVent from "@howaboua/pi-vent";
 
 export default async function (pi: ExtensionAPI) {
+	await howabouaPiAsk(pi);
 	await howabouaPiAutoReasoningTool(pi);
 	await howabouaPiAutoTrees(pi);
 	await howabouaPiDynamicTools(pi);

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -13,6 +13,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@howaboua/pi-ask": "0.0.0",
 		"@howaboua/pi-auto-reasoning-tool": "0.1.10",
 		"@howaboua/pi-auto-trees": "0.1.9",
 		"@howaboua/pi-dynamic-tools": "0.0.6",

--- a/packages/pi-stuff/README.md
+++ b/packages/pi-stuff/README.md
@@ -1,6 +1,6 @@
 # @howaboua/pi-stuff
 
-The full general-purpose bundle: all 10 extensions from `@howaboua/pi-extensions` and all 8 skills from `@howaboua/pi-skills`.
+The full general-purpose bundle: all 11 extensions from `@howaboua/pi-extensions` and all 8 skills from `@howaboua/pi-skills`.
 
 ## Install
 
@@ -10,7 +10,7 @@ pi install npm:@howaboua/pi-stuff
 
 This installs:
 
-- extensions: `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
+- extensions: `pi-ask`, `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
 - skills: `agent-native-hardening`, `agents-md`, `anti-ai-copy`, `chrome-cdp`, `gh-issue-pr-flow`, `model-facing-api-design`, `project-reference-research`, and `skill-creator`
 
 `pi-codex-conversion` and `omarchy-help` are intentionally separate because they depend on model and workstation choices.

--- a/packages/pi-stuff/README.md
+++ b/packages/pi-stuff/README.md
@@ -1,6 +1,6 @@
 # @howaboua/pi-stuff
 
-The full general-purpose bundle: all 11 extensions from `@howaboua/pi-extensions` and all 8 skills from `@howaboua/pi-skills`.
+The full general-purpose bundle: all 11 extensions from `@howaboua/pi-extensions`, pi-ask's prompt workflows, and all 8 skills from `@howaboua/pi-skills`.
 
 ## Install
 

--- a/packages/pi-stuff/index.ts
+++ b/packages/pi-stuff/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import howabouaPiAsk from "@howaboua/pi-ask";
 import howabouaPiAutoReasoningTool from "@howaboua/pi-auto-reasoning-tool";
 import howabouaPiAutoTrees from "@howaboua/pi-auto-trees";
 import howabouaPiDynamicTools from "@howaboua/pi-dynamic-tools";
@@ -11,6 +12,7 @@ import howabouaPiSubagentReview from "@howaboua/pi-subagent-review";
 import howabouaPiVent from "@howaboua/pi-vent";
 
 export default async function (pi: ExtensionAPI) {
+	await howabouaPiAsk(pi);
 	await howabouaPiAutoReasoningTool(pi);
 	await howabouaPiAutoTrees(pi);
 	await howabouaPiDynamicTools(pi);

--- a/packages/pi-stuff/package.json
+++ b/packages/pi-stuff/package.json
@@ -13,6 +13,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@howaboua/pi-ask": "0.0.0",
 		"@howaboua/pi-auto-reasoning-tool": "0.1.10",
 		"@howaboua/pi-auto-trees": "0.1.9",
 		"@howaboua/pi-dynamic-tools": "0.0.6",


### PR DESCRIPTION
## Summary
- add `@howaboua/pi-ask`, an agent-callable human-in-the-loop tool for batched decisions, review triage, comments, and user-only handoffs
- provide custom TUI and Pi UI flows with explicit dismissal, abort, blank rephrase, and multi-select lifecycle handling
- include configurable `/fold` and `/grill` prompt workflows in standalone and aggregate installs through `~/.pi/agent/ask.json`

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `bun run pack:dry` in `packages/pi-ask`
- prompt discovery smoke checks for defaults, per-template disabling, and unwritable config directories

## Release
- Changeset: yes
- Packages: `@howaboua/pi-ask`
- Aggregates: generated by release automation
