### PR TITLE
Route Code Mode web search through Responses proxies

### DIFF
--- a/.changeset/smooth-hats-rescue.md
+++ b/.changeset/smooth-hats-rescue.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Route Code Mode web search through explicitly configured Responses proxies using their active model and endpoint.

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -50,6 +50,7 @@ text(status);
 ```
 
 Nested `apply_patch`, `view_image`, `web__run`, `image_gen__imagegen`, `exec_command`, and `write_stdin` calls keep normal Pi rendering without exposing their schemas to the provider. When Code Mode becomes active, Pi starts downloading and verifying the pinned V8 host instead of waiting for the first `exec`. Downloads respect standard proxy environment variables and fail instead of hanging indefinitely.
+For configured Responses providers, `web__run` uses the active provider's `/responses` endpoint; the proxy must support the Responses `web_search` tool.
 
 ## Code Mode custom tools
 

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -125,6 +125,7 @@ function createNestedTools(
 			createWebSearchTool("web__run", {
 				getRecentInput: () => runtime.latestRecentWebSearchInput,
 				model: () => runtime.state.config.openai.webSearchModel,
+				allowConfiguredProvider: (model) => shouldUseGpt56CodeMode({ model }, runtime.state.config),
 				promptSnippet: false,
 				customRendering: runtime.state.config.ui.toolRenaming,
 			}),

--- a/packages/pi-codex-conversion/src/adapter/codex-tool-provider.ts
+++ b/packages/pi-codex-conversion/src/adapter/codex-tool-provider.ts
@@ -6,11 +6,15 @@ import { extractAccountId } from "../providers/openai-codex/headers.ts";
 export const CODEX_TOOL_PROVIDER_UNSUPPORTED_MESSAGE = "web_run/imagegen requires an OpenAI Codex-compatible Responses provider or /login openai-codex";
 
 export interface CodexToolProvider {
+	route: "openai-codex" | "configured-responses";
 	baseUrl: string;
+	responsesUrl: string;
 	model: string | undefined;
 	token: string;
 	accountId: string;
 }
+
+export type AllowConfiguredCodexToolProvider = (model: ExtensionContext["model"]) => boolean;
 
 const CODEX_ORIGINATOR = "codex_cli_rs";
 const OPENAI_CODEX_PROVIDER = "openai-codex";
@@ -80,24 +84,38 @@ function resolveOpenAICodexAuthModel(ctx: ExtensionContext): Model<any> | undefi
 	return all ? firstOpenAICodexModel(all) : undefined;
 }
 
-function resolveCodexToolAuthModel(ctx: ExtensionContext): Model<any> {
+function resolveCodexToolAuthModel(ctx: ExtensionContext, allowConfiguredProvider?: AllowConfiguredCodexToolProvider): Model<any> {
 	if (isUsableOpenAICodexModel(ctx.model)) return ctx.model as Model<any>;
+	if (isResponsesModel(ctx.model) && allowConfiguredProvider?.(ctx.model)) return ctx.model as Model<any>;
 	const openAICodexModel = resolveOpenAICodexAuthModel(ctx);
 	if (openAICodexModel) return openAICodexModel;
 	throw new Error(`${CODEX_TOOL_PROVIDER_UNSUPPORTED_MESSAGE}; run /login openai-codex or select an OpenAI Codex-compatible provider`);
 }
 
-export async function resolveCodexToolProvider(ctx: ExtensionContext): Promise<CodexToolProvider> {
-	const model = resolveCodexToolAuthModel(ctx);
+function resolveConfiguredResponsesUrl(modelBaseUrl: string | undefined): string {
+	const base = modelBaseUrl?.trim().replace(/\/+$/, "");
+	if (!base) throw new Error("Configured Responses provider is missing a base URL");
+	return base.endsWith("/responses") ? base : `${base}/responses`;
+}
+
+export async function resolveCodexToolProvider(ctx: ExtensionContext, allowConfiguredProvider?: AllowConfiguredCodexToolProvider): Promise<CodexToolProvider> {
+	const model = resolveCodexToolAuthModel(ctx, allowConfiguredProvider);
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (!auth.ok) throw new Error(auth.error);
 	const token = auth.apiKey ?? headerValue(auth.headers, "Authorization")?.replace(/^Bearer\s+/i, "");
 	if (!token) throw new Error(CODEX_TOOL_PROVIDER_UNSUPPORTED_MESSAGE);
+	const openAICodex = isOpenAICodexModel(model);
+	const baseUrl = openAICodex
+		? resolveCodexApiProviderBaseUrl(model.baseUrl)
+		: model.baseUrl?.trim().replace(/\/+$/, "");
+	if (!baseUrl) throw new Error("Configured Responses provider is missing a base URL");
 	return {
-		baseUrl: resolveCodexApiProviderBaseUrl(model.baseUrl),
+		route: openAICodex ? "openai-codex" : "configured-responses",
+		baseUrl,
+		responsesUrl: openAICodex ? resolveCodexResponsesUrl(baseUrl) : resolveConfiguredResponsesUrl(baseUrl),
 		model: model.id,
 		token,
-		accountId: headerValue(auth.headers, "chatgpt-account-id") ?? extractAccountId(token),
+		accountId: headerValue(auth.headers, "chatgpt-account-id") ?? (openAICodex ? extractAccountId(token) : ""),
 	};
 }
 
@@ -126,7 +144,7 @@ export function codexToolProviderEnv(provider: CodexToolProvider): NodeJS.Proces
 		PI_CODEX_ACCESS_TOKEN: provider.token,
 		PI_CODEX_ACCOUNT_ID: provider.accountId,
 		PI_CODEX_BASE_URL: provider.baseUrl,
-		PI_CODEX_RESPONSES_URL: resolveCodexResponsesUrl(provider.baseUrl),
+		PI_CODEX_RESPONSES_URL: provider.responsesUrl,
 		...(provider.model ? { PI_CODEX_MODEL: provider.model } : {}),
 	};
 }

--- a/packages/pi-codex-conversion/src/adapter/codex-tool-provider.ts
+++ b/packages/pi-codex-conversion/src/adapter/codex-tool-provider.ts
@@ -102,9 +102,10 @@ export async function resolveCodexToolProvider(ctx: ExtensionContext, allowConfi
 	const model = resolveCodexToolAuthModel(ctx, allowConfiguredProvider);
 	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (!auth.ok) throw new Error(auth.error);
-	const token = auth.apiKey ?? headerValue(auth.headers, "Authorization")?.replace(/^Bearer\s+/i, "");
-	if (!token) throw new Error(CODEX_TOOL_PROVIDER_UNSUPPORTED_MESSAGE);
 	const openAICodex = isOpenAICodexModel(model);
+	const authorization = headerValue(auth.headers, "Authorization")?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+	const token = openAICodex ? auth.apiKey ?? authorization : authorization ?? auth.apiKey;
+	if (!token) throw new Error(CODEX_TOOL_PROVIDER_UNSUPPORTED_MESSAGE);
 	const baseUrl = openAICodex
 		? resolveCodexApiProviderBaseUrl(model.baseUrl)
 		: model.baseUrl?.trim().replace(/\/+$/, "");
@@ -139,7 +140,7 @@ export function codexWebRunUserAgent(originator: string = CODEX_ORIGINATOR): str
 }
 
 export function codexToolProviderEnv(provider: CodexToolProvider): NodeJS.ProcessEnv {
-	return {
+	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		PI_CODEX_ACCESS_TOKEN: provider.token,
 		PI_CODEX_ACCOUNT_ID: provider.accountId,
@@ -147,4 +148,6 @@ export function codexToolProviderEnv(provider: CodexToolProvider): NodeJS.Proces
 		PI_CODEX_RESPONSES_URL: provider.responsesUrl,
 		...(provider.model ? { PI_CODEX_MODEL: provider.model } : {}),
 	};
+	if (provider.route === "configured-responses") delete env["PI_CODEX_AGENT_IDENTITY_JWT"];
+	return env;
 }

--- a/packages/pi-codex-conversion/src/extension/tools.ts
+++ b/packages/pi-codex-conversion/src/extension/tools.ts
@@ -15,6 +15,11 @@ export interface CodexToolRegistration {
 	ensureOptionalTools(config?: CodexConversionConfig): void;
 }
 
+export function isExplicitlyConfiguredToolProvider(model: Model<Api> | undefined, config: CodexConversionConfig): boolean {
+	const provider = model?.provider?.trim().toLowerCase();
+	return Boolean(provider && config.scope.additionalProviders.some((entry) => entry.trim().toLowerCase() === provider));
+}
+
 export function registerCodexTools(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexToolRegistration {
 	const renderOptions = (config: CodexConversionConfig) => ({ customRendering: config.ui.toolRenaming });
 	const promptOptions = (config: CodexConversionConfig) => ({ promptSnippet: config.mode === "path" });
@@ -31,11 +36,8 @@ export function registerCodexTools(pi: ExtensionAPI, runtime: CodexExtensionRunt
 		registerViewImageTool(pi, { describeForTextModels: config.tools.viewImageFallback, ...renderOptions(config), ...promptOptions(config) });
 	};
 	const ensureOptionalTools = (config = runtime.state.config) => {
-		const allowConfiguredProvider = (model: Model<Api> | undefined): boolean => {
-			if (config.scope.allProviders !== "off") return true;
-			const provider = model?.provider?.trim().toLowerCase();
-			return Boolean(provider && config.scope.additionalProviders.includes(provider));
-		};
+		const allowConfiguredProvider = (model: Model<Api> | undefined): boolean =>
+			isExplicitlyConfiguredToolProvider(model, config);
 		if (config.tools.webRun || config.tools.webRunOnly) {
 			registerWebSearchTool(pi, WEB_SEARCH_TOOL_NAME, {
 				getRecentInput: () => runtime.latestRecentWebSearchInput,

--- a/packages/pi-codex-conversion/src/tools/web-run/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/web-run/tool.ts
@@ -176,10 +176,11 @@ export function supportsMultimodalNativeWebSearch(model: ExtensionContext["model
 }
 
 export async function executeCodexWebSearch(params: Record<string, unknown>, ctx: ExtensionContext, signal: AbortSignal | undefined | null, options: WebSearchToolOptions = {}): Promise<WebRunExecutionResult> {
-	const provider = await resolveCodexToolProvider(ctx);
+	const provider = await resolveCodexToolProvider(ctx, options.allowConfiguredProvider);
 	const webRunPath = process.env["PI_CODEX_WEB_RUN_BIN"]?.trim() || join(getBundledPathToolsBinDir(), process.platform === "win32" ? "web_run.cmd" : "web_run");
 	const sessionId = ctx.sessionManager?.getSessionId?.() || options.sessionId;
-	const model = typeof options.model === "function" ? options.model() : options.model;
+	const configuredModel = typeof options.model === "function" ? options.model() : options.model;
+	const model = provider.route === "configured-responses" ? provider.model : configuredModel;
 	const statePath = webRunSessionStatePath(ctx);
 	const env = { ...codexToolProviderEnv(provider), ...(statePath ? { PI_WEB_RUN_STATE_PATH: statePath } : {}) };
 	try {

--- a/packages/pi-codex-conversion/tests/web-search-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/web-search-tool.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import { isExplicitlyConfiguredToolProvider } from "../src/extension/tools.ts";
 import { buildRecentWebSearchInput, createWebSearchTool, executeCodexWebSearch } from "../src/tools/web-run/tool.ts";
 
 
@@ -10,7 +12,7 @@ function fakeJwt(accountId: string): string {
 	return ["header", Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } })).toString("base64url"), "signature"].join(".");
 }
 
-function createContext(options: { token?: string; accountId?: string; baseUrl?: string; model?: string; provider?: string; api?: string; headers?: Record<string, string>; sessionFile?: string; sessionId?: string } = {}) {
+function createContext(options: { token?: string; accountId?: string; baseUrl?: string; model?: string; provider?: string; api?: string; headers?: Record<string, string>; apiKeyWithHeaders?: boolean; sessionFile?: string; sessionId?: string } = {}) {
 	const token = options.token ?? fakeJwt(options.accountId ?? "acct-from-token");
 	return {
 		cwd: process.cwd(),
@@ -28,7 +30,7 @@ function createContext(options: { token?: string; accountId?: string; baseUrl?: 
 			async getApiKeyAndHeaders() {
 				return {
 					ok: true,
-					apiKey: options.headers ? undefined : token,
+					apiKey: options.headers && !options.apiKeyWithHeaders ? undefined : token,
 					headers: options.headers ?? (options.accountId ? { "chatgpt-account-id": options.accountId } : {}),
 				};
 			},
@@ -52,6 +54,15 @@ test("buildRecentWebSearchInput mirrors Codex standalone web search context tail
 		{ type: "message", role: "assistant", content: [{ type: "output_text", text: "previous assistant", annotations: [] }], status: "completed" },
 		{ type: "message", role: "user", content: [{ type: "input_text", text: "current user" }] },
 	]);
+});
+
+test("proxy tool routing stays limited to explicit providers", () => {
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		scope: { allProviders: "on" as const, additionalProviders: ["responses-proxy"] },
+	};
+	assert.equal(isExplicitlyConfiguredToolProvider({ provider: "responses-proxy" } as never, config), true);
+	assert.equal(isExplicitlyConfiguredToolProvider({ provider: "unlisted-proxy" } as never, config), false);
 });
 async function withMockWebRun(script: string, run: (path: string) => Promise<void>): Promise<void> {
 	const dir = await mkdtemp(join(tmpdir(), "pi-web-run-test-"));
@@ -105,7 +116,9 @@ process.stdin.on("end", () => {
 
 test("web_run routes explicitly configured Responses providers through their endpoint", async () => {
 	const originalBin = process.env["PI_CODEX_WEB_RUN_BIN"];
+	const originalAgentIdentity = process.env["PI_CODEX_AGENT_IDENTITY_JWT"];
 	try {
+		process.env["PI_CODEX_AGENT_IDENTITY_JWT"] = "must-not-reach-proxy";
 		await withMockWebRun(`#!/usr/bin/env node
 let input = "";
 process.stdin.on("data", (chunk) => input += chunk);
