### PR TITLE
Report pi-ask prompts as blocked in Herdr

### DIFF
--- a/.changeset/afraid-vans-fry.md
+++ b/.changeset/afraid-vans-fry.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-ask": patch
+---
+
+Report open ask panels as blocked to Herdr's Pi integration.

--- a/packages/pi-ask/README.md
+++ b/packages/pi-ask/README.md
@@ -20,6 +20,8 @@ The agent can present several independently decidable prompts in one tabbed pane
 
 For work only you can complete—sign-in, authorization, hardware access, or another manual step—the agent can open a handoff and wait until you mark it done or unable to complete.
 
+When Pi runs inside Herdr with its Pi integration installed, an open ask panel marks the pane as blocked until you submit, dismiss, or abort it.
+
 `Other/rephrase` is always available. Submit it blank when the prompt needs to be rephrased, split, or followed up instead of answered as written.
 
 ## Prompt commands

--- a/packages/pi-ask/ask/tool.ts
+++ b/packages/pi-ask/ask/tool.ts
@@ -15,10 +15,19 @@ type AskInComposer = (
 	signal: AbortSignal | undefined,
 ) => Promise<unknown>;
 
+interface BlockedState {
+	active: boolean;
+	label: string;
+}
+
+type OnBlockedChange = (state: BlockedState) => void;
+
 export function createAskTool({
 	askInComposer,
+	onBlockedChange,
 }: {
 	askInComposer?: AskInComposer;
+	onBlockedChange?: OnBlockedChange;
 } = {}) {
 	return defineTool({
 		name: "ask",
@@ -43,17 +52,27 @@ export function createAskTool({
 			if (!askInComposer && !ctx.hasUI)
 				throw new Error("ask requires an interactive UI.");
 
-			const rawResponses = askInComposer
-				? await askInComposer(prompts, signal)
-				: ctx.mode === "tui"
-					? await askInTui(ctx, prompts, {
-							handoff,
-							...(signal ? { signal } : {}),
-						})
-					: await askWithPiUi(ctx, prompts, {
-							handoff,
-							...(signal ? { signal } : {}),
-						});
+			const blockedState = {
+				active: true,
+				label: handoff ? "Human action needed" : "Waiting for input",
+			};
+			onBlockedChange?.(blockedState);
+			let rawResponses: unknown;
+			try {
+				rawResponses = askInComposer
+					? await askInComposer(prompts, signal)
+					: ctx.mode === "tui"
+						? await askInTui(ctx, prompts, {
+								handoff,
+								...(signal ? { signal } : {}),
+							})
+						: await askWithPiUi(ctx, prompts, {
+								handoff,
+								...(signal ? { signal } : {}),
+							});
+			} finally {
+				onBlockedChange?.({ ...blockedState, active: false });
+			}
 			const responses = normalizeResponses(prompts, rawResponses);
 			if (!responses) {
 				return {

--- a/packages/pi-ask/index.ts
+++ b/packages/pi-ask/index.ts
@@ -9,7 +9,11 @@ export { createAskTool } from "./ask/tool.js";
 const PROMPTS_DIR = join(dirname(fileURLToPath(import.meta.url)), "prompts");
 
 export default function humanInTheLoop(pi: ExtensionAPI): void {
-	pi.registerTool(createAskTool());
+	pi.registerTool(
+		createAskTool({
+			onBlockedChange: (state) => pi.events.emit("herdr:blocked", state),
+		}),
+	);
 	pi.on("resources_discover", () => {
 		const config = loadAskConfig();
 		return {

--- a/packages/pi-ask/tests/integration.test.ts
+++ b/packages/pi-ask/tests/integration.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import type { createAskTool } from "../ask/tool.js";
+import humanInTheLoop from "../index.js";
+
+test("reports open prompts to Herdr through Pi's event bus", async () => {
+	let tool: ReturnType<typeof createAskTool> | undefined;
+	const events: Array<{ channel: string; data: unknown }> = [];
+	humanInTheLoop({
+		registerTool: (definition: unknown) => {
+			tool = definition as ReturnType<typeof createAskTool>;
+		},
+		on: () => {},
+		events: {
+			emit: (channel: string, data: unknown) => events.push({ channel, data }),
+		},
+	} as never);
+
+	const answers = ["Proceed", ""];
+	await tool?.execute(
+		"call-1",
+		{ prompts: [{ title: "Choose a path" }] },
+		undefined,
+		undefined,
+		{
+			hasUI: true,
+			mode: "rpc",
+			ui: { input: async () => answers.shift() },
+		} as never,
+	);
+
+	expect(events).toEqual([
+		{
+			channel: "herdr:blocked",
+			data: { active: true, label: "Waiting for input" },
+		},
+		{
+			channel: "herdr:blocked",
+			data: { active: false, label: "Waiting for input" },
+		},
+	]);
+});

--- a/packages/pi-ask/tests/tool.test.ts
+++ b/packages/pi-ask/tests/tool.test.ts
@@ -50,7 +50,11 @@ describe("ask tool results", () => {
 	});
 
 	test("keeps a dismissed handoff distinct from a response", async () => {
-		const tool = createAskTool({ askInComposer: async () => null });
+		const blockedStates: Array<{ active: boolean; label: string }> = [];
+		const tool = createAskTool({
+			askInComposer: async () => null,
+			onBlockedChange: (state) => blockedStates.push(state),
+		});
 
 		const result = await tool.execute(
 			"call-2",
@@ -67,5 +71,33 @@ describe("ask tool results", () => {
 			dismissed: true,
 			kind: "handoff",
 		});
+		expect(blockedStates).toEqual([
+			{ active: true, label: "Human action needed" },
+			{ active: false, label: "Human action needed" },
+		]);
+	});
+
+	test("clears blocked state when the prompt UI fails", async () => {
+		const blockedStates: Array<{ active: boolean; label: string }> = [];
+		const tool = createAskTool({
+			askInComposer: async () => {
+				throw new Error("UI unavailable");
+			},
+			onBlockedChange: (state) => blockedStates.push(state),
+		});
+
+		const execution = tool.execute(
+			"call-3",
+			{ prompts: [{ title: "Choose a path" }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		await expect(execution).rejects.toThrow("UI unavailable");
+		expect(blockedStates).toEqual([
+			{ active: true, label: "Waiting for input" },
+			{ active: false, label: "Waiting for input" },
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
- emit Herdr's shared blocked-state event while an ask or handoff panel is open
- clear the state on submission, dismissal, abort, and UI failure
- document the behavior and cover the Pi event-bus wiring

## Validation
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes (patch)
- Packages: `@howaboua/pi-ask`
- Aggregates: generated by release automation
