### PR TITLE
Trim duplicate tool names from model prompts

### DIFF
--- a/.changeset/nine-corners-cough.md
+++ b/.changeset/nine-corners-cough.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Remove redundant tool-name labels from promoted Code Mode usage contracts.

--- a/.changeset/purple-sloths-train.md
+++ b/.changeset/purple-sloths-train.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-ask": patch
+---
+
+Remove the duplicated ask tool name from the model-facing prompt inventory.

--- a/packages/pi-ask/ask/tool.ts
+++ b/packages/pi-ask/ask/tool.ts
@@ -35,7 +35,7 @@ export function createAskTool({
 		description:
 			"Request user input or action and return the response. Requires interactive UI.",
 		parameters: AskParameters,
-		promptSnippet: "ask: Request human input or action.",
+		promptSnippet: "Request human input or action.",
 		promptGuidelines: [
 			"ask: Use for needed user decisions or input; set handoff true for a user-only action and state its completion signal.",
 			"ask: For reviews, make each finding a prompt with disposition choices; do not report first.",

--- a/packages/pi-ask/tests/tool.test.ts
+++ b/packages/pi-ask/tests/tool.test.ts
@@ -4,6 +4,12 @@ import { createAskTool } from "../ask/tool.js";
 const context = { hasUI: false, mode: "print" } as never;
 
 describe("ask tool results", () => {
+	test("keeps the prompt inventory snippet free of the tool name", () => {
+		expect(createAskTool().promptSnippet).toBe(
+			"Request human input or action.",
+		);
+	});
+
 	test("serializes interactive calls", () => {
 		expect(createAskTool().executionMode).toBe("sequential");
 	});

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -39,7 +39,7 @@ text(ALL_TOOLS.map(({ name }) => name));
 text(ALL_TOOLS.find(({ name }) => name === "port_info"));
 ```
 
-Set `defer_loading = false` only for stable, frequently used tools. Promotion adds only the name and `usage` to the system prompt; full help remains local.
+Set `defer_loading = false` only for stable, frequently used tools. Promotion adds only `usage` to the system prompt; full help remains local.
 
 ## Bundled examples
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -31,7 +31,7 @@ export function buildPromotedToolsPrompt(
 		.sort((left, right) => left.name.localeCompare(right.name));
 	if (promoted.length === 0) return "";
 	return `${PROMOTED_TOOLS_HEADING}\n${promoted
-		.map((tool) => `- ${tool.name}: ${tool.usage}`)
+		.map((tool) => `- ${tool.usage}`)
 		.join("\n")}`;
 }
 

--- a/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
@@ -24,11 +24,11 @@ test("Code Mode advertises only model-compatible nested tools", async () => {
 		);
 		assert.match(
 			promptResult?.systemPrompt ?? "",
-			/apply_patch: await tools\.apply_patch\(patch\)/,
+			/await tools\.apply_patch\(patch\)/,
 		);
-		assert.match(promptResult?.systemPrompt ?? "", /view_image: const result = await tools\.view_image/);
-		assert.match(promptResult?.systemPrompt ?? "", /web__run: await tools\.web__run/);
-		assert.match(promptResult?.systemPrompt ?? "", /image_gen__imagegen: await tools\.image_gen__imagegen/);
+		assert.match(promptResult?.systemPrompt ?? "", /const result = await tools\.view_image/);
+		assert.match(promptResult?.systemPrompt ?? "", /await tools\.web__run/);
+		assert.match(promptResult?.systemPrompt ?? "", /await tools\.image_gen__imagegen/);
 		const textOnlyPrompt = promptHandler?.(
 			{ systemPrompt: "Base" },
 			{
@@ -40,8 +40,8 @@ test("Code Mode advertises only model-compatible nested tools", async () => {
 				},
 			},
 		) as { systemPrompt?: string } | undefined;
-		assert.doesNotMatch(textOnlyPrompt?.systemPrompt ?? "", /view_image:/);
-		assert.doesNotMatch(textOnlyPrompt?.systemPrompt ?? "", /image_gen__imagegen:/);
+		assert.doesNotMatch(textOnlyPrompt?.systemPrompt ?? "", /tools\.view_image/);
+		assert.doesNotMatch(textOnlyPrompt?.systemPrompt ?? "", /tools\.image_gen__imagegen/);
 		(runtime as any).state.config.tools.viewImageFallback = true;
 		const fallbackPrompt = promptHandler?.(
 			{ systemPrompt: "Base" },
@@ -54,7 +54,7 @@ test("Code Mode advertises only model-compatible nested tools", async () => {
 				},
 			},
 		) as { systemPrompt?: string } | undefined;
-		assert.match(fallbackPrompt?.systemPrompt ?? "", /view_image: const description = await tools\.view_image/);
+		assert.match(fallbackPrompt?.systemPrompt ?? "", /const description = await tools\.view_image/);
 		(runtime as any).state.config.tools.viewImageFallback = false;
 	} finally {
 		await fixture.close();

--- a/packages/pi-codex-conversion/tests/code-mode-custom-tools.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-custom-tools.test.ts
@@ -25,7 +25,7 @@ test("Code Mode keeps TOML tools deferred unless promoted", () => {
 	assert.equal(promoted.deferLoading, false);
 	assert.equal(
 		buildPromotedToolsPrompt([deferred, promoted]),
-		"Custom tools available in exec:\n- common_tool: await tools.common_tool(input)",
+		"Custom tools available in exec:\n- await tools.common_tool(input)",
 	);
 });
 


### PR DESCRIPTION
## Summary
- remove the duplicated `ask` name from Pi's tool inventory snippet
- emit promoted Code Mode tools as exact usage contracts without redundant name labels
- keep prompt behavior covered by focused and model-compatibility tests

## Validation
- `bun run check:changed` — 126 tests passed across both changed packages
- `bun run changeset:check origin/main`
- compared the custom Codex provider with Pi's current `openai-codex-responses` provider; this prompt-only change does not alter request shape, transport, headers, reasoning, service tier, retry, or stream termination

## Release
- Changesets: yes
- Packages: `@howaboua/pi-ask`, `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