@@ -113,6 +126,7 @@ process.stdin.on("end", () => console.log(JSON.stringify({
   output_text: "ok",
   observed: {
 	input: JSON.parse(input),
+	agentIdentity: process.env.PI_CODEX_AGENT_IDENTITY_JWT,
     token: process.env.PI_CODEX_ACCESS_TOKEN,
     accountId: process.env.PI_CODEX_ACCOUNT_ID,
     baseUrl: process.env.PI_CODEX_BASE_URL,
@@ -140,12 +154,15 @@ process.stdin.on("end", () => console.log(JSON.stringify({
 					api: "openai-responses",
 					baseUrl: "https://proxy.example/v1/",
 					model: "gpt-5.6",
-					token: "proxy-key",
+					token: "stale-api-key",
+					headers: { Authorization: "Bearer proxy-header-key" },
+					apiKeyWithHeaders: true,
 				}),
 			);
 			assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, "ok");
 			const observed = ((result.details as { webRun: { observed: {
 				input: Record<string, unknown>;
+				agentIdentity?: string;
 				token: string;
 				accountId: string;
 				baseUrl: string;
@@ -154,6 +171,7 @@ process.stdin.on("end", () => console.log(JSON.stringify({
 			} } }).webRun).observed;
 			assert.equal(observed.input["model"], "gpt-5.6");
 			assert.deepEqual(observed.input["search_query"], [{ q: "OpenAI" }]);
+			assert.equal(observed.agentIdentity, undefined);
 			assert.deepEqual({
 				token: observed.token,
 				accountId: observed.accountId,
@@ -161,7 +179,7 @@ process.stdin.on("end", () => console.log(JSON.stringify({
 				responsesUrl: observed.responsesUrl,
 				model: observed.model,
 			}, {
-				token: "proxy-key",
+				token: "proxy-header-key",
 				accountId: "",
 				baseUrl: "https://proxy.example/v1",
 				responsesUrl: "https://proxy.example/v1/responses",
@@ -171,5 +189,7 @@ process.stdin.on("end", () => console.log(JSON.stringify({
 	} finally {
 		if (originalBin === undefined) delete process.env["PI_CODEX_WEB_RUN_BIN"];
 		else process.env["PI_CODEX_WEB_RUN_BIN"] = originalBin;
+		if (originalAgentIdentity === undefined) delete process.env["PI_CODEX_AGENT_IDENTITY_JWT"];
+		else process.env["PI_CODEX_AGENT_IDENTITY_JWT"] = originalAgentIdentity;
 	}
 });

--- a/packages/pi-codex-conversion/tests/web-search-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/web-search-tool.test.ts
@@ -103,23 +103,70 @@ process.stdin.on("end", () => {
 	}
 });
 
-test("web_run rejects renamed Codex providers without canonical Codex auth", async () => {
+test("web_run routes explicitly configured Responses providers through their endpoint", async () => {
 	const originalBin = process.env["PI_CODEX_WEB_RUN_BIN"];
 	try {
 		await withMockWebRun(`#!/usr/bin/env node
-process.stdin.resume();
-process.stdin.on("end", () => console.log(JSON.stringify({ encrypted_output: "ok" })));
+let input = "";
+process.stdin.on("data", (chunk) => input += chunk);
+process.stdin.on("end", () => console.log(JSON.stringify({
+  output_text: "ok",
+  observed: {
+	input: JSON.parse(input),
+    token: process.env.PI_CODEX_ACCESS_TOKEN,
+    accountId: process.env.PI_CODEX_ACCOUNT_ID,
+    baseUrl: process.env.PI_CODEX_BASE_URL,
+    responsesUrl: process.env.PI_CODEX_RESPONSES_URL,
+    model: process.env.PI_CODEX_MODEL,
+  },
+})));
 `, async (webRunPath) => {
 			process.env["PI_CODEX_WEB_RUN_BIN"] = webRunPath;
 			await assert.rejects(
-				() => createWebSearchTool().execute("call", { search_query: [{ q: "OpenAI" }] }, undefined, undefined as never, createContext({ provider: "custom-codex", api: "openai-codex-responses" })),
+				() => createWebSearchTool().execute("call", { search_query: [{ q: "OpenAI" }] }, undefined, undefined as never, createContext({ provider: "responses-proxy", api: "openai-responses" })),
 				/requires an OpenAI Codex-compatible Responses provider/,
 			);
-			const tool = createWebSearchTool("web_run", { allowConfiguredProvider: (model) => model?.provider === "custom-codex" });
-			await assert.rejects(
-				() => tool.execute("call", { search_query: [{ q: "OpenAI" }] }, undefined, undefined as never, createContext({ provider: "custom-codex", api: "openai-codex-responses" })),
-				/requires an OpenAI Codex-compatible Responses provider/,
+			const tool = createWebSearchTool("web_run", {
+				allowConfiguredProvider: (model) => model?.provider === "responses-proxy",
+				model: "gpt-5.6-luna",
+			});
+			const result = await tool.execute(
+				"call",
+				{ search_query: [{ q: "OpenAI" }] },
+				undefined,
+				undefined as never,
+				createContext({
+					provider: "responses-proxy",
+					api: "openai-responses",
+					baseUrl: "https://proxy.example/v1/",
+					model: "gpt-5.6",
+					token: "proxy-key",
+				}),
 			);
+			assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, "ok");
+			const observed = ((result.details as { webRun: { observed: {
+				input: Record<string, unknown>;
+				token: string;
+				accountId: string;
+				baseUrl: string;
+				responsesUrl: string;
+				model: string;
+			} } }).webRun).observed;
+			assert.equal(observed.input["model"], "gpt-5.6");
+			assert.deepEqual(observed.input["search_query"], [{ q: "OpenAI" }]);
+			assert.deepEqual({
+				token: observed.token,
+				accountId: observed.accountId,
+				baseUrl: observed.baseUrl,
+				responsesUrl: observed.responsesUrl,
+				model: observed.model,
+			}, {
+				token: "proxy-key",
+				accountId: "",
+				baseUrl: "https://proxy.example/v1",
+				responsesUrl: "https://proxy.example/v1/responses",
+				model: "gpt-5.6",
+			});
 		});
 	} finally {
 		if (originalBin === undefined) delete process.env["PI_CODEX_WEB_RUN_BIN"];


### PR DESCRIPTION
## Summary
- route Code Mode web__run through an explicitly configured Responses provider's /responses endpoint
- use the active proxy model ID so LiteLLM aliases such as gpt-5.6 are preserved instead of forcing a suffixed Codex search model
- isolate proxy auth from OpenAI agent identity state and prefer explicit proxy Bearer headers over stale API keys
- keep all-provider mode from routing unlisted Responses providers

The routing core follows amiani's b38a04c reference commit, with the model-alias and auth boundaries adapted to the released proxy implementation.

## Validation
- bun run check:changed (109 tests)
- bun run build
- bun run changeset:check
- post-commit reviewer findings resolved

## Release
- Changeset: yes
- Packages: @howaboua/pi-codex-conversion
- Aggregates: generated by release automation
