### PR TITLE
Fix session-scoped WebSocket shutdown

### DIFF
--- a/.changeset/calm-dingos-listen.md
+++ b/.changeset/calm-dingos-listen.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Scope cached OpenAI Codex WebSocket shutdown to the Pi session being closed so in-process sibling sessions keep their connections.

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -108,9 +108,9 @@ export function registerCodexEvents(
 		if (event.toolName === "exec_command") tracker.recordEnd(event.toolCallId);
 	});
 
-	pi.on("session_shutdown", async () => {
+	pi.on("session_shutdown", async (_event, ctx) => {
 		try {
-			runtime.shutdownTransport();
+			runtime.shutdownTransport(ctx.sessionManager.getSessionId());
 			ui.clearBackgroundWidget();
 			runtime.backgroundWidget.ctx = undefined;
 			sessions.shutdown();

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -29,7 +29,7 @@ export interface CodexExtensionRuntime {
 	codexSystemPrompt(basePrompt: string, ctx: CodexContext, skills?: AdapterState["promptSkills"]): string;
 	startPrewarm(ctx: CodexContext, systemPrompt?: string): Promise<void> | undefined;
 	resetTransport(sessionId?: string): void;
-	shutdownTransport(): void;
+	shutdownTransport(sessionId: string): void;
 	waitForPrewarm(ctx: CodexContext, systemPrompt: string): Promise<void> | undefined;
 }
 
@@ -127,9 +127,8 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			state.codexTurnState.reset();
 			if (sessionId) closeOpenAICodexWebSocketSessions(sessionId);
 		},
-		shutdownTransport() {
-			runtime.resetTransport();
-			closeOpenAICodexWebSocketSessions();
+		shutdownTransport(sessionId) {
+			runtime.resetTransport(sessionId);
 		},
 		waitForPrewarm(ctx, systemPrompt) {
 			return prewarmPromise ?? runtime.startPrewarm(ctx, systemPrompt);

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -20,7 +20,7 @@ import { combineAbortSignals, compressRequestBodyZstd, createSSEHeaderTimeout, p
 import type { CodexProviderStreamOptions, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { createInitialAssistantMessage } from "./openai-codex/types.ts";
 import { finalizeUsage } from "./openai-codex/usage.ts";
-import { closeOpenAICodexWebSocketSessions, validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
+import { validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
 import { processCodexResponsesStream } from "./openai-codex/stream-events.ts";
 import { prewarmWebSocket, processWebSocketStream } from "./openai-codex/websocket-stream.ts";
 import { openaiCodexNativeOAuthProvider } from "./openai-codex/oauth.ts";
@@ -279,9 +279,5 @@ export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { g
 			...(options.getConfig ? { getConfig: options.getConfig } : {}),
 			...(options.turnState ? { turnState: options.turnState } : {}),
 		}),
-	});
-
-	pi.on("session_shutdown", async () => {
-		closeOpenAICodexWebSocketSessions();
 	});
 }

--- a/packages/pi-codex-conversion/tests/extension-events.test.ts
+++ b/packages/pi-codex-conversion/tests/extension-events.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { setImmediate as flush } from "node:timers/promises";
-import { prepareCodeModeHost, registerCodexEvents } from "../src/extension/events.ts";
+import { prepareCodeModeHost } from "../src/extension/events.ts";
 
 test("Code Mode host setup cancellation stays silent", async () => {
 	const notifications: string[] = [];
@@ -27,40 +27,4 @@ test("Code Mode reports real host setup failures", async () => {
 
 	await flush();
 	assert.deepEqual(notifications, ["Code Mode host setup failed: download failed"]);
-});
-
-test("session shutdown scopes transport cleanup to the current session", async () => {
-	const handlers = new Map<string, (...args: never[]) => unknown>();
-	const shutdownSessionIds: string[] = [];
-	const pi = {
-		on(event: string, handler: (...args: never[]) => unknown) {
-			handlers.set(event, handler);
-		},
-	};
-	const runtime = {
-		state: {},
-		tracker: { recordSessionFinished() {} },
-		sessions: { onSessionExit() {}, shutdown() {} },
-		backgroundWidget: { ctx: {} },
-		shutdownTransport(sessionId: string) {
-			shutdownSessionIds.push(sessionId);
-		},
-	};
-
-	registerCodexEvents(
-		pi as never,
-		runtime as never,
-		{} as never,
-		{ clearBackgroundWidget() {} } as never,
-		{ shutdown: async () => {} } as never,
-		{ shutdown() {} } as never,
-	);
-
-	const shutdown = handlers.get("session_shutdown");
-	assert.ok(shutdown);
-	await shutdown({ type: "session_shutdown", reason: "quit" } as never, {
-		sessionManager: { getSessionId: () => "child-a" },
-	} as never);
-
-	assert.deepEqual(shutdownSessionIds, ["child-a"]);
 });

--- a/packages/pi-codex-conversion/tests/extension-events.test.ts
+++ b/packages/pi-codex-conversion/tests/extension-events.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { setImmediate as flush } from "node:timers/promises";
-import { prepareCodeModeHost } from "../src/extension/events.ts";
+import { prepareCodeModeHost, registerCodexEvents } from "../src/extension/events.ts";
 
 test("Code Mode host setup cancellation stays silent", async () => {
 	const notifications: string[] = [];
@@ -27,4 +27,40 @@ test("Code Mode reports real host setup failures", async () => {
 
 	await flush();
 	assert.deepEqual(notifications, ["Code Mode host setup failed: download failed"]);
+});
+
+test("session shutdown scopes transport cleanup to the current session", async () => {
+	const handlers = new Map<string, (...args: never[]) => unknown>();
+	const shutdownSessionIds: string[] = [];
+	const pi = {
+		on(event: string, handler: (...args: never[]) => unknown) {
+			handlers.set(event, handler);
+		},
+	};
+	const runtime = {
+		state: {},
+		tracker: { recordSessionFinished() {} },
+		sessions: { onSessionExit() {}, shutdown() {} },
+		backgroundWidget: { ctx: {} },
+		shutdownTransport(sessionId: string) {
+			shutdownSessionIds.push(sessionId);
+		},
+	};
+
+	registerCodexEvents(
+		pi as never,
+		runtime as never,
+		{} as never,
+		{ clearBackgroundWidget() {} } as never,
+		{ shutdown: async () => {} } as never,
+		{ shutdown() {} } as never,
+	);
+
+	const shutdown = handlers.get("session_shutdown");
+	assert.ok(shutdown);
+	await shutdown({ type: "session_shutdown", reason: "quit" } as never, {
+		sessionManager: { getSessionId: () => "child-a" },
+	} as never);
+
+	assert.deepEqual(shutdownSessionIds, ["child-a"]);
 });

--- a/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { buildCachedWebSocketRequestBody, buildRequestBody, prewarmOpenAICodexWebSocket } from "../src/providers/openai-codex-custom-provider.ts";
 import { acquireWebSocket, closeOpenAICodexWebSocketSessions } from "../src/providers/openai-codex/websocket.ts";
 import { createCodexTurnState } from "../src/providers/openai-codex/turn-state.ts";
+import { registerCodexEvents } from "../src/extension/events.ts";
+import { createCodexExtensionRuntime } from "../src/extension/runtime.ts";
 
 class FakeWebSocket {
 	static instances: FakeWebSocket[] = [];
@@ -113,11 +115,29 @@ test("WebSocket prewarm sends generate=false and seeds cached continuation", asy
 	}
 });
 
-test("closing one session leaves sibling cached WebSockets reusable", async () => {
+test("session shutdown leaves sibling cached WebSockets reusable", async () => {
 	const originalWebSocket = globalThis.WebSocket;
 	FakeWebSocket.instances = [];
 	(globalThis as typeof globalThis & { WebSocket: typeof WebSocket }).WebSocket = FakeWebSocket as never;
 	try {
+		const handlers = new Map<string, (...args: never[]) => unknown>();
+		const pi = {
+			on(event: string, handler: (...args: never[]) => unknown) {
+				handlers.set(event, handler);
+			},
+		};
+		const runtime = createCodexExtensionRuntime(pi as never);
+		registerCodexEvents(
+			pi as never,
+			runtime,
+			{} as never,
+			{ clearBackgroundWidget() {} } as never,
+			{ shutdown: async () => {} } as never,
+			{ shutdown() {} } as never,
+		);
+		const shutdown = handlers.get("session_shutdown");
+		assert.ok(shutdown);
+
 		const childA = await acquireWebSocket("wss://chatgpt.example/codex/responses", new Headers(), "child-a", undefined);
 		childA.release({ keep: true });
 		const childB = await acquireWebSocket("wss://chatgpt.example/codex/responses", new Headers(), "child-b", undefined);
@@ -125,7 +145,9 @@ test("closing one session leaves sibling cached WebSockets reusable", async () =
 
 		const socketA = FakeWebSocket.instances[0]!;
 		const socketB = FakeWebSocket.instances[1]!;
-		closeOpenAICodexWebSocketSessions("child-a");
+		await shutdown({ type: "session_shutdown", reason: "quit" } as never, {
+			sessionManager: { getSessionId: () => "child-a" },
+		} as never);
 
 		assert.deepEqual(socketA.closes, [{ code: 1000, reason: "session_shutdown" }]);
 		assert.deepEqual(socketB.closes, []);
@@ -134,7 +156,9 @@ test("closing one session leaves sibling cached WebSockets reusable", async () =
 		assert.equal(reusedB.reused, true);
 		reusedB.release({ keep: true });
 
-		closeOpenAICodexWebSocketSessions("child-b");
+		await shutdown({ type: "session_shutdown", reason: "quit" } as never, {
+			sessionManager: { getSessionId: () => "child-b" },
+		} as never);
 		assert.deepEqual(socketB.closes, [{ code: 1000, reason: "session_shutdown" }]);
 	} finally {
 		closeOpenAICodexWebSocketSessions();

--- a/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
@@ -7,6 +7,7 @@ import { createCodexTurnState } from "../src/providers/openai-codex/turn-state.t
 class FakeWebSocket {
 	static instances: FakeWebSocket[] = [];
 	readonly sent: string[] = [];
+	readonly closes: Array<{ code: number | undefined; reason: string | undefined }> = [];
 	readonly options: { headers?: Record<string, string> } | undefined;
 	readyState = 0;
 	private listeners = new Map<string, Set<(event: unknown) => void>>();
@@ -41,7 +42,8 @@ class FakeWebSocket {
 		}, 0);
 	}
 
-	close(): void {
+	close(code?: number, reason?: string): void {
+		this.closes.push({ code, reason });
 		this.readyState = 3;
 	}
 
@@ -104,6 +106,36 @@ test("WebSocket prewarm sends generate=false and seeds cached continuation", asy
 			decision: "delta",
 		});
 		acquired.release({ keep: true });
+	} finally {
+		closeOpenAICodexWebSocketSessions();
+		if (originalWebSocket) globalThis.WebSocket = originalWebSocket;
+		else delete (globalThis as { WebSocket?: unknown }).WebSocket;
+	}
+});
+
+test("closing one session leaves sibling cached WebSockets reusable", async () => {
+	const originalWebSocket = globalThis.WebSocket;
+	FakeWebSocket.instances = [];
+	(globalThis as typeof globalThis & { WebSocket: typeof WebSocket }).WebSocket = FakeWebSocket as never;
+	try {
+		const childA = await acquireWebSocket("wss://chatgpt.example/codex/responses", new Headers(), "child-a", undefined);
+		childA.release({ keep: true });
+		const childB = await acquireWebSocket("wss://chatgpt.example/codex/responses", new Headers(), "child-b", undefined);
+		childB.release({ keep: true });
+
+		const socketA = FakeWebSocket.instances[0]!;
+		const socketB = FakeWebSocket.instances[1]!;
+		closeOpenAICodexWebSocketSessions("child-a");
+
+		assert.deepEqual(socketA.closes, [{ code: 1000, reason: "session_shutdown" }]);
+		assert.deepEqual(socketB.closes, []);
+
+		const reusedB = await acquireWebSocket("wss://chatgpt.example/codex/responses", new Headers(), "child-b", undefined);
+		assert.equal(reusedB.reused, true);
+		reusedB.release({ keep: true });
+
+		closeOpenAICodexWebSocketSessions("child-b");
+		assert.deepEqual(socketB.closes, [{ code: 1000, reason: "session_shutdown" }]);
 	} finally {
 		closeOpenAICodexWebSocketSessions();
 		if (originalWebSocket) globalThis.WebSocket = originalWebSocket;


### PR DESCRIPTION
## Summary
- scope cached OpenAI Codex WebSocket shutdown to the Pi session being disposed
- remove the redundant provider-level close-all shutdown handler
- verify that shutting down child A closes A while child B remains reusable

Closes #117

## Validation
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
