### PR TITLE
Fix Code Mode routing for Responses providers on Pi 0.80.8+

### DIFF
--- a/.changeset/beige-parents-stand.md
+++ b/.changeset/beige-parents-stand.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Restore Code Mode tool execution for configured OpenAI Responses providers on Pi 0.80.8 and newer by routing their streams through the custom-tool parser.

--- a/.changeset/beige-parents-stand.md
+++ b/.changeset/beige-parents-stand.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Restore Code Mode tool execution for configured OpenAI Responses providers on Pi 0.80.8 and newer by routing their streams through the custom-tool parser.
+Restore Code Mode tool execution for configured OpenAI Responses providers on Pi 0.80.8 and newer by routing their streams through the custom-tool parser. Persist settings atomically and make existing Code Mode history safe to resume after the mode is disabled.

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -217,7 +217,11 @@ export function writeCodexConversionConfig(
 		renameSync(temporaryPath, configPath);
 		return { ok: true };
 	} catch (error) {
-		rmSync(temporaryPath, { force: true });
+		try {
+			rmSync(temporaryPath, { force: true });
+		} catch {
+			// Keep the original write error.
+		}
 		const message = error instanceof Error ? error.message : String(error);
 		console.warn(`[pi-codex-conversion] Failed to write ${configPath}: ${message}`);
 		return { ok: false, error: message };

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { migrateCodexConversionConfigIfNeeded } from "./config-migration.ts";
@@ -206,11 +206,18 @@ export function writeCodexConversionConfig(
 	config: CodexConversionConfig,
 	configPath: string = getCodexConversionConfigPath(),
 ): { ok: true } | { ok: false; error: string } {
+	const temporaryPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
 	try {
 		mkdirSync(dirname(configPath), { recursive: true });
-		writeFileSync(configPath, `${JSON.stringify(normalizeCodexConversionConfig(config), null, 2)}\n`, "utf-8");
+		writeFileSync(
+			temporaryPath,
+			`${JSON.stringify(normalizeCodexConversionConfig(config), null, 2)}\n`,
+			{ encoding: "utf-8", mode: 0o600 },
+		);
+		renameSync(temporaryPath, configPath);
 		return { ok: true };
 	} catch (error) {
+		rmSync(temporaryPath, { force: true });
 		const message = error instanceof Error ? error.message : String(error);
 		console.warn(`[pi-codex-conversion] Failed to write ${configPath}: ${message}`);
 		return { ok: false, error: message };

--- a/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
@@ -60,19 +60,23 @@ export function sanitizeCodeModeHistoryForFunctionTools<T extends ResponsesLikeB
 	body: T,
 ): T {
 	if (!body.input) return body;
+	let changed = false;
+	const input = body.input.map((item) => {
+		if (
+			!isRecord(item)
+			|| item["type"] !== "function_call"
+			|| typeof item["id"] !== "string"
+			|| !item["id"].startsWith("ctc_")
+		)
+			return item;
+		changed = true;
+		const { id: _id, ...rest } = item;
+		return rest;
+	});
+	if (!changed) return body;
 	return {
 		...body,
-		input: body.input.map((item) => {
-			if (
-				!isRecord(item)
-				|| item["type"] !== "function_call"
-				|| typeof item["id"] !== "string"
-				|| item["id"].startsWith("fc_")
-			)
-				return item;
-			const { id: _id, ...rest } = item;
-			return rest;
-		}),
+		input,
 	};
 }
 

--- a/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
@@ -32,9 +32,10 @@ export function applyCodeModeFreeformContract<T extends ResponsesLikeBody>(
 		const callId =
 			typeof item["call_id"] === "string" ? item["call_id"] : undefined;
 		if (callId) execCallIds.add(callId);
-		const { arguments: _arguments, ...rest } = item;
+		const { arguments: _arguments, id, ...rest } = item;
 		return {
 			...rest,
+			...(typeof id === "string" && id.startsWith("ctc_") ? { id } : {}),
 			type: "custom_tool_call",
 			input: execSourceFromArguments(item["arguments"]),
 		};
@@ -52,6 +53,26 @@ export function applyCodeModeFreeformContract<T extends ResponsesLikeBody>(
 		...body,
 		...(body.tools ? { tools: body.tools.map(toCodeModeTool) } : {}),
 		...(body.input ? { input: rewrittenInput } : {}),
+	};
+}
+
+export function sanitizeCodeModeHistoryForFunctionTools<T extends ResponsesLikeBody>(
+	body: T,
+): T {
+	if (!body.input) return body;
+	return {
+		...body,
+		input: body.input.map((item) => {
+			if (
+				!isRecord(item)
+				|| item["type"] !== "function_call"
+				|| typeof item["id"] !== "string"
+				|| item["id"].startsWith("fc_")
+			)
+				return item;
+			const { id: _id, ...rest } = item;
+			return rest;
+		}),
 	};
 }
 

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -8,15 +8,14 @@ import { applyResponsesLiteRequest, supportsResponsesLiteModel, type ResponsesLi
 import { applyCodeModeFreeformContract, sanitizeCodeModeHistoryForFunctionTools } from "./code-mode-contract.ts";
 
 export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
-	const sanitizedPayload = isResponsesContext(ctx) && isCodeModeCompatibleBody(payload)
-		? sanitizeCodeModeHistoryForFunctionTools(payload)
-		: payload;
 	if (!shouldUseCodexAdapter(ctx, state.config) || (!isEffectiveOpenAICodexContext(ctx, state.config) && !isResponsesContext(ctx))) {
+		if (!isResponsesContext(ctx) || !isCodeModeCompatibleBody(payload)) return undefined;
+		const sanitizedPayload = sanitizeCodeModeHistoryForFunctionTools(payload);
 		return sanitizedPayload === payload ? undefined : sanitizedPayload;
 	}
 
 	const isEffectiveOpenAICodex = isEffectiveOpenAICodexContext(ctx, state.config);
-	const configuredPayload = applyCodexRequestParams(sanitizedPayload, state.config, {
+	const configuredPayload = applyCodexRequestParams(payload, state.config, {
 		serviceTier: isEffectiveOpenAICodex,
 		verbosity: true,
 	});

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -5,7 +5,7 @@ import type { AdapterState } from "./activation/state.ts";
 import { isEffectiveOpenAICodexContext, shouldUseCodexAdapter, shouldUseGpt56CodeMode, shouldUseResponsesLiteForCodeMode, supportsProxiedGpt56CodeModeModel } from "./activation/activation.ts";
 import { injectPendingNativeWindowIntoPiCompactionRequest, rewriteCodexCompactedProviderRequest } from "./compaction/compaction.ts";
 import { applyResponsesLiteRequest, supportsResponsesLiteModel, type ResponsesLiteCompatibleBody } from "../providers/openai-codex/responses-lite.ts";
-import { applyCodeModeFreeformContract } from "./code-mode-contract.ts";
+import { applyCodeModeFreeformContract, sanitizeCodeModeHistoryForFunctionTools } from "./code-mode-contract.ts";
 
 export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
 	if (!shouldUseCodexAdapter(ctx, state.config) || (!isEffectiveOpenAICodexContext(ctx, state.config) && !isResponsesContext(ctx))) {
@@ -31,7 +31,9 @@ export async function rewriteCodexProviderRequest(payload: unknown, ctx: Extensi
 			? applyResponsesLiteRequest(codeModePayload)
 			: codeModePayload;
 	}
-	return rewrittenPayload;
+	return isCodeModeCompatibleBody(rewrittenPayload)
+		? sanitizeCodeModeHistoryForFunctionTools(rewrittenPayload)
+		: rewrittenPayload;
 }
 
 function isCodeModeCompatibleBody(value: unknown): value is ResponsesLiteCompatibleBody {

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -8,12 +8,15 @@ import { applyResponsesLiteRequest, supportsResponsesLiteModel, type ResponsesLi
 import { applyCodeModeFreeformContract, sanitizeCodeModeHistoryForFunctionTools } from "./code-mode-contract.ts";
 
 export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
+	const sanitizedPayload = isResponsesContext(ctx) && isCodeModeCompatibleBody(payload)
+		? sanitizeCodeModeHistoryForFunctionTools(payload)
+		: payload;
 	if (!shouldUseCodexAdapter(ctx, state.config) || (!isEffectiveOpenAICodexContext(ctx, state.config) && !isResponsesContext(ctx))) {
-		return undefined;
+		return sanitizedPayload === payload ? undefined : sanitizedPayload;
 	}
 
 	const isEffectiveOpenAICodex = isEffectiveOpenAICodexContext(ctx, state.config);
-	const configuredPayload = applyCodexRequestParams(payload, state.config, {
+	const configuredPayload = applyCodexRequestParams(sanitizedPayload, state.config, {
 		serviceTier: isEffectiveOpenAICodex,
 		verbosity: true,
 	});

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -69,7 +69,7 @@ export function registerCodexEvents(
 		runtime.backgroundWidget.ctx = ctx;
 		state.cwd = ctx.cwd;
 		state.config = readCodexConversionConfig();
-		proxyProvider.applyConfig(state.config);
+		proxyProvider.applyConfig(state.config, ctx.modelRegistry);
 		sessions.setBaseEnv(runtime.bundledPathToolsEnv());
 		state.promptSkills = extractPiPromptSkills(ctx.getSystemPrompt());
 		tracker.clear();
@@ -87,6 +87,7 @@ export function registerCodexEvents(
 		runtime.resetTransport(ctx.sessionManager.getSessionId());
 		state.cwd = ctx.cwd;
 		state.promptSkills = extractPiPromptSkills(ctx.getSystemPrompt());
+		proxyProvider.applyConfig(state.config, ctx.modelRegistry);
 		tools.ensureOptionalTools();
 		syncAdapter(pi, ctx, state);
 		prepareCodeModeHost(codeMode, ctx);

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -21,8 +21,8 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 		cleanupProxyProvider = proxyProvider;
 		const tools = registerCodexTools(pi, runtime);
 		const ui = registerCodexUi(pi, runtime);
-		registerCodexCommand(pi, runtime.state, (config) => {
-			proxyProvider.applyConfig(config);
+		registerCodexCommand(pi, runtime.state, (config, ctx) => {
+			proxyProvider.applyConfig(config, ctx.modelRegistry);
 			tools.applyConfig(config);
 			ui.applyConfig(config);
 		}, { sessions: runtime.sessions, widget: runtime.backgroundWidget });

--- a/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
@@ -227,7 +227,8 @@ export function registerCodeModeProxyProvider(
 		for (const provider of desiredProviders) {
 			if (registeredProviders.has(provider)) continue;
 			const previous = modelRegistry.getRegisteredProviderConfig(provider) as RegisteredProviderConfig | undefined;
-			const fallbackStream = (previous?.api === undefined || previous.api === "openai-responses") && previous?.streamSimple
+			if (previous?.streamSimple && previous.api !== "openai-responses") continue;
+			const fallbackStream = previous?.api === "openai-responses" && previous.streamSimple
 				? previous.streamSimple
 				: standardResponsesStream;
 			const overlayStream: NonNullable<RegisteredProviderConfig["streamSimple"]> = (model, context, options) =>

--- a/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
@@ -169,7 +169,7 @@ function configuredProxyProviders(config: CodexConversionConfig): Set<string> {
 function resolveProviderIds(configuredProviders: Set<string>, modelRegistry: CodeModeModelRegistry): Set<string> {
 	const resolved = new Set<string>();
 	for (const model of modelRegistry.getAll()) {
-		if (configuredProviders.has(model.provider.trim().toLowerCase())) resolved.add(model.provider);
+		if (model.api === "openai-responses" && configuredProviders.has(model.provider.trim().toLowerCase())) resolved.add(model.provider);
 	}
 	return resolved;
 }
@@ -178,18 +178,29 @@ export function registerCodeModeProxyProvider(
 	pi: ExtensionAPI,
 	getConfig: () => CodexConversionConfig,
 ): CodeModeProxyProviderRegistration {
-	const registeredProviders = new Map<string, RegisteredProviderConfig | undefined>();
+	const registeredProviders = new Map<string, {
+		previous: RegisteredProviderConfig | undefined;
+		overlayStream: NonNullable<RegisteredProviderConfig["streamSimple"]>;
+		modelRegistry: CodeModeModelRegistry;
+	}>();
 	let legacyBridgeRegistered = false;
-	const restoreProvider = (provider: string, previous: RegisteredProviderConfig | undefined) => {
+	const restoreProvider = (provider: string, registration: NonNullable<ReturnType<typeof registeredProviders.get>>) => {
+		const current = registration.modelRegistry.getRegisteredProviderConfig?.(provider) as RegisteredProviderConfig | undefined;
+		if (!current || current.streamSimple !== registration.overlayStream) return;
+		const restored = { ...current } as RegisteredProviderConfig;
+		if (registration.previous?.streamSimple) restored.streamSimple = registration.previous.streamSimple;
+		else delete restored.streamSimple;
+		if (registration.previous?.api) restored.api = registration.previous.api;
+		else if (!registration.previous?.streamSimple && current.api === "openai-responses") delete restored.api;
 		pi.unregisterProvider(provider);
-		if (previous) pi.registerProvider(provider, previous);
+		if (Object.keys(restored).length > 0) pi.registerProvider(provider, restored);
 	};
 	const shutdown = () => {
 		if (legacyBridgeRegistered) {
 			pi.unregisterProvider(LEGACY_BRIDGE_PROVIDER);
 			legacyBridgeRegistered = false;
 		}
-		for (const [provider, previous] of registeredProviders) restoreProvider(provider, previous);
+		for (const [provider, registration] of registeredProviders) restoreProvider(provider, registration);
 		registeredProviders.clear();
 	};
 	const applyConfig = (config: CodexConversionConfig, modelRegistry: CodeModeModelRegistry) => {
@@ -216,21 +227,22 @@ export function registerCodeModeProxyProvider(
 		for (const provider of desiredProviders) {
 			if (registeredProviders.has(provider)) continue;
 			const previous = modelRegistry.getRegisteredProviderConfig(provider) as RegisteredProviderConfig | undefined;
-			const fallbackStream = previous?.api === "openai-responses" && previous.streamSimple
+			const fallbackStream = (previous?.api === undefined || previous.api === "openai-responses") && previous?.streamSimple
 				? previous.streamSimple
 				: standardResponsesStream;
+			const overlayStream: NonNullable<RegisteredProviderConfig["streamSimple"]> = (model, context, options) =>
+				shouldUseGpt56CodeMode({ model }, getConfig())
+					? streamCodeModeResponsesProxy(model, context, options)
+					: fallbackStream(model as never, context, options);
 			pi.registerProvider(provider, {
 				api: "openai-responses",
-				streamSimple: (model, context, options) =>
-					shouldUseGpt56CodeMode({ model }, getConfig())
-						? streamCodeModeResponsesProxy(model, context, options)
-						: fallbackStream(model as never, context, options),
+				streamSimple: overlayStream,
 			});
-			registeredProviders.set(provider, previous);
+			registeredProviders.set(provider, { previous, overlayStream, modelRegistry });
 		}
-		for (const [provider, previous] of registeredProviders) {
+		for (const [provider, registration] of registeredProviders) {
 			if (desiredProviders.has(provider)) continue;
-			restoreProvider(provider, previous);
+			restoreProvider(provider, registration);
 			registeredProviders.delete(provider);
 		}
 	};

--- a/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/code-mode-proxy-provider.ts
@@ -10,7 +10,7 @@ import {
 	type ProviderStreams,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import { shouldUseGpt56CodeMode } from "../adapter/activation/activation.ts";
@@ -19,7 +19,7 @@ import { isResponsesLiteRequest, prepareResponsesLiteRequestImages, RESPONSES_LI
 import { processCodexResponsesStream } from "./openai-codex/stream-events.ts";
 import type { OpenAICodexStreamOptions, ResponsesBody, StreamEventShape } from "./openai-codex/types.ts";
 
-const BRIDGE_PROVIDER = "@howaboua/pi-codex-conversion:responses-proxy";
+const LEGACY_BRIDGE_PROVIDER = "@howaboua/pi-codex-conversion:responses-proxy";
 const OPENAI_RESPONSES_API_MODULE = "@earendil-works/pi-ai/api/openai-responses";
 const standardResponsesStream = lazyApi(async () =>
 	await import(OPENAI_RESPONSES_API_MODULE) as ProviderStreams
@@ -153,38 +153,86 @@ export function streamCodeModeResponsesProxy<TApi extends Api>(
 }
 
 export interface CodeModeProxyProviderRegistration {
-	applyConfig(config: CodexConversionConfig): void;
+	applyConfig(config: CodexConversionConfig, modelRegistry: CodeModeModelRegistry): void;
 	shutdown(): void;
+}
+
+type CodeModeModelRegistry = Pick<ModelRegistry, "getAll"> & Partial<Pick<ModelRegistry, "getRegisteredProviderConfig">>;
+type RegisteredProviderConfig = Parameters<ExtensionAPI["registerProvider"]>[1];
+
+function configuredProxyProviders(config: CodexConversionConfig): Set<string> {
+	return new Set(config.beta.codeMode
+		? config.scope.additionalProviders.filter((provider) => provider !== "openai-codex")
+		: []);
+}
+
+function resolveProviderIds(configuredProviders: Set<string>, modelRegistry: CodeModeModelRegistry): Set<string> {
+	const resolved = new Set<string>();
+	for (const model of modelRegistry.getAll()) {
+		if (configuredProviders.has(model.provider.trim().toLowerCase())) resolved.add(model.provider);
+	}
+	return resolved;
 }
 
 export function registerCodeModeProxyProvider(
 	pi: ExtensionAPI,
 	getConfig: () => CodexConversionConfig,
 ): CodeModeProxyProviderRegistration {
-	let registered = false;
-	const shutdown = () => {
-		if (!registered) return;
-		pi.unregisterProvider(BRIDGE_PROVIDER);
-		registered = false;
+	const registeredProviders = new Map<string, RegisteredProviderConfig | undefined>();
+	let legacyBridgeRegistered = false;
+	const restoreProvider = (provider: string, previous: RegisteredProviderConfig | undefined) => {
+		pi.unregisterProvider(provider);
+		if (previous) pi.registerProvider(provider, previous);
 	};
-	const applyConfig = (config: CodexConversionConfig) => {
-		const needed = config.beta.codeMode && config.scope.additionalProviders.some((provider) => {
-			const normalized = provider.trim().toLowerCase();
-			return normalized !== "" && normalized !== "openai-codex";
-		});
-		if (needed === registered) return;
-		if (!needed) {
-			shutdown();
+	const shutdown = () => {
+		if (legacyBridgeRegistered) {
+			pi.unregisterProvider(LEGACY_BRIDGE_PROVIDER);
+			legacyBridgeRegistered = false;
+		}
+		for (const [provider, previous] of registeredProviders) restoreProvider(provider, previous);
+		registeredProviders.clear();
+	};
+	const applyConfig = (config: CodexConversionConfig, modelRegistry: CodeModeModelRegistry) => {
+		const configuredProviders = configuredProxyProviders(config);
+		if (!modelRegistry.getRegisteredProviderConfig) {
+			const needed = configuredProviders.size > 0;
+			if (needed === legacyBridgeRegistered) return;
+			if (!needed) {
+				pi.unregisterProvider(LEGACY_BRIDGE_PROVIDER);
+				legacyBridgeRegistered = false;
+				return;
+			}
+			pi.registerProvider(LEGACY_BRIDGE_PROVIDER, {
+				api: "openai-responses",
+				streamSimple: (model, context, options) =>
+					shouldUseGpt56CodeMode({ model }, getConfig())
+						? streamCodeModeResponsesProxy(model, context, options)
+						: standardResponsesStream(model as never, context, options),
+			});
+			legacyBridgeRegistered = true;
 			return;
 		}
-		pi.registerProvider(BRIDGE_PROVIDER, {
-			api: "openai-responses",
-			streamSimple: (model, context, options) =>
-				shouldUseGpt56CodeMode({ model }, getConfig())
-					? streamCodeModeResponsesProxy(model, context, options)
-					: standardResponsesStream(model as never, context, options),
-		});
-		registered = true;
+		const desiredProviders = resolveProviderIds(configuredProviders, modelRegistry);
+		for (const provider of desiredProviders) {
+			if (registeredProviders.has(provider)) continue;
+			const previous = modelRegistry.getRegisteredProviderConfig(provider) as RegisteredProviderConfig | undefined;
+			const fallbackStream = previous?.api === "openai-responses" && previous.streamSimple
+				? previous.streamSimple
+				: standardResponsesStream;
+			pi.registerProvider(provider, {
+				api: "openai-responses",
+				streamSimple: (model, context, options) =>
+					shouldUseGpt56CodeMode({ model }, getConfig())
+						? streamCodeModeResponsesProxy(model, context, options)
+						: fallbackStream(model as never, context, options),
+			});
+			registeredProviders.set(provider, previous);
+		}
+		for (const [provider, previous] of registeredProviders) {
+			if (desiredProviders.has(provider)) continue;
+			restoreProvider(provider, previous);
+			registeredProviders.delete(provider);
+		}
 	};
 
 	return { applyConfig, shutdown };

--- a/packages/pi-codex-conversion/src/ui/settings/AGENTS.md
+++ b/packages/pi-codex-conversion/src/ui/settings/AGENTS.md
@@ -1,0 +1,3 @@
+- Settings writes are explicit user actions; session startup and resume only read configuration.
+- Keep persistence synchronous and simple. Do not add process locks or concurrency machinery without a reproduced background writer or realistic overlapping-write path.
+- For apparent setting flips, trace the config source, read lifecycle, and UI draft first; do not promote a theoretical write race into the cause.

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -19,7 +19,7 @@ const CODEX_USAGE = "Usage: /codex, /codex all, /codex status, /codex fast, /cod
 export function registerCodexCommand(
 	pi: ExtensionAPI,
 	state: AdapterState,
-	onConfigApplied?: (config: CodexConversionConfig) => void,
+	onConfigApplied?: (config: CodexConversionConfig, ctx: ExtensionContext) => void,
 	backgroundShells?: { sessions: ExecSessionManager; widget: BackgroundBashWidgetState } | undefined,
 ): void {
 	function saveAndApply(ctx: ExtensionContext, nextConfig: CodexConversionConfig): boolean {
@@ -29,7 +29,7 @@ export function registerCodexCommand(
 			return false;
 		}
 		state.config = nextConfig;
-		onConfigApplied?.(nextConfig);
+		onConfigApplied?.(nextConfig, ctx);
 		syncAdapter(pi, ctx, state);
 		return true;
 	}

--- a/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
@@ -40,10 +40,12 @@ test("function-tool replay drops Code Mode item ids", () => {
 		input: [
 			{ type: "function_call", id: "ctc_1", call_id: "call_1", name: "exec", arguments: "{}" },
 			{ type: "function_call", id: "fc_2", call_id: "call_2", name: "wait", arguments: "{}" },
+			{ type: "function_call", id: "vendor_3", call_id: "call_3", name: "search", arguments: "{}" },
 		],
 	});
 	assert.deepEqual(body.input, [
 		{ type: "function_call", call_id: "call_1", name: "exec", arguments: "{}" },
 		{ type: "function_call", id: "fc_2", call_id: "call_2", name: "wait", arguments: "{}" },
+		{ type: "function_call", id: "vendor_3", call_id: "call_3", name: "search", arguments: "{}" },
 	]);
 });

--- a/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { applyCodeModeFreeformContract } from "../src/adapter/code-mode-contract.ts";
+import { applyCodeModeFreeformContract, sanitizeCodeModeHistoryForFunctionTools } from "../src/adapter/code-mode-contract.ts";
 
 test("Code Mode rewrites exec history to custom tool items", () => {
 	const body = applyCodeModeFreeformContract({
@@ -27,11 +27,23 @@ test("Code Mode rewrites exec history to custom tool items", () => {
 	assert.deepEqual(body.input, [
 		{
 			type: "custom_tool_call",
-			id: "fc_1",
 			call_id: "call_1",
 			name: "exec",
 			input: "text(42);",
 		},
 		{ type: "custom_tool_call_output", call_id: "call_1", output: "42" },
+	]);
+});
+
+test("function-tool replay drops Code Mode item ids", () => {
+	const body = sanitizeCodeModeHistoryForFunctionTools({
+		input: [
+			{ type: "function_call", id: "ctc_1", call_id: "call_1", name: "exec", arguments: "{}" },
+			{ type: "function_call", id: "fc_2", call_id: "call_2", name: "wait", arguments: "{}" },
+		],
+	});
+	assert.deepEqual(body.input, [
+		{ type: "function_call", call_id: "call_1", name: "exec", arguments: "{}" },
+		{ type: "function_call", id: "fc_2", call_id: "call_2", name: "wait", arguments: "{}" },
 	]);
 });

--- a/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
@@ -306,6 +306,38 @@ test("provider overlays ignore configured providers without Responses models", (
 	assert.equal(providers.size, 0);
 });
 
+test("mixed-API providers preserve an existing non-Responses custom stream", () => {
+	const originalStream = (() => "anthropic") as never;
+	const originalProvider = {
+		api: "anthropic-messages" as const,
+		streamSimple: originalStream,
+	};
+	const provider = originalProvider;
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		beta: { codeMode: true, responsesLite: false },
+		scope: { allProviders: "off" as const, additionalProviders: ["mixed-proxy"] },
+	};
+	const registration = registerCodeModeProxyProvider({
+		registerProvider() {
+			throw new Error("must not replace the provider's non-Responses stream");
+		},
+		unregisterProvider() {
+			throw new Error("must not unregister the provider's non-Responses stream");
+		},
+	} as never, () => config);
+
+	registration.applyConfig(config, {
+		getAll: () => [
+			{ provider: "mixed-proxy", api: "anthropic-messages" },
+			{ provider: "mixed-proxy", api: "openai-responses" },
+		] as never,
+		getRegisteredProviderConfig: () => provider,
+	});
+
+	assert.equal(provider.streamSimple, originalStream);
+});
+
 test("provider teardown preserves later registrations and never restores stale streams", () => {
 	const originalStream = (() => "original") as never;
 	const replacementStream = (() => "replacement") as never;

--- a/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
@@ -210,8 +210,8 @@ test("the provider-scoped proxy stream delegates ordinary Responses models witho
 
 		assert.equal(providers.size, 0);
 		registration.applyConfig(config, {
-			getAll: () => [{ provider: "proxy" }] as never,
-			getRegisteredProviderConfig: () => undefined,
+			getAll: () => [{ provider: "proxy", api: "openai-responses" }] as never,
+			getRegisteredProviderConfig: (name: string) => providers.get(name) as never,
 		});
 		assert.equal(providers.size, 1);
 		assert.ok(providers.has("proxy"));
@@ -266,7 +266,7 @@ test("the provider-scoped proxy stream preserves an existing extension provider"
 		},
 	} as never, () => config);
 	const modelRegistry = {
-		getAll: () => [{ provider: "ExtensionProxy" }] as never,
+		getAll: () => [{ provider: "ExtensionProxy", api: "openai-responses" }] as never,
 		getRegisteredProviderConfig: () => provider,
 	};
 
@@ -281,6 +281,66 @@ test("the provider-scoped proxy stream preserves an existing extension provider"
 
 	registration.shutdown();
 	assert.deepEqual(provider, originalProvider);
+});
+
+test("provider overlays ignore configured providers without Responses models", () => {
+	const providers = new Map<string, unknown>();
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		beta: { codeMode: true, responsesLite: false },
+		scope: { allProviders: "off" as const, additionalProviders: ["anthropic-proxy"] },
+	};
+	const registration = registerCodeModeProxyProvider({
+		registerProvider(name: string, provider: unknown) {
+			providers.set(name, provider);
+		},
+		unregisterProvider(name: string) {
+			providers.delete(name);
+		},
+	} as never, () => config);
+
+	registration.applyConfig(config, {
+		getAll: () => [{ provider: "anthropic-proxy", api: "anthropic-messages" }] as never,
+		getRegisteredProviderConfig: () => undefined,
+	});
+	assert.equal(providers.size, 0);
+});
+
+test("provider teardown preserves later registrations and never restores stale streams", () => {
+	const originalStream = (() => "original") as never;
+	const replacementStream = (() => "replacement") as never;
+	let provider: Parameters<ModelRegistry["registerProvider"]>[1] | undefined = {
+		api: "openai-responses",
+		streamSimple: originalStream,
+	};
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		beta: { codeMode: true, responsesLite: false },
+		scope: { allProviders: "off" as const, additionalProviders: ["proxy"] },
+	};
+	const registration = registerCodeModeProxyProvider({
+		registerProvider(_name: string, overlay: Parameters<ModelRegistry["registerProvider"]>[1]) {
+			provider = { ...provider, ...overlay };
+		},
+		unregisterProvider() {
+			provider = undefined;
+		},
+	} as never, () => config);
+	const modelRegistry = {
+		getAll: () => [{ provider: "proxy", api: "openai-responses" }] as never,
+		getRegisteredProviderConfig: () => provider,
+	};
+
+	registration.applyConfig(config, modelRegistry);
+	provider = { ...provider, headers: { "x-later-extension": "true" } };
+	registration.applyConfig({ ...config, beta: { ...config.beta, codeMode: false } }, modelRegistry);
+	assert.equal(provider?.streamSimple, originalStream);
+	assert.deepEqual(provider?.headers, { "x-later-extension": "true" });
+
+	registration.applyConfig(config, modelRegistry);
+	provider = { ...provider, streamSimple: replacementStream };
+	registration.shutdown();
+	assert.equal(provider?.streamSimple, replacementStream);
 });
 
 test("Pi 0.80.7 keeps using the API-level compatibility bridge", () => {

--- a/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
 import { applyCodeModeFreeformContract } from "../src/adapter/code-mode-contract.ts";
 import {
@@ -175,7 +179,7 @@ test("the proxy stream reports failed HTTP responses", async () => {
 	}
 });
 
-test("the proxy bridge delegates ordinary Responses models without recursion", async () => {
+test("the provider-scoped proxy stream delegates ordinary Responses models without recursion", async () => {
 	const originalFetch = globalThis.fetch;
 	const providers = new Map<string, { streamSimple: (...args: never[]) => AsyncIterable<unknown> }>();
 	const unregistered: string[] = [];
@@ -205,8 +209,12 @@ test("the proxy bridge delegates ordinary Responses models without recursion", a
 		} as never, () => config);
 
 		assert.equal(providers.size, 0);
-		registration.applyConfig(config);
+		registration.applyConfig(config, {
+			getAll: () => [{ provider: "proxy" }] as never,
+			getRegisteredProviderConfig: () => undefined,
+		});
 		assert.equal(providers.size, 1);
+		assert.ok(providers.has("proxy"));
 		const provider = [...providers.values()][0]!;
 		const events = await collect(provider.streamSimple(
 			{ ...proxyModel, id: "gpt-5.5" } as never,
@@ -223,6 +231,151 @@ test("the proxy bridge delegates ordinary Responses models without recursion", a
 		assert.equal(unregistered.length, 1);
 	} finally {
 		globalThis.fetch = originalFetch;
+	}
+});
+
+test("the provider-scoped proxy stream preserves an existing extension provider", async () => {
+	const originalStream = (() => "original") as never;
+	const originalProvider = {
+		api: "openai-responses" as const,
+		baseUrl: "https://extension.example/v1",
+		apiKey: "extension-key",
+		streamSimple: originalStream,
+		models: [{
+			id: "gpt-5.5",
+			name: "Extension model",
+			reasoning: true,
+			input: ["text" as const],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		}],
+	};
+	let provider: Parameters<ModelRegistry["registerProvider"]>[1] | undefined = originalProvider;
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		beta: { codeMode: true, responsesLite: false },
+		scope: { allProviders: "off" as const, additionalProviders: ["extensionproxy"] },
+	};
+	const registration = registerCodeModeProxyProvider({
+		registerProvider(_name: string, overlay: Parameters<ModelRegistry["registerProvider"]>[1]) {
+			provider = { ...provider, ...overlay };
+		},
+		unregisterProvider() {
+			provider = undefined;
+		},
+	} as never, () => config);
+	const modelRegistry = {
+		getAll: () => [{ provider: "ExtensionProxy" }] as never,
+		getRegisteredProviderConfig: () => provider,
+	};
+
+	registration.applyConfig(config, modelRegistry);
+	assert.notEqual(provider?.streamSimple, originalStream);
+	assert.equal(provider?.streamSimple?.({ ...proxyModel, provider: "ExtensionProxy", id: "gpt-5.5" } as never, {} as never), "original");
+	registration.applyConfig({ ...config, beta: { ...config.beta, codeMode: false } }, modelRegistry);
+	assert.deepEqual(provider, originalProvider);
+
+	registration.applyConfig(config, modelRegistry);
+	assert.notEqual(provider?.streamSimple, originalStream);
+
+	registration.shutdown();
+	assert.deepEqual(provider, originalProvider);
+});
+
+test("Pi 0.80.7 keeps using the API-level compatibility bridge", () => {
+	const providers = new Map<string, unknown>();
+	const config = {
+		...DEFAULT_CODEX_CONVERSION_CONFIG,
+		beta: { codeMode: true, responsesLite: false },
+		scope: { allProviders: "off" as const, additionalProviders: ["proxy"] },
+	};
+	const registration = registerCodeModeProxyProvider({
+		registerProvider(name: string, provider: unknown) {
+			providers.set(name, provider);
+		},
+		unregisterProvider(name: string) {
+			providers.delete(name);
+		},
+	} as never, () => config);
+
+	registration.applyConfig(config, { getAll: () => [{ provider: "proxy" }] as never });
+	assert.equal(providers.size, 1);
+	assert.equal(providers.has("proxy"), false);
+
+	registration.shutdown();
+	assert.equal(providers.size, 0);
+});
+
+test("configured Responses models route through the Code Mode stream in Pi's model runtime", async () => {
+	const originalFetch = globalThis.fetch;
+	const agentDir = await mkdtemp(join(tmpdir(), "pi-code-mode-proxy-"));
+	let registration: ReturnType<typeof registerCodeModeProxyProvider> | undefined;
+	try {
+		await writeFile(join(agentDir, "models.json"), JSON.stringify({
+			providers: {
+				MyProxy: {
+					baseUrl: "https://proxy.example/v1",
+					apiKey: "test-key",
+					api: "openai-responses",
+					models: [{
+						id: "gpt-5.6",
+						name: "GPT-5.6 Proxy",
+						reasoning: true,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 100_000,
+						maxTokens: 10_000,
+					}],
+				},
+			},
+		}));
+		globalThis.fetch = (async () => sseResponse([
+			{ type: "response.created", response: { id: "resp_runtime" } },
+			{ type: "response.output_item.added", output_index: 0, item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", input: "" } },
+			{ type: "response.custom_tool_call_input.delta", output_index: 0, item_id: "ctc_1", delta: "text(\"runtime\");" },
+			{ type: "response.output_item.done", output_index: 0, item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", input: "text(\"runtime\");", status: "completed" } },
+			{ type: "response.completed", response: { id: "resp_runtime", status: "completed", usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+		])) as typeof fetch;
+
+		const runtime = await ModelRuntime.create({
+			modelsPath: join(agentDir, "models.json"),
+			allowModelNetwork: false,
+		});
+		const registry = new ModelRegistry(runtime);
+		const config = {
+			...DEFAULT_CODEX_CONVERSION_CONFIG,
+			beta: { codeMode: true, responsesLite: false },
+			scope: { allProviders: "off" as const, additionalProviders: ["myproxy"] },
+		};
+		registration = registerCodeModeProxyProvider({
+			registerProvider: (name: string, provider: Parameters<ModelRegistry["registerProvider"]>[1]) =>
+				registry.registerProvider(name, provider),
+			unregisterProvider: (name: string) => registry.unregisterProvider(name),
+		} as never, () => config);
+		registration.applyConfig(config, registry);
+		await runtime.refresh({ allowNetwork: false });
+
+		const model = registry.find("MyProxy", "gpt-5.6");
+		assert.ok(model);
+		const events = await collect(runtime.streamSimple(
+			model,
+			{ systemPrompt: "Use Code Mode", messages: [], tools: [{ name: "exec", description: "Run JavaScript", parameters: { type: "object" } }] } as never,
+			{ onPayload: (payload: unknown) => applyCodeModeFreeformContract(payload as never) } as never,
+		));
+		const done = events.at(-1) as { type: string; reason: string; message: { content: unknown[] } };
+		assert.equal(done.type, "done");
+		assert.equal(done.reason, "toolUse");
+		assert.deepEqual(done.message.content, [{
+			type: "toolCall",
+			id: "call_1|ctc_1",
+			name: "exec",
+			arguments: { code: "text(\"runtime\");" },
+		}]);
+	} finally {
+		registration?.shutdown();
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
 	}
 });
 

--- a/packages/pi-codex-conversion/tests/config-migration.test.ts
+++ b/packages/pi-codex-conversion/tests/config-migration.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { migrateCodexConversionConfigIfNeeded } from "../src/adapter/activation/config-migration.ts";
-import { normalizeCodexConversionConfig } from "../src/adapter/activation/config.ts";
+import { DEFAULT_CODEX_CONVERSION_CONFIG, normalizeCodexConversionConfig, writeCodexConversionConfig } from "../src/adapter/activation/config.ts";
 
 test("old flat config migrates to grouped config and respects disabled provider gate", () => {
 	const migration = migrateCodexConversionConfigIfNeeded({
@@ -102,4 +105,21 @@ test("beta-only Code Mode config stays grouped", () => {
 	const migration = migrateCodexConversionConfigIfNeeded({ beta: { codeMode: true } });
 	assert.equal(migration.migrated, false);
 	assert.equal(normalizeCodexConversionConfig(migration.config).beta.codeMode, true);
+});
+
+test("config writes replace the file atomically with private permissions", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-codex-config-"));
+	const path = join(dir, "pi-codex-conversion.json");
+	try {
+		const result = writeCodexConversionConfig({
+			...DEFAULT_CODEX_CONVERSION_CONFIG,
+			beta: { ...DEFAULT_CODEX_CONVERSION_CONFIG.beta, codeMode: true },
+		}, path);
+		assert.deepEqual(result, { ok: true });
+		assert.equal(JSON.parse(await readFile(path, "utf8")).beta.codeMode, true);
+		assert.deepEqual(await readdir(dir), ["pi-codex-conversion.json"]);
+		assert.equal((await stat(path)).mode & 0o777, 0o600);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
 });

--- a/packages/pi-codex-conversion/tests/provider-request.test.ts
+++ b/packages/pi-codex-conversion/tests/provider-request.test.ts
@@ -49,6 +49,27 @@ test("Code Mode leaves a rewritten request for another model untouched", async (
 	assert.equal(rewritten.instructions, "Instructions");
 });
 
+test("turning Code Mode off safely replays stored custom-tool history", async () => {
+	const adapterState = state();
+	adapterState.config.beta.codeMode = false;
+	const rewritten = await rewriteCodexProviderRequest({
+		...payload,
+		input: [
+			{ type: "function_call", id: "ctc_02c506", call_id: "call_1", name: "exec", arguments: JSON.stringify({ code: "text(42);" }) },
+			{ type: "function_call_output", call_id: "call_1", output: "42" },
+		],
+	}, {
+		model: { provider: "openai-codex", api: "openai-codex-responses", id: "gpt-5.6-luna" },
+	} as never, adapterState) as typeof payload;
+
+	assert.deepEqual(rewritten.input[0], {
+		type: "function_call",
+		call_id: "call_1",
+		name: "exec",
+		arguments: JSON.stringify({ code: "text(42);" }),
+	});
+});
+
 test("Responses Lite rewrites the GPT-5.6 alias when enabled for configured providers", async () => {
 	const rewritten = await rewriteCodexProviderRequest({ ...payload, model: "gpt-5.6" }, {
 		model: { provider: "litellm", api: "openai-responses", id: "gpt-5.6" },

--- a/packages/pi-codex-conversion/tests/provider-request.test.ts
+++ b/packages/pi-codex-conversion/tests/provider-request.test.ts
@@ -70,6 +70,22 @@ test("turning Code Mode off safely replays stored custom-tool history", async ()
 	});
 });
 
+test("stored Code Mode history is sanitized after its provider leaves adapter scope", async () => {
+	const rewritten = await rewriteCodexProviderRequest({
+		...payload,
+		input: [{ type: "function_call", id: "ctc_02c506", call_id: "call_1", name: "exec", arguments: "{}" }],
+	}, {
+		model: { provider: "litellm", api: "openai-responses", id: "gpt-5.6" },
+	} as never, state()) as typeof payload;
+
+	assert.deepEqual(rewritten.input[0], {
+		type: "function_call",
+		call_id: "call_1",
+		name: "exec",
+		arguments: "{}",
+	});
+});
+
 test("Responses Lite rewrites the GPT-5.6 alias when enabled for configured providers", async () => {
 	const rewritten = await rewriteCodexProviderRequest({ ...payload, model: "gpt-5.6" }, {
 		model: { provider: "litellm", api: "openai-responses", id: "gpt-5.6" },

--- a/packages/pi-codex-conversion/tests/provider-request.test.ts
+++ b/packages/pi-codex-conversion/tests/provider-request.test.ts
@@ -39,6 +39,24 @@ test("Code Mode keeps raw exec tools in standard Responses requests", async () =
 	assert.equal((rewritten.input[0] as { role: string }).role, "user");
 });
 
+test("Code Mode preserves backend item IDs while replaying exec history", async () => {
+	const rewritten = await rewriteCodexProviderRequest({
+		...payload,
+		model: "gpt-5.6",
+		input: [
+			{ type: "function_call", id: "ctc_02c506", call_id: "call_1", name: "exec", arguments: JSON.stringify({ code: "text(42);" }) },
+			{ type: "function_call_output", call_id: "call_1", output: "42" },
+		],
+	}, {
+		model: { provider: "litellm", api: "openai-responses", id: "gpt-5.6" },
+	} as never, state(["litellm"])) as typeof payload;
+
+	assert.deepEqual(rewritten.input, [
+		{ type: "custom_tool_call", id: "ctc_02c506", call_id: "call_1", name: "exec", input: "text(42);" },
+		{ type: "custom_tool_call_output", call_id: "call_1", output: "42" },
+	]);
+});
+
 test("Code Mode leaves a rewritten request for another model untouched", async () => {
 	const rewritten = await rewriteCodexProviderRequest({ ...payload, model: "gpt-5.5" }, {
 		model: { provider: "litellm", api: "openai-responses", id: "gpt-5.6" },


### PR DESCRIPTION
## Summary
- route configured OpenAI Responses providers through the Code Mode stream parser under Pi's provider-scoped `ModelRuntime`
- retain the API-level compatibility bridge for Pi 0.80.7 and restore pre-existing extension provider registrations on teardown
- resolve normalized configuration names to exact provider IDs and cover the real runtime path with a regression test
- merge settings changes against the latest disk state, persist them atomically, and safely replay custom-tool history if Code Mode is disabled between sessions

Closes #133

## Validation
- `bun run check:changed` (118 tests)
- `bun run changeset:check`
- runtime-routing regression copied onto `origin/main` fails with `stop !== toolUse`
- resume regression copied onto `origin/main` preserves the invalid `ctc_` ID and fails

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
