### PR TITLE
Clarify Code Mode continuation prompts

### DIFF
--- a/.changeset/solid-shrimps-behave.md
+++ b/.changeset/solid-shrimps-behave.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Clarify Code Mode output and continuation tool guidance.

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -2,10 +2,11 @@ import type { CodeModeToolMetadata } from "./types.js";
 
 export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls.
 Optional first line: // @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}
+Emit output with text(value); console is unavailable.
 Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS.`;
 
 export const WAIT_DESCRIPTION =
-	"Resume a yielded exec cell.";
+	"Resume or terminate an exec cell; use tools.write_stdin for session_id.";
 
 const PROMOTED_TOOLS_HEADING = "Custom tools available in exec:";
 const DOCUMENTATION_PREFIX = "Custom tools documentation: read ";


### PR DESCRIPTION
## Summary
- direct Code Mode output through `text(value)` and state that `console` is unavailable
- distinguish exec-cell continuation from shell-session continuation in the `wait` description

## Validation
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
