### PR TITLE
Add cache hit predictor extension

### DIFF
--- a/.changeset/ten-items-nail.md
+++ b/.changeset/ten-items-nail.md
@@ -1,5 +1,8 @@
 ---
 "@howaboua/pi-cache-hit-predictor": patch
+"@howaboua/pi-auto-reasoning-tool": patch
 ---
 
 Add inline cache-hit predictions when switching Pi model or reasoning lanes.
+
+Warn once that automatic reasoning-level changes can cause prompt-cache misses and affect provider costs or quotas.

--- a/.changeset/ten-items-nail.md
+++ b/.changeset/ten-items-nail.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-cache-hit-predictor": patch
+---
+
+Add inline cache-hit predictions when switching Pi model or reasoning lanes.

--- a/.github/ISSUE_TEMPLATE/pi-stuff.yml
+++ b/.github/ISSUE_TEMPLATE/pi-stuff.yml
@@ -12,6 +12,7 @@ body:
         - pi-codex-conversion
         - pi-auto-reasoning-tool
         - pi-auto-trees
+        - pi-cache-hit-predictor
         - pi-explore-subagents
         - pi-markdown-workflows
         - pi-memories

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 | Package | Includes | Deliberate exclusions |
 |---|---|---|
-| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 11 general extensions and 9 shareable skills | Codex conversion and Omarchy support |
-| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 11 general extensions | Codex conversion |
+| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 12 general extensions and 9 shareable skills | Codex conversion and Omarchy support |
+| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 12 general extensions | Codex conversion |
 | [`@howaboua/pi-skills`](./packages/pi-skills) | 9 shareable skills | Omarchy support |
 
 ```bash
@@ -30,6 +30,7 @@ pi install npm:@howaboua/pi-skills
 | [`pi-ask`](./packages/pi-ask) | Interactive user decisions, review triage, and human handoffs |
 | [`pi-auto-reasoning-tool`](./packages/pi-auto-reasoning-tool) | An agent-callable `change_reasoning` tool with the user's selected level as its floor |
 | [`pi-auto-trees`](./packages/pi-auto-trees) | `/marker` and `/end` for rolling completed work into a compact branch summary |
+| [`pi-cache-hit-predictor`](./packages/pi-cache-hit-predictor) | Inline prompt-cache hit predictions when switching models or reasoning levels |
 | [`pi-codex-conversion`](./packages/pi-codex-conversion) | Codex-shaped shell, patch, image, web, and Code Mode tools for GPT/Codex models |
 | [`pi-dynamic-tools`](./packages/pi-dynamic-tools) | TOML-defined command-line tools exposed through JavaScript Code Mode |
 | [`pi-explore-subagents`](./packages/pi-explore-subagents) | Isolated, discovery-only shallow and deep subagents |

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,18 @@
         "@earendil-works/pi-coding-agent": "*",
       },
     },
+    "packages/pi-cache-hit-predictor": {
+      "name": "@howaboua/pi-cache-hit-predictor",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
+        "@earendil-works/pi-coding-agent": "0.80.8",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.8",
+      },
+    },
     "packages/pi-codex-conversion": {
       "name": "@howaboua/pi-codex-conversion",
       "version": "2.2.1",

--- a/packages/pi-auto-reasoning-tool/src/index.ts
+++ b/packages/pi-auto-reasoning-tool/src/index.ts
@@ -85,6 +85,16 @@ function formatSelection(
 export default function autoReasoningSelector(pi: ExtensionAPI) {
 	let lastSelection: LastSelection | undefined;
 	let turnBaselineReasoningLevel: AppliedReasoningLevel | undefined;
+	let warnedAboutCacheImpact = false;
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (warnedAboutCacheImpact) return;
+		warnedAboutCacheImpact = true;
+		ctx.ui.notify(
+			"Auto Reasoning switches reasoning levels mid-session. This can cause prompt-cache misses and affect costs or quotas, depending on your provider. Use with caution.",
+			"warning",
+		);
+	});
 
 	pi.registerTool({
 		name: "change_reasoning",

--- a/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
+++ b/packages/pi-auto-reasoning-tool/tests/reasoning-floor.test.ts
@@ -68,4 +68,24 @@ describe("reasoning floor", () => {
 		await state.handler("agent_settled")({}, {});
 		expect(state.level).toBe("medium");
 	});
+
+	test("warns about cache impact only once", async () => {
+		const state = setup("medium");
+		const notifications: unknown[][] = [];
+		const ctx = {
+			ui: {
+				notify: (...args: unknown[]) => notifications.push(args),
+			},
+		};
+
+		await state.handler("session_start")({}, ctx);
+		await state.handler("session_start")({}, ctx);
+
+		expect(notifications).toEqual([
+			[
+				"Auto Reasoning switches reasoning levels mid-session. This can cause prompt-cache misses and affect costs or quotas, depending on your provider. Use with caution.",
+				"warning",
+			],
+		]);
+	});
 });

--- a/packages/pi-cache-hit-predictor/.gitignore
+++ b/packages/pi-cache-hit-predictor/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/packages/pi-cache-hit-predictor/LICENSE
+++ b/packages/pi-cache-hit-predictor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pi-cache-hit-predictor contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-cache-hit-predictor/README.md
+++ b/packages/pi-cache-hit-predictor/README.md
@@ -1,0 +1,38 @@
+# @howaboua/pi-cache-hit-predictor
+
+Shows an inline cache-hit prediction when you switch Pi models or reasoning levels.
+
+```text
+Cache hit prediction · gpt-5.6-sol · low: ~27k / ~104k (26%) cached
+```
+
+The prediction is a UI-only transcript notification. It is not sent to the model and does not change the prompt. Back-to-back predictions update the same line while you cycle through models or reasoning levels.
+
+## Install
+
+```bash
+pi install npm:@howaboua/pi-cache-hit-predictor
+```
+
+Try it for one session:
+
+```bash
+pi -e npm:@howaboua/pi-cache-hit-predictor
+```
+
+## How it works
+
+The extension treats each provider, API, model, and reasoning level combination as a separate cache lane. It remembers the prompt size from the latest successful request in each lane. When you return to one, the old prompt size is the prefix that may still be reusable.
+
+For example, if `low` last saw 25k tokens and the session grew to 100k on `high`, switching back predicts a hit of up to 25k, or 25%. The next completed request refreshes that lane with the larger prompt.
+
+This is an estimate, not provider preflight data. Provider expiry or eviction, compaction, branch summaries, changed tools or system instructions, and provider serialization can change the actual hit. The provider's `cacheRead` usage remains the final result.
+
+## Local development
+
+```bash
+bun install
+bun run check
+bun run pack:dry
+pi -e ./index.ts
+```

--- a/packages/pi-cache-hit-predictor/biome.json
+++ b/packages/pi-cache-hit-predictor/biome.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": [
+			"**",
+			"!node_modules",
+			"!dist",
+			"!coverage",
+			"!package-lock.json"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/packages/pi-cache-hit-predictor/index.ts
+++ b/packages/pi-cache-hit-predictor/index.ts
@@ -1,0 +1,132 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+	type CacheLane,
+	type CachePrediction,
+	predictCacheHit,
+	recordAssistantUsage,
+	scanCacheHistory,
+} from "./src/predictor.js";
+
+interface ModelIdentity {
+	provider: string;
+	api: string;
+	id: string;
+}
+
+function formatTokens(tokens: number): string {
+	if (tokens < 1_000) return Math.round(tokens).toString();
+	if (tokens < 1_000_000) {
+		return `${(tokens / 1_000).toFixed(tokens < 10_000 ? 1 : 0)}k`;
+	}
+	return `${(tokens / 1_000_000).toFixed(tokens < 10_000_000 ? 1 : 0)}m`;
+}
+
+function predictionText(prediction: CachePrediction): string {
+	const lane = `${prediction.lane.model} · ${prediction.lane.thinkingLevel}`;
+	if (!prediction.hasLaneHistory) {
+		const prompt = prediction.currentPromptTokens
+			? ` of ~${formatTokens(prediction.currentPromptTokens)}`
+			: "";
+		return `Cache hit prediction · ${lane}: cold lane (0%${prompt})`;
+	}
+
+	if (prediction.currentPromptTokens === null || prediction.percent === null) {
+		return `Cache hit prediction · ${lane}: ~${formatTokens(prediction.estimatedCacheTokens)} cached`;
+	}
+	return `Cache hit prediction · ${lane}: ~${formatTokens(prediction.estimatedCacheTokens)} / ~${formatTokens(prediction.currentPromptTokens)} (${Math.round(prediction.percent)}%) cached`;
+}
+
+function laneFor(model: ModelIdentity, thinkingLevel: string): CacheLane {
+	return {
+		provider: model.provider,
+		api: model.api,
+		model: model.id,
+		thinkingLevel,
+	};
+}
+
+export default function (pi: ExtensionAPI) {
+	let history = scanCacheHistory([]);
+	let pendingPredictionTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const rebuild = (ctx: ExtensionContext) => {
+		history = scanCacheHistory(
+			ctx.sessionManager.getBranch(),
+			pi.getThinkingLevel(),
+		);
+	};
+
+	const appendPrediction = (
+		ctx: ExtensionContext,
+		model: ModelIdentity,
+		thinkingLevel: string,
+	) => {
+		if (ctx.mode !== "tui") return;
+		const contextTokens = ctx.getContextUsage()?.tokens ?? null;
+		const prediction = predictCacheHit(
+			history,
+			laneFor(model, thinkingLevel),
+			contextTokens,
+		);
+		ctx.ui.notify(predictionText(prediction), "info");
+	};
+
+	const schedulePrediction = (
+		ctx: ExtensionContext,
+		model: ModelIdentity,
+		thinkingLevel: string,
+	) => {
+		if (pendingPredictionTimer) clearTimeout(pendingPredictionTimer);
+		pendingPredictionTimer = setTimeout(() => {
+			pendingPredictionTimer = undefined;
+			appendPrediction(ctx, model, thinkingLevel);
+		}, 0);
+	};
+
+	pi.on("session_start", async (_event, ctx) => rebuild(ctx));
+	pi.on("session_tree", async (_event, ctx) => rebuild(ctx));
+	pi.on("session_compact", async (_event, ctx) => rebuild(ctx));
+
+	pi.on("message_end", async (event, ctx) => {
+		if (event.message.role !== "assistant") return;
+		const selected = ctx.model;
+		recordAssistantUsage(
+			history,
+			event.message,
+			laneFor(
+				selected?.provider === event.message.provider &&
+					selected.id === event.message.model &&
+					selected.api === event.message.api
+					? selected
+					: {
+							provider: event.message.provider,
+							api: event.message.api,
+							id: event.message.model,
+						},
+				pi.getThinkingLevel(),
+			),
+		);
+	});
+
+	pi.on("thinking_level_select", async (event, ctx) => {
+		if (event.level === event.previousLevel || !ctx.model) return;
+		schedulePrediction(ctx, ctx.model, event.level);
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		if (event.source === "restore" || !event.previousModel) {
+			if (pendingPredictionTimer) clearTimeout(pendingPredictionTimer);
+			pendingPredictionTimer = undefined;
+			return;
+		}
+		schedulePrediction(ctx, event.model, pi.getThinkingLevel());
+	});
+
+	pi.on("session_shutdown", async () => {
+		if (pendingPredictionTimer) clearTimeout(pendingPredictionTimer);
+		pendingPredictionTimer = undefined;
+	});
+}

--- a/packages/pi-cache-hit-predictor/package.json
+++ b/packages/pi-cache-hit-predictor/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@howaboua/pi-cache-hit-predictor",
+	"version": "0.0.0",
+	"description": "Predicts reusable prompt-cache prefixes when Pi switches model or reasoning lanes.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-cache-hit-predictor"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-cache-hit-predictor#readme",
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-coding-agent",
+		"prompt-cache",
+		"cache-prediction",
+		"model-switching"
+	],
+	"engines": {
+		"node": ">=20.6.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"index.ts",
+		"src",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.80.8"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "0.80.8",
+		"typescript": "^6.0.3"
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck && bun run test",
+		"test": "bun test",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run",
+		"prepublishOnly": "bun run check && bun run pack:dry"
+	},
+	"main": "index.ts",
+	"exports": "./index.ts"
+}

--- a/packages/pi-cache-hit-predictor/src/predictor.ts
+++ b/packages/pi-cache-hit-predictor/src/predictor.ts
@@ -1,0 +1,137 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export const UNKNOWN_THINKING_LEVEL = "unknown";
+
+export interface CacheLane {
+	provider: string;
+	api: string;
+	model: string;
+	thinkingLevel: string;
+}
+
+export interface CacheLaneSnapshot extends CacheLane {
+	promptTokens: number;
+}
+
+export interface CacheHistory {
+	lanes: Map<string, CacheLaneSnapshot>;
+}
+
+export interface CachePrediction {
+	lane: CacheLane;
+	estimatedCacheTokens: number;
+	currentPromptTokens: number | null;
+	percent: number | null;
+	hasLaneHistory: boolean;
+}
+
+export function cacheLaneKey(lane: CacheLane): string {
+	return JSON.stringify([
+		lane.provider,
+		lane.api,
+		lane.model,
+		lane.thinkingLevel,
+	]);
+}
+
+export function promptTokens(usage: {
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+}): number {
+	return usage.input + usage.cacheRead + usage.cacheWrite;
+}
+
+export function scanCacheHistory(
+	entries: readonly SessionEntry[],
+	initialThinkingLevel = UNKNOWN_THINKING_LEVEL,
+): CacheHistory {
+	const history: CacheHistory = { lanes: new Map() };
+	let thinkingLevel = initialThinkingLevel;
+
+	for (const entry of entries) {
+		if (entry.type === "thinking_level_change") {
+			thinkingLevel = entry.thinkingLevel;
+			continue;
+		}
+
+		if (entry.type === "compaction" || entry.type === "branch_summary") {
+			history.lanes.clear();
+			continue;
+		}
+
+		if (entry.type !== "message" || entry.message.role !== "assistant") {
+			continue;
+		}
+
+		const message = entry.message;
+		if (message.stopReason === "aborted" || message.stopReason === "error") {
+			continue;
+		}
+
+		const tokens = promptTokens(message.usage);
+		if (tokens <= 0) continue;
+
+		const lane: CacheLane = {
+			provider: message.provider,
+			api: message.api,
+			model: message.model,
+			thinkingLevel,
+		};
+
+		history.lanes.set(cacheLaneKey(lane), {
+			...lane,
+			promptTokens: tokens,
+		});
+	}
+
+	return history;
+}
+
+export function recordAssistantUsage(
+	history: CacheHistory,
+	message: Extract<SessionEntry, { type: "message" }>["message"],
+	lane: CacheLane,
+): void {
+	if (
+		message.role !== "assistant" ||
+		message.stopReason === "aborted" ||
+		message.stopReason === "error"
+	) {
+		return;
+	}
+
+	const tokens = promptTokens(message.usage);
+	if (tokens <= 0) return;
+
+	history.lanes.set(cacheLaneKey(lane), {
+		...lane,
+		promptTokens: tokens,
+	});
+}
+
+export function predictCacheHit(
+	history: CacheHistory,
+	lane: CacheLane,
+	currentPromptTokens: number | null,
+): CachePrediction {
+	const snapshot = history.lanes.get(cacheLaneKey(lane));
+	const currentTokens =
+		currentPromptTokens !== null && currentPromptTokens > 0
+			? currentPromptTokens
+			: null;
+	const estimatedCacheTokens = snapshot
+		? Math.min(snapshot.promptTokens, currentTokens ?? snapshot.promptTokens)
+		: 0;
+
+	return {
+		lane,
+		estimatedCacheTokens,
+		currentPromptTokens: currentTokens,
+		percent:
+			currentTokens === null
+				? null
+				: Math.min(100, (estimatedCacheTokens / currentTokens) * 100),
+		hasLaneHistory: snapshot !== undefined,
+	};
+}

--- a/packages/pi-cache-hit-predictor/tests/extension.test.ts
+++ b/packages/pi-cache-hit-predictor/tests/extension.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import cacheHitPredictor from "../index.js";
+
+test("coalesces a model clamp into one inline notification", async () => {
+	const handlers = new Map<
+		string,
+		(event: never, ctx: ExtensionContext) => unknown
+	>();
+	const notifications: string[] = [];
+	const pi = {
+		on(
+			event: string,
+			handler: (event: never, ctx: ExtensionContext) => unknown,
+		) {
+			handlers.set(event, handler);
+		},
+		getThinkingLevel: () => "high",
+	} as unknown as ExtensionAPI;
+
+	cacheHitPredictor(pi);
+
+	const branch = [
+		{
+			type: "thinking_level_change",
+			id: "00000001",
+			parentId: null,
+			timestamp: new Date(1_000).toISOString(),
+			thinkingLevel: "low",
+		},
+		{
+			type: "message",
+			id: "00000002",
+			parentId: "00000001",
+			timestamp: new Date(2_000).toISOString(),
+			message: {
+				role: "assistant",
+				content: [],
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-old",
+				usage: {
+					input: 17_000,
+					output: 10,
+					cacheRead: 8_000,
+					cacheWrite: 0,
+					totalTokens: 25_010,
+					cost: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						total: 0,
+					},
+				},
+				stopReason: "stop",
+				timestamp: 2_000,
+			},
+		},
+	] as SessionEntry[];
+	const oldModel = {
+		provider: "openai",
+		api: "openai-responses",
+		id: "gpt-old",
+		name: "Old",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0.1, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 10_000,
+	} as const;
+	const newModel = { ...oldModel, id: "gpt-new", name: "New" };
+	const ctx = {
+		mode: "tui",
+		model: newModel,
+		getContextUsage: () => ({
+			tokens: 100_000,
+			contextWindow: 200_000,
+			percent: 50,
+		}),
+		sessionManager: { getBranch: () => branch },
+		modelRegistry: { find: () => undefined },
+		ui: {
+			notify(message: string) {
+				notifications.push(message);
+			},
+		},
+	} as unknown as ExtensionContext;
+
+	await handlers.get("session_start")?.({} as never, ctx);
+	await handlers.get("thinking_level_select")?.(
+		{ level: "high", previousLevel: "low" } as never,
+		ctx,
+	);
+	await handlers.get("model_select")?.(
+		{
+			model: newModel,
+			previousModel: oldModel,
+			source: "set",
+		} as never,
+		ctx,
+	);
+	expect(notifications).toHaveLength(0);
+	await Bun.sleep(5);
+
+	expect(notifications).toEqual([
+		"Cache hit prediction · gpt-new · high: cold lane (0% of ~100k)",
+	]);
+});

--- a/packages/pi-cache-hit-predictor/tests/predictor.test.ts
+++ b/packages/pi-cache-hit-predictor/tests/predictor.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+	cacheLaneKey,
+	predictCacheHit,
+	scanCacheHistory,
+} from "../src/predictor.js";
+
+let nextId = 0;
+
+function base(type: string) {
+	nextId += 1;
+	return {
+		type,
+		id: nextId.toString(16).padStart(8, "0"),
+		parentId: nextId === 1 ? null : (nextId - 1).toString(16).padStart(8, "0"),
+		timestamp: new Date(nextId * 1_000).toISOString(),
+	};
+}
+
+function thinking(level: string): SessionEntry {
+	return {
+		...base("thinking_level_change"),
+		type: "thinking_level_change",
+		thinkingLevel: level,
+	};
+}
+
+function assistant(
+	model: string,
+	prompt: number,
+	timestamp: number,
+	cacheRead = 0,
+): SessionEntry {
+	return {
+		...base("message"),
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "openai",
+			model,
+			usage: {
+				input: prompt - cacheRead,
+				output: 10,
+				cacheRead,
+				cacheWrite: 0,
+				totalTokens: prompt + 10,
+				cost: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					total: 0,
+				},
+			},
+			stopReason: "stop",
+			timestamp,
+		},
+	} as SessionEntry;
+}
+
+describe("cache lane history", () => {
+	test("uses the live reasoning level when old sessions have no initial entry", () => {
+		const history = scanCacheHistory(
+			[assistant("gpt-test", 25_000, 1_000, 8_000)],
+			"medium",
+		);
+
+		expect([...history.lanes.values()][0]?.thinkingLevel).toBe("medium");
+	});
+
+	test("keeps separate snapshots for reasoning levels", () => {
+		const history = scanCacheHistory([
+			thinking("low"),
+			assistant("gpt-test", 25_000, 1_000, 8_000),
+			thinking("high"),
+			assistant("gpt-test", 100_000, 2_000, 24_000),
+		]);
+
+		expect(history.lanes.size).toBe(2);
+		expect(
+			history.lanes.get(
+				cacheLaneKey({
+					provider: "openai",
+					api: "openai-responses",
+					model: "gpt-test",
+					thinkingLevel: "low",
+				}),
+			)?.promptTokens,
+		).toBe(25_000);
+	});
+
+	test("drops incompatible pre-compaction snapshots", () => {
+		const compaction = {
+			...base("compaction"),
+			type: "compaction",
+			summary: "summary",
+			firstKeptEntryId: "00000001",
+			tokensBefore: 50_000,
+		} as SessionEntry;
+		const history = scanCacheHistory([
+			thinking("low"),
+			assistant("gpt-old", 50_000, 1_000, 20_000),
+			compaction,
+			assistant("gpt-new", 10_000, 2_000, 0),
+		]);
+
+		expect(history.lanes.size).toBe(1);
+		expect([...history.lanes.values()][0]?.model).toBe("gpt-new");
+	});
+});
+
+describe("cache hit prediction", () => {
+	test("bounds the old lane prefix by the current prompt", () => {
+		const history = scanCacheHistory([
+			thinking("low"),
+			assistant("gpt-test", 25_000, 1_000, 8_000),
+		]);
+		const prediction = predictCacheHit(
+			history,
+			{
+				provider: "openai",
+				api: "openai-responses",
+				model: "gpt-test",
+				thinkingLevel: "low",
+			},
+			100_000,
+		);
+
+		expect(prediction.estimatedCacheTokens).toBe(25_000);
+		expect(prediction.percent).toBe(25);
+	});
+
+	test("reports an unseen destination as cold", () => {
+		const history = scanCacheHistory([
+			thinking("high"),
+			assistant("gpt-test", 100_000, 1_000, 20_000),
+		]);
+		const prediction = predictCacheHit(
+			history,
+			{
+				provider: "openai",
+				api: "openai-responses",
+				model: "gpt-test",
+				thinkingLevel: "low",
+			},
+			100_000,
+		);
+
+		expect(prediction.hasLaneHistory).toBe(false);
+		expect(prediction.estimatedCacheTokens).toBe(0);
+		expect(prediction.percent).toBe(0);
+	});
+});

--- a/packages/pi-cache-hit-predictor/tsconfig.json
+++ b/packages/pi-cache-hit-predictor/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "src/**/*.ts"]
+}

--- a/packages/pi-extensions/README.md
+++ b/packages/pi-extensions/README.md
@@ -13,6 +13,7 @@ pi install npm:@howaboua/pi-extensions
 - `pi-ask` — interactive decisions, review triage, human handoffs, and optional `/fold` and `/grill` prompts
 - `pi-auto-reasoning-tool` — agent-controlled reasoning levels with the user's level as a floor
 - `pi-auto-trees` — `/marker` and `/end` for incremental long sessions
+- `pi-cache-hit-predictor` — inline prompt-cache hit predictions when switching models or reasoning levels
 - `pi-dynamic-tools` — TOML-defined command tools through JavaScript Code Mode
 - `pi-explore-subagents` — isolated, discovery-only subagents
 - `pi-markdown-workflows` — workflow/skill UI and nested `AGENTS.md` loading

--- a/packages/pi-stuff/README.md
+++ b/packages/pi-stuff/README.md
@@ -1,6 +1,6 @@
 # @howaboua/pi-stuff
 
-The full general-purpose bundle: all 11 extensions from `@howaboua/pi-extensions`, pi-ask's prompt workflows, and all 9 skills from `@howaboua/pi-skills`.
+The full general-purpose bundle: all 12 extensions from `@howaboua/pi-extensions`, pi-ask's prompt workflows, and all 9 skills from `@howaboua/pi-skills`.
 
 ## Install
 
@@ -10,7 +10,7 @@ pi install npm:@howaboua/pi-stuff
 
 This installs:
 
-- extensions: `pi-ask`, `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
+- extensions: `pi-ask`, `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-cache-hit-predictor`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
 - skills: `adversarial-qa`, `agent-native-hardening`, `agents-md`, `anti-ai-copy`, `chrome-cdp`, `gh-issue-pr-flow`, `model-facing-api-design`, `project-reference-research`, and `skill-creator`
 
 `pi-codex-conversion` and `omarchy-help` are intentionally separate because they depend on model and workstation choices.


### PR DESCRIPTION
## Summary
- add `@howaboua/pi-cache-hit-predictor` with per-provider/API/model/reasoning cache-lane estimates
- show predictions as UI-only inline notifications that update in place while cycling
- make Auto Reasoning warn once that its mid-session reasoning changes can cause cache misses and affect provider costs or quotas
- include package metadata, bundle documentation, tests, and issue-template routing

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `bun run --cwd packages/pi-cache-hit-predictor pack:dry`
- manually switched models and reasoning levels in Pi and verified the inline notice updates in place

## Release
- Changeset: yes
- Packages: `@howaboua/pi-cache-hit-predictor`, `@howaboua/pi-auto-reasoning-tool`
- Aggregates: generated by release automation
