### PR TITLE
Harden Code Mode tools and sessions

### DIFF
--- a/.changeset/nice-corners-notice.md
+++ b/.changeset/nice-corners-notice.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Preserve exec_command startup failures, recover confused process continuations, and add forced per-tool yield times plus project-local custom-tool discovery in Code Mode.
+Preserve exec_command startup failures, recover confused process continuations, and add forced per-tool yield times, project-local custom-tool discovery, isolated definition failures, and more bundled custom-tool examples in Code Mode.

--- a/.changeset/nice-corners-notice.md
+++ b/.changeset/nice-corners-notice.md
@@ -1,5 +1,6 @@
 ---
 "@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-dynamic-tools": patch
 ---
 
-Preserve exec_command startup failures, recover confused process continuations, and add forced per-tool yield times, project-local custom-tool discovery, isolated definition failures, and more bundled custom-tool examples in Code Mode.
+Preserve exec_command startup failures, recover confused process continuations, and align Code Mode command tools around forced per-tool yield times, project-local discovery, isolated definition failures, and expanded bundled examples.

--- a/.changeset/nice-corners-notice.md
+++ b/.changeset/nice-corners-notice.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-dynamic-tools": patch
 ---
 
-Preserve exec_command startup failures, recover confused process continuations, and align Code Mode command tools around forced per-tool yield times, project-local discovery, named configuration failures, and expanded bundled examples.
+Preserve exec_command startup failures, recover confused process continuations, avoid duplicate nested image rendering, and align Code Mode command tools around forced per-tool yield times, project-local discovery, named configuration failures, and expanded bundled examples.

--- a/.changeset/nice-corners-notice.md
+++ b/.changeset/nice-corners-notice.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-dynamic-tools": patch
 ---
 
-Preserve exec_command startup failures, recover confused process continuations, and align Code Mode command tools around forced per-tool yield times, project-local discovery, isolated definition failures, and expanded bundled examples.
+Preserve exec_command startup failures, recover confused process continuations, and align Code Mode command tools around forced per-tool yield times, project-local discovery, named configuration failures, and expanded bundled examples.

--- a/.changeset/nice-corners-notice.md
+++ b/.changeset/nice-corners-notice.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Preserve exec_command startup failures, recover confused process continuations, and add forced per-tool yield times plus project-local custom-tool discovery in Code Mode.

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -56,7 +56,7 @@ For configured Responses providers, `web__run` uses the active provider's `/resp
 
 Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/` (or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`) and, for trusted project-only tools, `<launch-directory>/.pi/codex-conversion-custom-tools/`. Only the launch directory is checked; project-local definitions override same-named global definitions. Each filename becomes a method on `tools`.
 
-Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Invalid definitions are reported and omitted without disabling other tools. Disabled examples ship under `examples/custom-tools/`.
+Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Invalid definitions with valid tool names remain callable and throw their configuration error; unrepresentable definitions are reported separately without disabling other tools. Disabled examples ship under `examples/custom-tools/`.
 
 ## Settings
 

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -54,7 +54,7 @@ For configured Responses providers, `web__run` uses the active provider's `/resp
 
 ## Code Mode custom tools
 
-Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/` (or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`) and, for project-only tools, `<launch-directory>/.pi/codex-conversion-custom-tools/`. Only the launch directory is checked; project-local definitions override same-named global definitions. Each filename becomes a method on `tools`.
+Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/` (or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`) and, for trusted project-only tools, `<launch-directory>/.pi/codex-conversion-custom-tools/`. Only the launch directory is checked; project-local definitions override same-named global definitions. Each filename becomes a method on `tools`.
 
 Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Invalid definitions are reported and omitted without disabling other tools. Disabled examples ship under `examples/custom-tools/`.
 

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -56,7 +56,7 @@ For configured Responses providers, `web__run` uses the active provider's `/resp
 
 Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/` (or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`) and, for project-only tools, `<launch-directory>/.pi/codex-conversion-custom-tools/`. Only the launch directory is checked; project-local definitions override same-named global definitions. Each filename becomes a method on `tools`.
 
-Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Disabled examples for `port_info`, `semantic_grep`, `spawn_agent`, `vent`, and `workflows_create` ship under `examples/custom-tools/`.
+Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Invalid definitions are reported and omitted without disabling other tools. Disabled examples ship under `examples/custom-tools/`.
 
 ## Settings
 

--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -54,9 +54,9 @@ For configured Responses providers, `web__run` uses the active provider's `/resp
 
 ## Code Mode custom tools
 
-Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/`, or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`. Each filename becomes a method on `tools`.
+Put top-level TOML definitions in `~/.pi/agent/codex-conversion-custom-tools/` (or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/`) and, for project-only tools, `<launch-directory>/.pi/codex-conversion-custom-tools/`. Only the launch directory is checked; project-local definitions override same-named global definitions. Each filename becomes a method on `tools`.
 
-Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Disabled examples for `port_info`, `semantic_grep`, `spawn_agent`, `vent`, and `workflows_create` ship under `examples/custom-tools/`.
+Definitions are deferred by default; set `defer_loading = false` to add one to the prompt. Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool; this private policy overrides the model's `// @exec` value. Disabled examples for `port_info`, `semantic_grep`, `spawn_agent`, `vent`, and `workflows_create` ship under `examples/custom-tools/`.
 
 ## Settings
 

--- a/packages/pi-codex-conversion/examples/custom-tools/herdr-agent/herdr-agent.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/herdr-agent/herdr-agent.mjs
@@ -1,0 +1,1038 @@
+#!/usr/bin/env node
+
+import { createConnection } from "node:net";
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const ACTION_FIELDS = {
+	help: new Set(["action"]),
+	find: new Set(["action", "query", "status", "include_self"]),
+	send: new Set([
+		"action",
+		"target",
+		"text",
+		"queue",
+		// Accepted for live sessions that cached the previous contract. New callers
+		// use queue; prompt/steer are both Pi's context-sensitive submit action.
+		"mode",
+		"wait",
+		"timeout_ms",
+	]),
+	wait: new Set(["action", "target", "timeout_ms"]),
+	read: new Set(["action", "target", "source", "lines"]),
+	answer: new Set(["action", "target", "answers", "wait", "timeout_ms"]),
+};
+const STATUSES = new Set(["blocked", "done", "idle", "unknown", "working"]);
+const TERMINAL_STATUSES = new Set(["done", "idle"]);
+const LEGACY_MODES = new Set(["auto", "prompt", "steer", "follow_up"]);
+const SOURCES = new Set(["latest", "visible", "recent"]);
+const DEFAULT_TIMEOUT_MS = 300_000;
+const MAX_TIMEOUT_MS = 1_800_000;
+const MAX_TEXT_CHARS = 36_000;
+// Pi can accept PTY input before the appended session message becomes readable.
+// Leave enough time for that persistence lag before retrying the submit key.
+const DELIVERY_TIMEOUT_MS = 5_000;
+const STATUS_ORDER = { blocked: 0, working: 1, done: 2, idle: 3, unknown: 4 };
+const AGENT_DIR =
+	process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+
+function isObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanString(value, field) {
+	if (typeof value !== "string" || !value.trim())
+		throw new Error(`${field} must be a non-empty string`);
+	return value.trim();
+}
+
+function optionalBoolean(value, field) {
+	if (value !== undefined && typeof value !== "boolean")
+		throw new Error(`${field} must be a boolean when provided`);
+	return value;
+}
+
+function parseTimeout(value) {
+	if (value === undefined) return DEFAULT_TIMEOUT_MS;
+	if (!Number.isInteger(value) || value < 1 || value > MAX_TIMEOUT_MS)
+		throw new Error(`timeout_ms must be an integer from 1 to ${MAX_TIMEOUT_MS}`);
+	return value;
+}
+
+function parseAnswers(value) {
+	if (!Array.isArray(value)) throw new Error("answers must be an array");
+	return value.map((answer, index) => {
+		if (!isObject(answer)) throw new Error(`answers[${index}] must be an object`);
+		const allowed = new Set(["selections", "other", "comment"]);
+		const unknown = Object.keys(answer).filter((key) => !allowed.has(key));
+		if (unknown.length)
+			throw new Error(`unknown answers[${index}] field(s): ${unknown.join(", ")}`);
+		if (
+			answer.selections !== undefined &&
+			(!Array.isArray(answer.selections) ||
+				answer.selections.some((item) => typeof item !== "string" || !item))
+		)
+			throw new Error(`answers[${index}].selections must be string labels`);
+		for (const field of ["other", "comment"])
+			if (answer[field] !== undefined && typeof answer[field] !== "string")
+				throw new Error(`answers[${index}].${field} must be a string`);
+		return {
+			...(answer.selections ? { selections: answer.selections } : {}),
+			...(answer.other !== undefined ? { other: answer.other } : {}),
+			...(answer.comment !== undefined ? { comment: answer.comment } : {}),
+		};
+	});
+}
+
+export function parseRequest(text) {
+	if (text.trim() === "help") return { action: "help" };
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`input must be \"help\" or valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isObject(value)) throw new Error("input must be a JSON object");
+	if (
+		typeof value.action !== "string" ||
+		!Object.hasOwn(ACTION_FIELDS, value.action)
+	)
+		throw new Error(`action must be one of: ${Object.keys(ACTION_FIELDS).join(", ")}`);
+	const unknown = Object.keys(value).filter(
+		(key) => !ACTION_FIELDS[value.action].has(key),
+	);
+	if (unknown.length)
+		throw new Error(`unknown ${value.action} field(s): ${unknown.join(", ")}`);
+	if (value.action === "help") return { action: "help" };
+
+	if (value.action === "find") {
+		if (value.query !== undefined && typeof value.query !== "string")
+			throw new Error("query must be a string when provided");
+		if (value.status !== undefined && !STATUSES.has(value.status))
+			throw new Error("status is invalid");
+		return {
+			action: "find",
+			...(value.query?.trim() ? { query: value.query.trim() } : {}),
+			...(value.status ? { status: value.status } : {}),
+			include_self: optionalBoolean(value.include_self, "include_self") === true,
+		};
+	}
+
+	const target = cleanString(value.target, "target");
+	if (value.action === "wait")
+		return { action: "wait", target, timeout_ms: parseTimeout(value.timeout_ms) };
+	if (value.action === "read") {
+		const source = value.source ?? "latest";
+		if (!SOURCES.has(source)) throw new Error("source is invalid");
+		const lines = value.lines ?? 40;
+		if (!Number.isInteger(lines) || lines < 1 || lines > 200)
+			throw new Error("lines must be an integer from 1 to 200");
+		return { action: "read", target, source, lines };
+	}
+	if (value.action === "answer")
+		return {
+			action: "answer",
+			target,
+			answers: parseAnswers(value.answers),
+			wait: optionalBoolean(value.wait, "wait") ?? true,
+			timeout_ms: parseTimeout(value.timeout_ms),
+		};
+
+	if (value.mode !== undefined && !LEGACY_MODES.has(value.mode))
+		throw new Error("mode is invalid");
+	if (value.mode !== undefined && value.queue !== undefined)
+		throw new Error("use queue or legacy mode, not both");
+	const queue =
+		optionalBoolean(value.queue, "queue") ?? value.mode === "follow_up";
+	return {
+		action: "send",
+		target,
+		text: cleanString(value.text, "text"),
+		queue,
+		wait: optionalBoolean(value.wait, "wait") ?? true,
+		timeout_ms: parseTimeout(value.timeout_ms),
+	};
+}
+
+class HerdrClient {
+	constructor(socketPath = process.env.HERDR_SOCKET_PATH) {
+		if (!socketPath)
+			throw new Error(
+				"HERDR_SOCKET_PATH is not set; run the calling Pi session inside Herdr",
+			);
+		this.socketPath = socketPath;
+	}
+
+	request(method, params = {}) {
+		return new Promise((resolve, reject) => {
+			const id = `herdr-agent:${crypto.randomUUID()}`;
+			let buffer = "";
+			let settled = false;
+			const socket = createConnection(this.socketPath, () =>
+				socket.write(`${JSON.stringify({ id, method, params })}\n`),
+			);
+			socket.setEncoding("utf8");
+			const timer = setTimeout(
+				() => finish(new Error(`Herdr ${method} timed out`)),
+				10_000,
+			);
+			timer.unref();
+			function finish(error, result) {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				socket.destroy();
+				if (error) reject(error);
+				else resolve(result);
+			}
+			socket.on("error", (error) => finish(error));
+			socket.on("data", (chunk) => {
+				buffer += chunk;
+				if (buffer.length > 16 * 1024 * 1024)
+					return finish(new Error(`Herdr ${method} response is too large`));
+				const newline = buffer.indexOf("\n");
+				if (newline < 0) return;
+				let response;
+				try {
+					response = JSON.parse(buffer.slice(0, newline));
+				} catch (error) {
+					return finish(new Error(`Herdr returned invalid JSON: ${error.message}`));
+				}
+				if (response.error)
+					return finish(
+						new Error(response.error.message || JSON.stringify(response.error)),
+					);
+				if (!("result" in response))
+					return finish(new Error(`Herdr ${method} returned no result`));
+				finish(undefined, response.result);
+			});
+		});
+	}
+}
+
+function optionalString(value) {
+	return typeof value === "string" ? value : undefined;
+}
+
+function parseAskChoice(value) {
+	if (!isObject(value) || typeof value.label !== "string") return undefined;
+	return {
+		label: value.label,
+		...(typeof value.description === "string"
+			? { description: value.description }
+			: {}),
+	};
+}
+
+function parseAskPrompt(value) {
+	if (!isObject(value) || typeof value.title !== "string") return undefined;
+	return {
+		title: value.title,
+		multiple: value.multiple === true,
+		choices: (Array.isArray(value.choices) ? value.choices : [])
+			.map(parseAskChoice)
+			.filter(Boolean),
+		...(typeof value.body === "string" ? { body: value.body } : {}),
+	};
+}
+
+function parseAskCall(part) {
+	if (!isObject(part) || part.type !== "toolCall" || part.name !== "ask")
+		return undefined;
+	if (typeof part.id !== "string" || !isObject(part.arguments)) return undefined;
+	const prompts = (Array.isArray(part.arguments.prompts)
+		? part.arguments.prompts
+		: []
+	)
+		.map(parseAskPrompt)
+		.filter(Boolean);
+	if (!prompts.length) return undefined;
+	return {
+		tool_call_id: part.id,
+		handoff: part.arguments.handoff === true,
+		prompts,
+	};
+}
+
+export function parseSessionLines(lines) {
+	const nodes = new Map();
+	let leaf_id;
+	for (const line of lines) {
+		let entry;
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (!isObject(entry) || typeof entry.id !== "string") continue;
+		const node = {
+			parent_id: typeof entry.parentId === "string" ? entry.parentId : null,
+			asks: [],
+		};
+		const message = entry.message;
+		if (isObject(message) && message.role === "assistant") {
+			const text = [];
+			if (typeof message.content === "string") text.push(message.content);
+			if (Array.isArray(message.content))
+				for (const part of message.content) {
+					if (isObject(part) && part.type === "text" && typeof part.text === "string")
+						text.push(part.text);
+					const ask = parseAskCall(part);
+					if (ask) node.asks.push(ask);
+				}
+			node.assistant_entry = {
+				id: entry.id,
+				...(typeof message.stopReason === "string"
+					? { stop_reason: message.stopReason }
+					: {}),
+			};
+			const joined = text.join("");
+			if (joined)
+				node.assistant = {
+					id: entry.id,
+					text: joined,
+					...(typeof message.stopReason === "string"
+						? { stop_reason: message.stopReason }
+						: {}),
+				};
+		}
+		if (isObject(message) && message.role === "user") {
+			const text = [];
+			if (typeof message.content === "string") text.push(message.content);
+			if (Array.isArray(message.content))
+				for (const part of message.content)
+					if (isObject(part) && part.type === "text" && typeof part.text === "string")
+						text.push(part.text);
+			const joined = text.join("");
+			if (joined) node.user = { id: entry.id, text: joined };
+		}
+		if (
+			isObject(message) &&
+			(message.role === "toolResult" || message.role === "tool")
+		)
+			node.resolved_tool_call_id = optionalString(
+				message.toolCallId ?? message.tool_call_id,
+			);
+		nodes.set(entry.id, node);
+		leaf_id = entry.id;
+	}
+
+	let current = leaf_id;
+	let assistant;
+	let assistant_entry;
+	let user;
+	let ask;
+	const resolved = new Set();
+	const visited = new Set();
+	while (current && !visited.has(current)) {
+		visited.add(current);
+		const node = nodes.get(current);
+		if (!node) break;
+		if (node.resolved_tool_call_id) resolved.add(node.resolved_tool_call_id);
+		if (!ask)
+			ask = [...node.asks]
+				.reverse()
+				.find((candidate) => !resolved.has(candidate.tool_call_id));
+		assistant ??= node.assistant;
+		assistant_entry ??= node.assistant_entry;
+		user ??= node.user;
+		current = node.parent_id;
+	}
+	return {
+		leaf_id,
+		assistant,
+		assistant_entry,
+		user,
+		ask,
+	};
+}
+
+class SessionReader {
+	cache = new Map();
+
+	async read(path) {
+		if (!path) return { leaf_id: undefined };
+		let metadata;
+		try {
+			metadata = await stat(path);
+		} catch (error) {
+			if (error?.code === "ENOENT") return { leaf_id: undefined, path };
+			throw error;
+		}
+		const prior = this.cache.get(path);
+		if (prior?.size === metadata.size && prior?.mtime_ms === metadata.mtimeMs)
+			return prior.view;
+		const text = await readFile(path, "utf8");
+		const view = {
+			...parseSessionLines(text.split("\n")),
+			path,
+			size: metadata.size,
+			mtime_ms: metadata.mtimeMs,
+		};
+		this.cache.set(path, {
+			size: metadata.size,
+			mtime_ms: metadata.mtimeMs,
+			view,
+		});
+		return view;
+	}
+}
+
+async function getAgent(client, target) {
+	return (await client.request("agent.get", { target })).agent;
+}
+
+async function getSnapshot(client) {
+	return (await client.request("session.snapshot", {})).snapshot;
+}
+
+function enrichPanels(snapshot) {
+	const tabs = new Map(snapshot.tabs.map((tab) => [tab.tab_id, tab.label]));
+	const workspaces = new Map(
+		snapshot.workspaces.map((workspace) => [workspace.workspace_id, workspace.label]),
+	);
+	return (snapshot.agents.length ? snapshot.agents : snapshot.panes).map(
+		(panel) => ({
+			...panel,
+			tab_label: tabs.get(panel.tab_id),
+			workspace_label: workspaces.get(panel.workspace_id),
+		}),
+	);
+}
+
+function panelHaystack(panel) {
+	return [
+		panel.pane_id,
+		panel.terminal_id,
+		panel.name,
+		panel.cwd,
+		panel.foreground_cwd,
+		panel.tab_label,
+		panel.workspace_label,
+	]
+		.filter(Boolean)
+		.join("\n")
+		.toLowerCase();
+}
+
+async function findPanels(client, request) {
+	const query = request.query?.toLowerCase();
+	return enrichPanels(await getSnapshot(client))
+		.filter((panel) => panel.agent === "pi")
+		.filter(
+			(panel) => request.include_self || panel.pane_id !== process.env.HERDR_PANE_ID,
+		)
+		.filter((panel) => !request.status || panel.agent_status === request.status)
+		.filter((panel) => !query || panelHaystack(panel).includes(query))
+		.sort(
+			(a, b) =>
+				STATUS_ORDER[a.agent_status] - STATUS_ORDER[b.agent_status] ||
+				a.pane_id.localeCompare(b.pane_id),
+		);
+}
+
+function compactPanel(panel) {
+	return {
+		id: panel.pane_id,
+		status: panel.agent_status,
+		cwd: panel.foreground_cwd,
+		...(panel.name || panel.tab_label || panel.workspace_label
+			? { label: panel.name || panel.tab_label || panel.workspace_label }
+			: {}),
+	};
+}
+
+async function resolvePanel(client, target) {
+	let directError;
+	try {
+		const direct = await getAgent(client, target);
+		if (direct.agent === "pi") return direct;
+		directError = new Error(`${target} is not a Pi panel`);
+	} catch (error) {
+		directError = error;
+	}
+	const matches = await findPanels(client, {
+		action: "find",
+		query: target,
+		include_self: true,
+	});
+	if (matches.length === 1) return matches[0];
+	if (matches.length > 1)
+		throw new Error(
+			`ambiguous target ${JSON.stringify(target)}; candidates: ${matches
+				.slice(0, 10)
+				.map((panel) => panel.pane_id)
+				.join(", ")}`,
+		);
+	throw directError instanceof Error
+		? directError
+		: new Error(`no Pi panel matches ${JSON.stringify(target)}`);
+}
+
+function assertRemote(panel) {
+	if (panel.pane_id === process.env.HERDR_PANE_ID)
+		throw new Error("refusing to target the calling Pi panel from its own tool call");
+}
+
+function sessionPath(panel) {
+	return panel.agent_session?.kind === "path"
+		? panel.agent_session.value
+		: undefined;
+}
+
+async function terminalRead(client, target, source = "visible", lines = 40) {
+	return (
+		await client.request("agent.read", {
+			target,
+			source,
+			format: "text",
+			lines,
+			strip_ansi: true,
+		})
+	).read.text;
+}
+
+export function isBusyScreen(text) {
+	const tail = text.split("\n").slice(-18).join("\n");
+	return /Auto-compacting\.\.\.|Queued message for after compaction|(?:^|\s)Working\.\.\.|Retrying(?:\s|…|\.\.\.)/m.test(
+		tail,
+	);
+}
+
+async function isBusy(client, panel) {
+	if (panel.agent_status === "working") return true;
+	if (!TERMINAL_STATUSES.has(panel.agent_status)) return false;
+	return isBusyScreen(await terminalRead(client, panel.pane_id, "visible", 30));
+}
+
+function sleep(milliseconds) {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function boundText(text) {
+	if (text.length <= MAX_TEXT_CHARS) return { text };
+	return { text: `${text.slice(0, MAX_TEXT_CHARS)}\n…`, truncated: true };
+}
+
+function askOutput(ask) {
+	if (!ask) return undefined;
+	return {
+		handoff: ask.handoff,
+		prompts: ask.prompts.map((prompt) => ({
+			title: prompt.title,
+			multiple: prompt.multiple,
+			choices: prompt.choices.map((choice) => choice.label),
+			...(prompt.body ? { body: prompt.body } : {}),
+		})),
+	};
+}
+
+export function herdrHelp() {
+	return {
+		call: "await tools.herdr_agent(JSON.stringify(request))",
+		actions: {
+			find: {
+				request: {
+					action: "find",
+					query: "string?",
+					status: "idle | working | blocked | done?",
+					include_self: "boolean?",
+				},
+				returns: "compact matching Pi panels",
+			},
+			send: {
+				request: {
+					action: "send",
+					target: "string",
+					text: "string",
+					queue: "boolean? (default false)",
+					wait: "boolean? (default true)",
+					timeout_ms: "integer? (default 300000)",
+				},
+				returns: "new assistant text, blocked ask, timeout, or acknowledgement",
+			},
+			wait: {
+				request: { action: "wait", target: "string", timeout_ms: "integer?" },
+				returns: "settled latest assistant text or blocked ask",
+			},
+			read: {
+				request: {
+					action: "read",
+					target: "string",
+					source: "latest | visible | recent? (default latest)",
+					lines: "1..200?",
+				},
+				returns: "latest assistant text or bounded terminal output",
+			},
+			answer: {
+				request: {
+					action: "answer",
+					target: "string",
+					answers: "Array<{ selections?: string[], other?: string, comment?: string }>",
+					wait: "boolean? (default true)",
+					timeout_ms: "integer?",
+				},
+				returns: "next assistant text, next ask, or completion",
+			},
+		},
+		advanced: {
+			load: 'await tools.more_skills("herdr")',
+			covers: [
+				"workspace/tab/pane lifecycle",
+				"generic command panes",
+				"raw terminal input",
+				"output and agent-status waits",
+			],
+		},
+	};
+}
+
+function stableKey(panel, view) {
+	return [
+		panel.agent_status,
+		view.path,
+		view.size,
+		view.mtime_ms,
+		view.leaf_id,
+		view.assistant_entry?.id,
+	].join(":");
+}
+
+async function waitForPanel(client, reader, paneId, baseline, timeoutMs, options = {}) {
+	const deadline = Date.now() + timeoutMs;
+	let latestPanel = await getAgent(client, paneId);
+	let latestView = await reader.read(sessionPath(latestPanel));
+	let candidate;
+	let candidateSince = 0;
+	while (Date.now() < deadline) {
+		latestPanel = await getAgent(client, paneId);
+		latestView = await reader.read(sessionPath(latestPanel));
+		if (latestPanel.agent_status === "blocked") {
+			const priorAskStillClearing =
+				options.ignore_blocked_ask_id &&
+				latestView.ask?.tool_call_id === options.ignore_blocked_ask_id;
+			if (
+				!(options.ignore_blocked_without_ask && !latestView.ask) &&
+				!priorAskStillClearing
+			)
+				return {
+					pane: paneId,
+					status: "blocked",
+					...(askOutput(latestView.ask)
+						? { ask: askOutput(latestView.ask) }
+						: {}),
+				};
+			await sleep(100);
+			continue;
+		}
+		const terminal = TERMINAL_STATUSES.has(latestPanel.agent_status);
+		const busy = terminal ? await isBusy(client, latestPanel) : false;
+		const sessionChanged = baseline.path !== latestView.path;
+		const assistantChanged =
+			sessionChanged ||
+			latestView.assistant_entry?.id !== baseline.assistant_entry_id;
+		const branchAdvanced =
+			sessionChanged || latestView.leaf_id !== baseline.leaf_id;
+		const qualifies =
+			!baseline.require_new ||
+			assistantChanged ||
+			(options.allow_branch_advance && branchAdvanced);
+		if (terminal && !busy && qualifies) {
+			const key = stableKey(latestPanel, latestView);
+			if (candidate === key && Date.now() - candidateSince >= 500) {
+				if (
+					assistantChanged &&
+					latestView.assistant_entry?.stop_reason === "error"
+				)
+					throw new Error(
+						latestView.assistant?.text || `${paneId} assistant stopped with an error`,
+					);
+				const newReply =
+					latestView.assistant?.id !== baseline.reply_id
+						? latestView.assistant
+						: undefined;
+				return {
+					pane: paneId,
+					status: latestPanel.agent_status,
+					...(newReply ? boundText(newReply.text) : { completed: true }),
+					...(sessionChanged ? { session_changed: true } : {}),
+				};
+			}
+			if (candidate !== key) {
+				candidate = key;
+				candidateSince = Date.now();
+			}
+		} else {
+			candidate = undefined;
+			candidateSince = 0;
+		}
+		await sleep(250);
+	}
+	return {
+		pane: paneId,
+		status: latestPanel.agent_status,
+		timed_out: true,
+	};
+}
+
+async function readKeybindings() {
+	try {
+		const value = JSON.parse(await readFile(join(AGENT_DIR, "keybindings.json"), "utf8"));
+		return isObject(value) ? value : {};
+	} catch {
+		return {};
+	}
+}
+
+function keyFor(bindings, action, fallback) {
+	const configured = bindings[action];
+	if (typeof configured === "string" && configured) return configured;
+	if (Array.isArray(configured)) {
+		const first = configured.find((key) => typeof key === "string" && key);
+		if (first) return first;
+		if (configured.length === 0)
+			throw new Error(`${action} has no configured keybinding`);
+	}
+	return fallback;
+}
+
+export function resolveSendDisposition({ busy, queue }) {
+	if (busy && queue)
+		return { keybinding: "app.message.followUp", fallback: "alt+enter", mode: "follow_up" };
+	return {
+		keybinding: "tui.input.submit",
+		fallback: "enter",
+		mode: busy ? "steer" : "prompt",
+	};
+}
+
+async function sendInput(client, paneId, input) {
+	await client.request("pane.send_input", {
+		pane_id: paneId,
+		...(input.text !== undefined ? { text: input.text } : {}),
+		...(input.keys ? { keys: input.keys } : {}),
+	});
+}
+
+function normalizeDeliveryText(value) {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+export function detectDelivery(baseline, view, screen, text) {
+	if (
+		view.user?.id !== baseline.user?.id &&
+		view.user?.text === text
+	)
+		return "delivered";
+	const normalizedScreen = normalizeDeliveryText(screen);
+	const prefix = normalizeDeliveryText(text).slice(0, 80);
+	if (prefix && normalizedScreen.includes(`Follow-up: ${prefix}`))
+		return "queued_follow_up";
+	if (prefix && normalizedScreen.includes(`Steering: ${prefix}`))
+		return "queued_steer";
+	return undefined;
+}
+
+async function waitForDelivery(client, reader, paneId, baseline, text) {
+	const deadline = Date.now() + DELIVERY_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const panel = await getAgent(client, paneId);
+		const [view, screen] = await Promise.all([
+			reader.read(sessionPath(panel)),
+			terminalRead(client, paneId, "visible", 50),
+		]);
+		const delivery = detectDelivery(baseline, view, screen, text);
+		if (delivery) return delivery;
+		await sleep(50);
+	}
+	return undefined;
+}
+
+function down(count, key) {
+	return Array.from({ length: Math.max(0, count) }, () => key);
+}
+
+export function planAskAnswer(prompts, answers, controls = {}) {
+	if (answers.length !== prompts.length)
+		throw new Error(
+			`answer requires ${prompts.length} response${prompts.length === 1 ? "" : "s"}, in prompt order`,
+		);
+	const keys = {
+		down: controls.down || "down",
+		confirm: controls.confirm || "enter",
+		next: controls.next || "tab",
+	};
+	const steps = [];
+	for (const [promptIndex, prompt] of prompts.entries()) {
+		const answer = answers[promptIndex];
+		const labels = answer.selections ?? [];
+		const indexes = labels.map((label) => {
+			const index = prompt.choices.findIndex((choice) => choice.label === label);
+			if (index < 0)
+				throw new Error(
+					`unknown choice ${JSON.stringify(label)} for ${JSON.stringify(prompt.title)}`,
+				);
+			return index;
+		});
+		if (new Set(indexes).size !== indexes.length)
+			throw new Error(`duplicate choice for ${JSON.stringify(prompt.title)}`);
+		if (!prompt.multiple && indexes.length > 1)
+			throw new Error(`${JSON.stringify(prompt.title)} accepts one choice`);
+		if (!prompt.multiple && indexes.length && answer.other !== undefined)
+			throw new Error(
+				`${JSON.stringify(prompt.title)} cannot combine a choice with Other/rephrase`,
+			);
+		indexes.sort((a, b) => a - b);
+		let focus = 0;
+		for (const index of indexes) {
+			steps.push({ keys: [...down(index - focus, keys.down), keys.confirm] });
+			focus = index;
+		}
+		const needsOther =
+			answer.other !== undefined ||
+			(indexes.length === 0 && answer.comment !== undefined);
+		if (needsOther) {
+			steps.push({
+				keys: [...down(prompt.choices.length - focus, keys.down), keys.confirm],
+			});
+			steps.push({ text: answer.other ?? "", keys: [keys.confirm] });
+			focus = prompt.choices.length;
+		}
+		if (answer.comment !== undefined) {
+			steps.push({
+				keys: [
+					...down(prompt.choices.length + 1 - focus, keys.down),
+					keys.confirm,
+				],
+			});
+			steps.push({ text: answer.comment, keys: [keys.next] });
+		} else {
+			steps.push({ keys: [keys.next] });
+		}
+	}
+	steps.push({ keys: [keys.confirm], final: true });
+	return steps;
+}
+
+function askFrame(screen) {
+	const lines = screen.split("\n");
+	const review = lines.map((line) => line.includes("Review")).lastIndexOf(true);
+	return (review >= 0 ? lines.slice(review) : lines.slice(-30)).join("\n");
+}
+
+export function inspectAskScreen(screen, ask) {
+	const frame = askFrame(screen);
+	const selected = frame.match(/^>\s+(.*?)\s*$/m)?.[1];
+	const review = /^\s*Review\s*$/m.test(frame) && frame.includes("enter submit");
+	const current_prompt = review
+		? "Review"
+		: ask?.prompts.find((prompt) =>
+				frame.split("\n").some((line) => line.trim() === prompt.title),
+			)?.title;
+	const prompt =
+		frame.includes("Review") &&
+		frame.includes("Other/rephrase") &&
+		frame.includes("Comment (optional)");
+	return { recognized: prompt || review, current_prompt, selected };
+}
+
+async function answerAsk(client, reader, panel, request) {
+	if (panel.agent_status !== "blocked")
+		throw new Error(
+			`${panel.pane_id} is ${panel.agent_status}, not blocked on ask`,
+		);
+	const baseline = await reader.read(sessionPath(panel));
+	if (!baseline.ask)
+		throw new Error(`${panel.pane_id} has no pending pi-ask call on its active branch`);
+	const screen = await terminalRead(client, panel.pane_id, "visible", 80);
+	const inspection = inspectAskScreen(screen, baseline.ask);
+	const first = baseline.ask.prompts[0];
+	const expectedSelection = first?.choices[0]?.label ?? "Other/rephrase";
+	if (
+		!inspection.recognized ||
+		inspection.current_prompt !== first?.title ||
+		inspection.selected !== expectedSelection
+	)
+		throw new Error(
+			"ask UI is not at the first prompt's default selection; refusing to send guessed keys",
+		);
+	const bindings = await readKeybindings();
+	const steps = planAskAnswer(baseline.ask.prompts, request.answers, {
+		down: keyFor(bindings, "tui.select.down", "down"),
+		confirm: keyFor(bindings, "tui.select.confirm", "enter"),
+		next: keyFor(bindings, "tui.input.tab", "tab"),
+	});
+	for (const step of steps) {
+		await sendInput(client, panel.pane_id, step);
+		await sleep(35);
+		if (!step.final) {
+			const current = await getAgent(client, panel.pane_id);
+			if (current.agent_status !== "blocked")
+				throw new Error("ask closed before all requested answers were entered");
+			const currentScreen = await terminalRead(
+				client,
+				panel.pane_id,
+				"visible",
+				80,
+			);
+			if (!inspectAskScreen(currentScreen, baseline.ask).recognized)
+				throw new Error("ask UI became unrecognized; stopped without retrying input");
+		}
+	}
+	if (!request.wait)
+		return { pane: panel.pane_id, answered: true };
+	return waitForPanel(
+		client,
+		reader,
+		panel.pane_id,
+		{
+			path: baseline.path,
+			leaf_id: baseline.leaf_id,
+			assistant_entry_id: baseline.assistant_entry?.id,
+			reply_id: baseline.assistant?.id,
+			require_new: true,
+		},
+		request.timeout_ms,
+		{
+			allow_branch_advance: true,
+			ignore_blocked_without_ask: true,
+			ignore_blocked_ask_id: baseline.ask.tool_call_id,
+		},
+	);
+}
+
+async function execute(request) {
+	if (request.action === "help") return herdrHelp();
+	const client = new HerdrClient();
+	const reader = new SessionReader();
+	if (request.action === "find") {
+		const panels = await findPanels(client, request);
+		return { panels: panels.slice(0, 30).map(compactPanel) };
+	}
+	const panel = await resolvePanel(client, request.target);
+	if (request.action === "read") {
+		if (request.source !== "latest") {
+			const output = boundText(
+				await terminalRead(client, panel.pane_id, request.source, request.lines),
+			);
+			return { pane: panel.pane_id, status: panel.agent_status, ...output };
+		}
+		const view = await reader.read(sessionPath(panel));
+		return {
+			pane: panel.pane_id,
+			status: panel.agent_status,
+			...(view.assistant ? boundText(view.assistant.text) : { text: null }),
+			...(panel.agent_status === "blocked" && askOutput(view.ask)
+				? { ask: askOutput(view.ask) }
+				: {}),
+		};
+	}
+	assertRemote(panel);
+	if (request.action === "wait") {
+		const view = await reader.read(sessionPath(panel));
+		return waitForPanel(
+			client,
+			reader,
+			panel.pane_id,
+			{
+				path: view.path,
+				leaf_id: view.leaf_id,
+				assistant_entry_id: view.assistant_entry?.id,
+				reply_id: undefined,
+				require_new: false,
+			},
+			request.timeout_ms,
+		);
+	}
+	if (request.action === "answer")
+		return answerAsk(client, reader, panel, request);
+
+	const baseline = await reader.read(sessionPath(panel));
+	if (panel.agent_status === "blocked")
+		throw new Error(
+			`${panel.pane_id} is blocked${baseline.ask ? " on ask; use action=answer" : ""}`,
+		);
+	const busy = await isBusy(client, panel);
+	const disposition = resolveSendDisposition({ busy, queue: request.queue });
+	const bindings = await readKeybindings();
+	const key = keyFor(
+		bindings,
+		disposition.keybinding,
+		disposition.fallback,
+	);
+	// Paste and submit separately. A combined PTY write can hit Pi's
+	// streaming-to-idle transition before the editor has consumed the paste.
+	await sendInput(client, panel.pane_id, { text: request.text });
+	await sleep(40);
+	await sendInput(client, panel.pane_id, { keys: [key] });
+	let delivery = await waitForDelivery(
+		client,
+		reader,
+		panel.pane_id,
+		baseline,
+		request.text,
+	);
+	if (!delivery) {
+		// Retrying only the submit key is duplicate-safe: if Pi accepted the first
+		// key, its editor is empty; if it missed the key, the pasted text remains.
+		const current = await getAgent(client, panel.pane_id);
+		const retryDisposition = resolveSendDisposition({
+			busy: await isBusy(client, current),
+			queue: request.queue,
+		});
+		const retryKey = keyFor(
+			bindings,
+			retryDisposition.keybinding,
+			retryDisposition.fallback,
+		);
+		await sendInput(client, panel.pane_id, { keys: [retryKey] });
+		delivery = await waitForDelivery(
+			client,
+			reader,
+			panel.pane_id,
+			baseline,
+			request.text,
+		);
+	}
+	if (!delivery)
+		throw new Error(
+			`${panel.pane_id} did not accept the message; the text may remain in Pi's editor`,
+		);
+	if (!request.wait)
+		return { pane: panel.pane_id, sent: true, mode: disposition.mode, delivery };
+	return waitForPanel(
+		client,
+		reader,
+		panel.pane_id,
+		{
+			path: baseline.path,
+			leaf_id: baseline.leaf_id,
+			assistant_entry_id: baseline.assistant_entry?.id,
+			reply_id: baseline.assistant?.id,
+			require_new: true,
+		},
+		request.timeout_ms,
+	);
+}
+
+async function readStdin() {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	return input;
+}
+
+async function main() {
+	const result = await execute(parseRequest(await readStdin()));
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname)
+	main().catch((error) => {
+		process.stderr.write(
+			`herdr_agent: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
+		process.exitCode = 1;
+	});

--- a/packages/pi-codex-conversion/examples/custom-tools/herdr_agent.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/herdr_agent.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.herdr_agent("help") // Pi-panel messaging; advanced orchestration: await tools.more_skills("herdr")'''
+description = '''Find and coordinate with Pi agents in Herdr panels. send automatically prompts an idle Pi or steers a working Pi; queue=true waits behind current work. It waits by default and returns only the new assistant text. For advanced workspace/tab/pane orchestration, generic command panes, raw terminal input, or output waits, load the extra skill exactly with: await tools.more_skills("herdr")'''
+output = "Compact JSON: pane/status plus only relevant panels, text, ask, acknowledgement, timeout, or truncation fields."
+command = "./herdr-agent/herdr-agent.mjs"
+input = "stdin"
+defer_loading = false

--- a/packages/pi-codex-conversion/examples/custom-tools/more-skills/more-skills.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/more-skills/more-skills.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_OUTPUT_BYTES = 48 * 1024;
+const MAX_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const SKILL_FILENAMES = ["SKILL.md", "SKILL.MD"];
+
+export function defaultSkillsDir() {
+	const scriptPath = fileURLToPath(import.meta.url);
+	const agentDir = dirname(dirname(dirname(scriptPath)));
+	return join(agentDir, "more-skills");
+}
+
+function decodeQuotedScalar(value, path, field) {
+	if (value.startsWith('"')) {
+		try {
+			const parsed = JSON.parse(value);
+			if (typeof parsed !== "string") throw new Error();
+			return parsed;
+		} catch {
+			throw new Error(`${path}: ${field} must be a valid quoted YAML string`);
+		}
+	}
+	if (value.startsWith("'")) {
+		if (!value.endsWith("'") || value.length < 2) {
+			throw new Error(`${path}: ${field} must be a valid quoted YAML string`);
+		}
+		return value.slice(1, -1).replace(/''/g, "'");
+	}
+	return value;
+}
+
+function parseBlockScalar(lines, start, parentIndent, style) {
+	const values = [];
+	let commonIndent;
+	let index = start;
+	for (; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (!line.trim()) {
+			values.push("");
+			continue;
+		}
+		const indent = line.match(/^\s*/)[0].length;
+		if (indent <= parentIndent) break;
+		commonIndent = commonIndent === undefined ? indent : Math.min(commonIndent, indent);
+		values.push(line);
+	}
+	const indent = commonIndent ?? parentIndent + 1;
+	const normalized = values.map((line) => line.slice(Math.min(indent, line.length)));
+	const value = style === ">"
+		? normalized.join("\n").replace(/([^\n])\n(?=[^\n])/g, "$1 ")
+		: normalized.join("\n");
+	return { value: value.trim(), nextIndex: index };
+}
+
+export function parseSkillDocument(content, label) {
+	const normalized = content.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+	const lines = normalized.split("\n");
+	if (lines[0] !== "---") {
+		throw new Error(`${label}: missing YAML frontmatter`);
+	}
+	const end = lines.findIndex((line, index) => index > 0 && (line === "---" || line === "..."));
+	if (end < 0) throw new Error(`${label}: unterminated YAML frontmatter`);
+
+	const fields = {};
+	for (let index = 1; index < end; index += 1) {
+		const line = lines[index];
+		const match = /^(\s*)(name|description):\s*(.*)$/.exec(line);
+		if (!match) continue;
+		const [, whitespace, field, rawValue] = match;
+		const block = /^([>|])[-+]?\s*$/.exec(rawValue);
+		if (block) {
+			const parsed = parseBlockScalar(lines.slice(0, end), index + 1, whitespace.length, block[1]);
+			fields[field] = parsed.value;
+			index = parsed.nextIndex - 1;
+			continue;
+		}
+		fields[field] = decodeQuotedScalar(rawValue.trim(), label, field);
+	}
+	return {
+		frontmatter: fields,
+		body: lines.slice(end + 1).join("\n").trim(),
+	};
+}
+
+function validateSkill(skill) {
+	const errors = [];
+	if (!skill.name) errors.push("name is required");
+	else {
+		if (skill.name === "list") errors.push('name "list" is reserved by the loader');
+		if (skill.name.length > MAX_NAME_LENGTH) errors.push(`name exceeds ${MAX_NAME_LENGTH} characters`);
+		if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(skill.name)) {
+			errors.push("name must contain only lowercase letters, numbers, and single hyphens");
+		}
+	}
+	if (!skill.description?.trim()) errors.push("description is required");
+	else if (skill.description.length > MAX_DESCRIPTION_LENGTH) {
+		errors.push(`description exceeds ${MAX_DESCRIPTION_LENGTH} characters`);
+	}
+	if (!skill.body) errors.push("Markdown body is required");
+	if (errors.length) throw new Error(`${skill.packageName}: ${errors.join("; ")}`);
+}
+
+function skillFileIn(directory, packageName) {
+	const matches = SKILL_FILENAMES.map((name) => join(directory, name)).filter(existsSync);
+	if (matches.length > 1) {
+		throw new Error(`${packageName}: keep only one of SKILL.md or SKILL.MD`);
+	}
+	return matches[0];
+}
+
+function directoryEntries(directory) {
+	return readdirSync(directory, { withFileTypes: true })
+		.sort((a, b) => a.name.localeCompare(b.name))
+		.filter((entry) => !entry.name.startsWith("."));
+}
+
+function isDirectoryEntry(entry, path) {
+	if (entry.isDirectory()) return true;
+	if (!entry.isSymbolicLink()) return false;
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function loadSkill(directory, packageName, category) {
+	const path = skillFileIn(directory, packageName);
+	if (!path) return undefined;
+	const content = readFileSync(path, "utf8");
+	const document = parseSkillDocument(content, packageName);
+	const skill = {
+		name: document.frontmatter.name || packageName.split("/").at(-1),
+		description: document.frontmatter.description,
+		packageName,
+		category,
+		body: document.body,
+	};
+	validateSkill(skill);
+	return skill;
+}
+
+export function discoverSkills(root = defaultSkillsDir()) {
+	if (!existsSync(root)) return [];
+	const skills = [];
+	for (const entry of directoryEntries(root)) {
+		const directory = join(root, entry.name);
+		if (!isDirectoryEntry(entry, directory)) continue;
+
+		const directSkill = loadSkill(directory, entry.name, "other");
+		if (directSkill) {
+			skills.push(directSkill);
+			continue;
+		}
+
+		if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry.name)) {
+			throw new Error(`${entry.name}: category names must contain only lowercase letters, numbers, and single hyphens`);
+		}
+		for (const child of directoryEntries(directory)) {
+			const childDirectory = join(directory, child.name);
+			if (!isDirectoryEntry(child, childDirectory)) continue;
+			const skill = loadSkill(childDirectory, `${entry.name}/${child.name}`, entry.name);
+			if (skill) skills.push(skill);
+		}
+	}
+
+	const names = new Map();
+	for (const skill of skills) {
+		const existing = names.get(skill.name);
+		if (existing) throw new Error(`Duplicate additional skill name "${skill.name}" in packages ${existing} and ${skill.packageName}`);
+		names.set(skill.name, skill.packageName);
+	}
+	return skills.sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
+}
+
+export function formatSkillList(skills) {
+	if (!skills.length) {
+		return "No additional skills available.";
+	}
+	const groups = new Map();
+	for (const skill of skills) {
+		const group = groups.get(skill.category) ?? [];
+		group.push(skill);
+		groups.set(skill.category, group);
+	}
+	const categories = [...groups].sort(([left], [right]) => {
+		if (left === "other") return 1;
+		if (right === "other") return -1;
+		return left.localeCompare(right);
+	});
+	const lines = [];
+	for (const [category, categorySkills] of categories) {
+		lines.push(`# ${category.replace(/-/g, " ").toUpperCase()}`);
+		for (const skill of categorySkills) {
+			lines.push(`- ${skill.name}: ${skill.description.replace(/\s+/g, " ").trim()}`);
+		}
+	}
+	const output = lines.join("\n");
+	const bytes = Buffer.byteLength(output);
+	if (bytes > MAX_OUTPUT_BYTES) {
+		throw new Error(`Additional skill catalog is ${bytes} bytes; shorten descriptions to keep it under ${MAX_OUTPUT_BYTES} bytes`);
+	}
+	return output;
+}
+
+export function run(argument, root = defaultSkillsDir()) {
+	if (typeof argument !== "string" || !argument) {
+		throw new Error('Expected "list" or an exact skill name.');
+	}
+	const skills = discoverSkills(root);
+	if (argument === "list") return formatSkillList(skills);
+	const skill = skills.find((candidate) => candidate.name === argument);
+	if (!skill) {
+		const available = skills.map(({ name }) => name).join(", ") || "none";
+		throw new Error(`Unknown additional skill "${argument}". Available names: ${available}. Call with "list" to inspect descriptions.`);
+	}
+	const bytes = Buffer.byteLength(skill.body);
+	if (bytes > MAX_OUTPUT_BYTES) {
+		throw new Error(`Skill "${skill.name}" is ${bytes} bytes; maximum loadable size is ${MAX_OUTPUT_BYTES} bytes`);
+	}
+	return skill.body;
+}
+
+function isMainModule() {
+	return process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+}
+
+if (isMainModule()) {
+	try {
+		process.stdout.write(run(process.argv[2]));
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	}
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/more_skills.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/more_skills.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.more_skills("list" | "<exact-skill-name>") // extra categories: design, engineering, media, operations, writing; list when core skills do not fit, then load an exact match'''
+description = "Lists additional skill names and descriptions, or returns one skill's Markdown body by exact name."
+output = "A concise skill list or the selected skill's Markdown instructions."
+command = "./more-skills/more-skills.mjs"
+input = "arg"
+defer_loading = false

--- a/packages/pi-codex-conversion/examples/custom-tools/semantic_grep.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/semantic_grep.toml
@@ -1,4 +1,4 @@
-usage = '''await tools.semantic_grep(JSON.stringify({ query: string, top_k?: number })) // conceptual or cross-file discovery; use exact grep for literals'''
+usage = '''await tools.semantic_grep(JSON.stringify({ query: string, top_k?: number })) // query with terse search intent, pseudocode, or half-sentences—not questions; use exact grep for literals'''
 description = "Searches the current repository's existing semantic-grep index and returns ranked paths, line ranges, scores, and snippets."
 command = "./semantic-grep/semantic-grep.mjs"
 input = "stdin"

--- a/packages/pi-codex-conversion/examples/custom-tools/sites.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites.toml
@@ -1,0 +1,7 @@
+usage = '''await tools.sites(JSON.stringify({ resource: string, action: string, params?: object }))'''
+description = "Manage ChatGPT Sites through a curated facade. Read sites_documentation before first use."
+command = "./sites/sites.mjs"
+args = ["call"]
+input = "stdin"
+defer_loading = true
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites.toml
@@ -4,4 +4,3 @@ command = "./sites/sites.mjs"
 args = ["call"]
 input = "stdin"
 defer_loading = true
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/auth.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/auth.mjs
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export async function getSitesAuth() {
+  const authPath = process.env.PI_AUTH_FILE || join(
+    process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent"),
+    "auth.json",
+  );
+  let credential;
+  try {
+    const stored = JSON.parse(await readFile(authPath, "utf8"));
+    credential = stored?.["openai-codex"];
+  } catch (error) {
+    throw new Error(`Could not read Pi authentication from ${authPath}: ${error.message}`);
+  }
+  if (typeof credential?.access !== "string" || !credential.access) {
+    throw new Error("OpenAI Codex OAuth is not configured in Pi");
+  }
+  if (Number.isFinite(credential.expires) && credential.expires <= Date.now()) {
+    throw new Error("Pi's OpenAI Codex OAuth token is expired; run a Codex prompt in Pi to refresh it, then retry");
+  }
+
+  const accountId = credential.accountId || accountIdFromJwt(credential.access);
+  if (typeof accountId !== "string" || !accountId) {
+    throw new Error("The Pi Codex OAuth token has no ChatGPT account ID");
+  }
+  return { token: credential.access, accountId };
+}
+
+function accountIdFromJwt(token) {
+  try {
+    const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString("utf8"));
+    return payload["https://api.openai.com/auth"]?.chatgpt_account_id;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/client.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/client.mjs
@@ -1,0 +1,174 @@
+import { getSitesAuth } from "./auth.mjs";
+
+const ENDPOINT = "https://chatgpt.com/backend-api/wham/apps";
+const CONNECTOR_ID = "connector_20205bf7d4e99a89d7154bb849718324";
+
+export class SitesClient {
+  constructor({ fetchImpl = fetch, authProvider = getSitesAuth } = {}) {
+    this.fetchImpl = fetchImpl;
+    this.authProvider = authProvider;
+    this.requestId = 0;
+    this.tools = undefined;
+    this.headers = undefined;
+  }
+
+  async initialize() {
+    if (this.headers) return;
+    const { token, accountId } = await this.authProvider();
+    this.headers = {
+      authorization: `Bearer ${token}`,
+      "chatgpt-account-id": accountId,
+      "x-openai-product-sku": "codex",
+      originator: "pi",
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    };
+    const initialized = await this.rpc("initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "pi-sites", version: "0.1.0" },
+    });
+    this.headers["mcp-protocol-version"] = initialized?.protocolVersion ?? "2025-03-26";
+    await this.rpc("notifications/initialized", {}, { notification: true });
+  }
+
+  async listSitesTools() {
+    if (this.tools) return this.tools;
+    await this.initialize();
+    const response = await this.rpc("tools/list", {});
+    const tools = Array.isArray(response?.tools) ? response.tools : [];
+    this.tools = tools.filter((tool) => isSitesTool(tool));
+    if (this.tools.length === 0) {
+      throw new Error("The ChatGPT account did not expose the Sites connector");
+    }
+    return this.tools;
+  }
+
+  async schema(toolSuffix) {
+    const tool = await this.findTool(toolSuffix);
+    return tool.inputSchema;
+  }
+
+  async call(toolSuffix, args) {
+    const tool = await this.findTool(toolSuffix);
+    const response = await this.rpc("tools/call", { name: tool.name, arguments: args });
+    return decodeToolResult(response);
+  }
+
+  async findTool(toolSuffix) {
+    const expected = `sites_${toolSuffix}`.toLowerCase();
+    const tools = await this.listSitesTools();
+    const tool = tools.find((candidate) => {
+      const names = [candidate.name, candidate._meta?.resource_name]
+        .filter((value) => typeof value === "string")
+        .map(normalizeToolName);
+      return names.includes(expected);
+    });
+    if (!tool) throw new Error(`Sites backend no longer exposes ${toolSuffix}`);
+    return tool;
+  }
+
+  async rpc(method, params, { notification = false } = {}) {
+    const payload = { jsonrpc: "2.0", method, params };
+    if (!notification) payload.id = ++this.requestId;
+    const response = await this.fetchImpl(ENDPOINT, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(45_000),
+    });
+    const sessionId = response.headers.get("mcp-session-id");
+    if (sessionId) this.headers["mcp-session-id"] = sessionId;
+    const body = await readCappedBody(response);
+    if (notification && response.ok && !body) return undefined;
+    const result = parseRpcBody(body, response.headers.get("content-type"));
+    if (!response.ok || result?.error) {
+      throw backendError(response.status, result?.error ?? result ?? body);
+    }
+    return result?.result;
+  }
+}
+
+function isSitesTool(tool) {
+  return tool?._meta?.connector_id === CONNECTOR_ID;
+}
+
+function normalizeToolName(name) {
+  return name.toLowerCase().replaceAll(".", "_");
+}
+
+function parseRpcBody(body, contentType = "") {
+  if (contentType?.includes("text/event-stream")) {
+    const messages = body
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .filter((line) => line && line !== "[DONE]");
+    if (messages.length === 0) throw new Error("Sites backend returned an empty event stream");
+    return JSON.parse(messages.at(-1));
+  }
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error("Sites backend returned a non-JSON response");
+  }
+}
+
+async function readCappedBody(response, maxBytes = 4 * 1024 * 1024) {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error("Sites backend response exceeded the 4 MiB safety limit");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8");
+}
+
+function decodeToolResult(result) {
+  if (result?.isError) throw backendError(200, result);
+  if (result?.structuredContent !== undefined) return result.structuredContent;
+  const texts = Array.isArray(result?.content)
+    ? result.content.filter((item) => item?.type === "text").map((item) => item.text)
+    : [];
+  if (texts.length === 1) {
+    try {
+      return JSON.parse(texts[0]);
+    } catch {
+      return { message: texts[0] };
+    }
+  }
+  return texts.length > 0 ? { messages: texts } : result;
+}
+
+function backendError(status, payload) {
+  const serialized = safeStringify(payload);
+  const terms = serialized.match(/sites_publication_terms_required:\s*(https?:\/\/[^\s"}]+)/i);
+  const message = terms
+    ? "ChatGPT Sites publication terms must be accepted before this operation can continue"
+    : `Sites backend request failed${status ? ` (HTTP ${status})` : ""}`;
+  return Object.assign(new Error(message), {
+    code: terms ? "terms_required" : "backend_error",
+    status,
+    termsUrl: terms?.[1],
+  });
+}
+
+function safeStringify(value) {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/access.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/access.md
@@ -1,0 +1,21 @@
+# Access operations
+
+Hosting does not automatically make a Site public. New Sites normally begin with owner/admin-only access, subject to workspace policy.
+
+## `access.get`
+
+Returns only the Site ID, title, live URL, access mode, access policy, and currently available modes. This intentionally omits unrelated Site fields.
+
+## `access.update`
+
+Change access only when the user asks. Pi custom tools have no trusted approval callback, so calling this action applies the change immediately.
+
+Backend modes can include:
+
+- `public`: anyone with the URL;
+- `workspace_all`: active users in the workspace;
+- `custom`: supplied user and group allowlists.
+
+For `custom`, omitted allowlists preserve existing values; empty lists clear non-owner entries. IDs and eligible modes depend on workspace policy. Never invent group IDs. The owner remains allowed.
+
+Before widening access, review the deployed content, data handling, forms, uploads, links, and sign-in behavior. Public publishing may be disabled by an admin.

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/analytics.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/analytics.md
@@ -1,0 +1,18 @@
+# Analytics operations
+
+Analytics queries require a Site project and an explicit millisecond time range. Keep ranges bounded and paginate or narrow queries instead of requesting unbounded output.
+
+## `analytics.overview`
+
+Get aggregate Site analytics between `start_time_ms` and `end_time_ms`. Optional `granularity` values are defined by the current backend schema.
+
+## `analytics.events`
+
+List event names observed in the requested time range. Use this before querying an unfamiliar event.
+
+## `analytics.query`
+
+Query one exact `event_name` over a bounded time range. Event names and IDs are opaque backend values; do not invent or normalize them.
+
+Analytics can contain operational or visitor-derived information. Return only what the task needs and avoid copying large event payloads into model context.
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/analytics.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/analytics.md
@@ -15,4 +15,3 @@ List event names observed in the requested time range. Use this before querying 
 Query one exact `event_name` over a bounded time range. Event names and IDs are opaque backend values; do not invent or normalize them.
 
 Analytics can contain operational or visitor-derived information. Return only what the task needs and avoid copying large event payloads into model context.
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/deployment.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/deployment.md
@@ -1,0 +1,29 @@
+# Deployment operations
+
+Every Sites deployment URL is production. Deploy only a saved `version_id` after the intended audience and content have been reviewed.
+
+## `deployment.deploy`
+
+Required facade parameters: `project_id` (or local manifest), `version_id`, and `visibility`.
+
+- `visibility: "private"` uses the owner-only deployment path. The backend refuses it unless the caller is the sole explicitly allowed viewer and no groups are allowed.
+- `visibility: "shared"` is an open-world production deployment for shared, workspace, public, or unverifiable access.
+
+Pi has no trusted approval callback for custom tools. Calling this action is the production effect; the agent must obtain user approval before calling it. Shared deployment warrants an explicit audience warning.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "deployment",
+  action: "deploy",
+  params: {
+    version_id: "<opaque-version-id>",
+    visibility: "private"
+  }
+}))
+```
+
+If private deployment is rejected because access is not owner-only, do not silently fall back. Ask the user before making a shared deployment.
+
+## `deployment.status`
+
+Pass the exact `project_id`, `version_id`, and deployment `id` returned by deploy as `deployment_id`. Poll only while status is `pending`, `building`, or `publishing`, or when the user asks for progress.

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/domains.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/domains.md
@@ -1,0 +1,19 @@
+# Custom-domain operations
+
+Use resource name `domain` in calls. Sites does not register domains; the user must own the hostname and control its DNS. Availability depends on plan and workspace policy.
+
+## Actions
+
+- `domain.list`: list current custom domains for a Site.
+- `domain.add`: add a hostname and return required DNS records.
+- `domain.refresh`: recheck DNS using the exact `custom_domain_id`.
+- `domain.remove`: immediately detach the exact custom domain. Pi custom tools have no separate approval callback.
+
+Typical flow:
+
+1. Add the apex domain or subdomain.
+2. Show the returned DNS names, record types, and values to the user.
+3. Wait for the user to update DNS at their provider.
+4. Refresh status after propagation.
+
+Do not claim that DNS was changed merely because the domain was added in Sites. Never remove or replace a domain to solve a transient propagation delay.

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/environment.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/environment.md
@@ -1,0 +1,31 @@
+# Runtime environment operations
+
+Sites runtime values are separate from local `.env` files and `.openai/hosting.json`.
+
+## `environment.get`
+
+Get configured production runtime entries and their revision. The facade recursively redacts secret values even if the backend returns one unexpectedly.
+
+## `environment.update`
+
+Pass `set_values` and optional `remove`:
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "environment",
+  action: "update",
+  params: {
+    set_values: [
+      { key: "API_ORIGIN", value: "https://example.test", is_secret: false },
+      { key: "SERVICE_TOKEN", value: "<secret>", is_secret: true }
+    ],
+    remove: []
+  }
+}))
+```
+
+Keys are case-sensitive. Do not repeat a key or put it in both lists. Only listed keys change. Mark sensitive values with `is_secret: true` and do not echo them in prose or logs. The tool deliberately cannot read values from arbitrary environment variables or files. For secrets that should never enter model context, use the Sites settings UI instead.
+
+Calling this action changes production runtime configuration immediately; Pi custom tools have no separate approval callback.
+
+Environment changes do not alter an existing deployment. Redeploy an approved saved version when the new revision should become active.

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/index.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/index.md
@@ -32,4 +32,3 @@ await tools.sites(JSON.stringify({
 `project_id` is read from `<project>/.openai/hosting.json` when omitted. Pass `project_dir` when Pi's current directory is not the Site project.
 
 The tool never returns OAuth tokens, source-repository credentials, secret environment values, or SIWC bypass tokens. Unknown operations return one documentation pointer instead of the full catalog.
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/index.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/index.md
@@ -1,0 +1,35 @@
+# ChatGPT Sites custom tool
+
+This is an exploratory, private-API bridge from Pi to ChatGPT Sites. The backend is in public beta and may change. Use the facade rather than guessing remote MCP names.
+
+## First use
+
+1. Read `sites_documentation("workflow")`.
+2. Read the resource topic you need.
+3. For exact parameters, read `sites_documentation("resource.action")`.
+4. Call `sites` with one resource, action, and `params` object.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "site",
+  action: "list",
+  params: { limit: 10 }
+}))
+```
+
+## Topics and resources
+
+| Topic | Actions |
+|---|---|
+| `site` | `list`, `get`, `create`, `update` |
+| `version` | `list`, `get`, `save` |
+| `deployment` | `deploy`, `status` |
+| `access` | `get`, `update` |
+| `environment` | `get`, `update` |
+| `domains` | resource `domain`: `list`, `add`, `refresh`, `remove` |
+| `analytics` | `overview`, `events`, `query` |
+
+`project_id` is read from `<project>/.openai/hosting.json` when omitted. Pass `project_dir` when Pi's current directory is not the Site project.
+
+The tool never returns OAuth tokens, source-repository credentials, secret environment values, or SIWC bypass tokens. Unknown operations return one documentation pointer instead of the full catalog.
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/site.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/site.md
@@ -29,4 +29,3 @@ await tools.sites(JSON.stringify({
   params: { project_dir: "/absolute/project/path" }
 }))
 ```
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/site.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/site.md
@@ -1,0 +1,32 @@
+# Site operations
+
+## `site.list`
+
+List accessible Sites. `limit` defaults to 20; use the returned cursor for another page.
+
+## `site.get`
+
+Get metadata, current URLs, version state, and access configuration for one opaque `project_id`.
+
+## `site.create`
+
+Create only when the local `.openai/hosting.json` has no `project_id`.
+
+Required facade parameters: `title`, `slug`. Optional: `description`, `project_dir`.
+
+The slug must start with a lowercase ASCII letter, be at least five characters, and contain only lowercase letters, digits, and single hyphens. The facade persists the new project ID atomically. It removes the short-lived source credential from model-visible output.
+
+## `site.update`
+
+Update user-facing metadata. The current backend supports `title`; inspect `sites_documentation("site.update")` before calling.
+
+Examples:
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "site",
+  action: "get",
+  params: { project_dir: "/absolute/project/path" }
+}))
+```
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/version.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/version.md
@@ -1,0 +1,33 @@
+# Version operations
+
+A saved version is a reviewable deployment candidate. Saving is not deployment.
+
+## `version.list`
+
+List saved versions for a Site. Use `limit` and `cursor` for pagination.
+
+## `version.get`
+
+Inspect one opaque `version_id` within its `project_id`.
+
+## `version.save`
+
+Run only after local validation and review. The facade:
+
+1. finds the Git project from `project_dir` or the current directory;
+2. requires a committed `.openai/hosting.json` bound to the Site;
+3. requires a clean worktree, including no untracked files;
+4. derives the exact HEAD commit SHA;
+5. obtains a short-lived Sites repository credential;
+6. pushes HEAD to the backend-selected source branch without exposing the token or running repository hooks;
+7. saves that exact commit and returns the opaque `version_id` and user-facing version number.
+
+Do not pass `commit_sha` or `archive`; the facade rejects both. It currently supports repository-backed saves, not uploaded build archives.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "version",
+  action: "save",
+  params: { project_dir: "/absolute/project/path" }
+}))
+```

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/workflow.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/workflow.md
@@ -1,0 +1,25 @@
+# Sites workflow
+
+Sites publishing has two separate stages: save a version, then deploy that saved version. Every deployment URL is production.
+
+## Existing local project
+
+1. Confirm the project can produce a Sites-compatible build and validate it locally.
+2. Commit all intended source. `version.save` rejects dirty or untracked worktrees.
+3. If `.openai/hosting.json` has no `project_id`, call `site.create` once. The facade writes the returned ID into that file without replacing other bindings.
+4. Call `version.save`. The facade derives HEAD, obtains a temporary repository credential, pushes that exact commit internally, and saves it. Saving does not deploy.
+5. Review the saved candidate.
+6. Call `deployment.deploy` only when production publication is intended.
+7. Poll `deployment.status` when the initial deployment is non-terminal.
+
+## Invariants
+
+- Treat project, version, deployment, domain, and cursor IDs as opaque.
+- Never call `site.create` when `.openai/hosting.json` already has `project_id`.
+- Never treat a local build or Git commit as a saved `version_id`.
+- Never deploy an unsaved version.
+- Keep runtime secrets out of prompts, source, `.env.example`, and `.openai/hosting.json`.
+- Prefer the narrowest access mode that fits the audience.
+
+If the backend returns `terms_required`, give the URL to the user. They must accept the ChatGPT Sites publication terms in a browser, then retry the operation.
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/docs/workflow.md
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/docs/workflow.md
@@ -22,4 +22,3 @@ Sites publishing has two separate stages: save a version, then deploy that saved
 - Prefer the narrowest access mode that fits the audience.
 
 If the backend returns `terms_required`, give the URL to the user. They must accept the ChatGPT Sites publication terms in a browser, then retry the operation.
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/git-askpass.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/git-askpass.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const prompt = process.argv.slice(2).join(" ").toLowerCase();
+if (prompt.includes("username")) {
+  process.stdout.write(process.env.SITES_GIT_USERNAME || "x-access-token");
+} else {
+  process.stdout.write(process.env.SITES_GIT_TOKEN || "");
+}
+

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/git-askpass.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/git-askpass.mjs
@@ -6,4 +6,3 @@ if (prompt.includes("username")) {
 } else {
   process.stdout.write(process.env.SITES_GIT_TOKEN || "");
 }
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/local-project.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/local-project.mjs
@@ -1,0 +1,163 @@
+import { execFile } from "node:child_process";
+import { mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const runFile = promisify(execFile);
+const askPass = join(dirname(fileURLToPath(import.meta.url)), "git-askpass.mjs");
+
+export async function projectContext(projectDir) {
+  const requested = projectDir ? resolve(projectDir) : process.cwd();
+  const requestedStat = await stat(requested);
+  if (!requestedStat.isDirectory()) throw new Error("project_dir must name a directory");
+  let gitRoot;
+  try {
+    gitRoot = (await git(requested, ["rev-parse", "--show-toplevel"])).trim();
+  } catch {
+    // Site creation can precede Git initialization.
+  }
+  if (projectDir && gitRoot && resolve(gitRoot) !== requested) {
+    throw new Error("project_dir must be the Git repository root, not a nested directory");
+  }
+  const root = gitRoot || requested;
+  return { root, manifestPath: join(root, ".openai", "hosting.json") };
+}
+
+export async function acquireHostingLock(context) {
+  await mkdir(dirname(context.manifestPath), { recursive: true });
+  const lockPath = join(dirname(context.manifestPath), "hosting.lock");
+  let handle;
+  try {
+    handle = await open(lockPath, "wx", 0o600);
+    await handle.writeFile(`${process.pid}\n`);
+  } catch (error) {
+    await handle?.close();
+    if (error.code === "EEXIST") {
+      throw new Error(`Another Sites operation holds ${lockPath}`);
+    }
+    throw error;
+  }
+  let released = false;
+  return async () => {
+    if (released) return;
+    released = true;
+    await handle.close();
+    await rm(lockPath, { force: true });
+  };
+}
+
+export async function readHosting(context) {
+  try {
+    const value = JSON.parse(await readFile(context.manifestPath, "utf8"));
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("manifest must contain a JSON object");
+    }
+    return value;
+  } catch (error) {
+    if (error.code === "ENOENT") return {};
+    throw new Error(`${context.manifestPath}: ${error.message}`);
+  }
+}
+
+export async function persistProjectId(context, projectId) {
+  const manifest = await readHosting(context);
+  if (manifest.project_id && manifest.project_id !== projectId) {
+    throw new Error(`${context.manifestPath} already contains a different project_id`);
+  }
+  manifest.project_id = projectId;
+  await mkdir(dirname(context.manifestPath), { recursive: true });
+  const temporary = `${context.manifestPath}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, context.manifestPath);
+}
+
+export async function resolveProjectId(params, context) {
+  const manifest = await readHosting(context);
+  const supplied = params.project_id;
+  if (supplied !== undefined && typeof supplied !== "string") {
+    throw new Error("project_id must be a string");
+  }
+  if (supplied && manifest.project_id && supplied !== manifest.project_id) {
+    throw new Error("project_id does not match .openai/hosting.json");
+  }
+  const projectId = supplied || manifest.project_id;
+  if (!projectId) {
+    throw new Error("No project_id supplied and .openai/hosting.json has none");
+  }
+  return projectId;
+}
+
+export async function inspectCleanCommit(context) {
+  const root = (await git(context.root, ["rev-parse", "--show-toplevel"])).trim();
+  const status = await git(root, ["status", "--porcelain=v1", "--untracked-files=all"]);
+  if (status.trim()) throw new Error("version.save requires a clean Git worktree");
+  const manifestRelative = ".openai/hosting.json";
+  await git(root, ["ls-files", "--error-unmatch", manifestRelative]);
+  const commitSha = (await git(root, ["rev-parse", "HEAD"])).trim();
+  if (!/^[0-9a-f]{40,64}$/i.test(commitSha)) throw new Error("Could not resolve the current Git commit");
+  return { root, commitSha };
+}
+
+export async function pushCommit({ root, commitSha, credential }) {
+  const remoteUrl = credential?.remote_url;
+  const branch = credential?.branch;
+  const token = credential?.token;
+  const authMode = String(credential?.auth_mode ?? "").toLowerCase();
+  if (![remoteUrl, branch, token].every((value) => typeof value === "string" && value)) {
+    throw new Error("Sites returned an incomplete source repository credential");
+  }
+  const url = new URL(remoteUrl);
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("Sites source repository URL must be credential-free HTTPS");
+  }
+  await git(root, ["check-ref-format", `refs/heads/${branch}`]);
+
+  const env = {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  if (authMode.includes("bearer")) {
+    env.GIT_CONFIG_COUNT = "1";
+    env.GIT_CONFIG_KEY_0 = "http.extraHeader";
+    env.GIT_CONFIG_VALUE_0 = `Authorization: Bearer ${token}`;
+  } else {
+    env.GIT_ASKPASS = askPass;
+    env.SITES_GIT_TOKEN = token;
+    env.SITES_GIT_USERNAME = "x-access-token";
+  }
+  await git(
+    root,
+    [
+      "-c",
+      "credential.helper=",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "push",
+      "--no-verify",
+      "--porcelain",
+      remoteUrl,
+      `${commitSha}:refs/heads/${branch}`,
+    ],
+    env,
+  );
+}
+
+async function git(cwd, args, env = process.env) {
+  if (!isAbsolute(cwd)) throw new Error("Git working directory must be absolute");
+  try {
+    const result = await runFile("git", args, {
+      cwd,
+      env,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      timeout: 120_000,
+    });
+    return result.stdout;
+  } catch (error) {
+    const detail = String(error.stderr || error.message || "Git command failed")
+      .replaceAll(env.SITES_GIT_TOKEN || "\0", "[redacted]")
+      .trim();
+    throw new Error(detail.slice(0, 2_000));
+  }
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/operations.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/operations.mjs
@@ -1,0 +1,72 @@
+export const OPERATIONS = Object.freeze({
+  site: Object.freeze({
+    list: operation("list_sites", "site"),
+    get: operation("get_site", "site"),
+    create: operation("create_site", "site", { local: "create" }),
+    update: operation("update_site_metadata", "site"),
+  }),
+  version: Object.freeze({
+    list: operation("list_site_versions", "version"),
+    get: operation("get_site_version", "version"),
+    save: operation("save_site_version", "version", { local: "save" }),
+  }),
+  deployment: Object.freeze({
+    deploy: operation("deploy_site_version", "deployment", { local: "deploy" }),
+    status: operation("get_deployment_status", "deployment"),
+  }),
+  access: Object.freeze({
+    get: operation("get_site", "access", { select: "access" }),
+    update: operation("update_site_access", "access"),
+  }),
+  environment: Object.freeze({
+    get: operation("get_environment_variables", "environment"),
+    update: operation("update_environment_variables", "environment"),
+  }),
+  domain: Object.freeze({
+    list: operation("list_custom_domains", "domains"),
+    add: operation("add_custom_domain", "domains"),
+    refresh: operation("refresh_custom_domain_status", "domains"),
+    remove: operation("remove_custom_domain", "domains"),
+  }),
+  analytics: Object.freeze({
+    overview: operation("get_site_analytics_overview", "analytics"),
+    events: operation("list_site_analytics_events", "analytics"),
+    query: operation("query_site_analytics_event", "analytics"),
+  }),
+});
+
+function operation(tool, topic, options = {}) {
+  return Object.freeze({ tool, topic, ...options });
+}
+
+export function resolveOperation(resource, action) {
+  if (typeof resource !== "string" || typeof action !== "string") {
+    throw facadeError("invalid_operation", "resource and action must both be strings", "index");
+  }
+  const resourceOperations = OPERATIONS[resource];
+  const resolved = resourceOperations?.[action];
+  if (!resolved) {
+    const topic = resource === "domain" ? "domains" : resource in OPERATIONS ? resource : "index";
+    throw facadeError(
+      "unknown_operation",
+      `Unknown Sites operation ${resource}.${action}; read sites_documentation(\"${topic}\")`,
+      topic,
+    );
+  }
+  return { resource, action, key: `${resource}.${action}`, ...resolved };
+}
+
+export function facadeError(code, message, topic, details) {
+  return Object.assign(new Error(message), { code, topic, details });
+}
+
+export function operationForTopic(topic) {
+  if (typeof topic !== "string" || !topic.includes(".")) return undefined;
+  const [resource, action, ...rest] = topic.split(".");
+  if (rest.length > 0) return undefined;
+  try {
+    return resolveOperation(resource, action);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/redact.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/redact.mjs
@@ -1,0 +1,63 @@
+const SENSITIVE_KEYS = new Set([
+  "token",
+  "access_token",
+  "api_key",
+  "client_secret",
+  "credential",
+  "credentials",
+  "private_key",
+  "refresh",
+  "refresh_token",
+  "password",
+  "secret",
+  "authorization",
+  "siwc_bypass_bearer_token",
+  "source_repository_credential",
+]);
+
+export function redact(value) {
+  return redactValue(value, new WeakSet());
+}
+
+function redactValue(value, seen) {
+  if (typeof value === "string") return redactString(value);
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((entry) => redactValue(entry, seen));
+
+  const output = {};
+  const secretEnvironmentEntry = value.is_secret === true;
+  for (const [key, entry] of Object.entries(value)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase()) || (secretEnvironmentEntry && key === "value")) {
+      output[key] = "[redacted]";
+    } else {
+      output[key] = redactValue(entry, seen);
+    }
+  }
+  return output;
+}
+
+function redactString(value) {
+  return value
+    .replace(/(https?:\/\/)[^/@\s:]+:[^/@\s]+@/gi, "$1[redacted]@")
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/gi, "$1 [redacted]")
+    .replace(/([?&](?:token|access_token|key|signature|sig)=)[^&#\s]+/gi, "$1[redacted]");
+}
+
+export function boundedJson(value, maxBytes = 32_000) {
+  const serialized = JSON.stringify(redact(value), null, 2);
+  if (Buffer.byteLength(serialized) <= maxBytes) return serialized;
+  return JSON.stringify(
+    {
+      ok: false,
+      error: {
+        code: "output_too_large",
+        message: "Sites output was truncated; use narrower filters or pagination",
+        original_bytes: Buffer.byteLength(serialized),
+      },
+    },
+    null,
+    2,
+  );
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites/sites.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites/sites.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SitesClient } from "./client.mjs";
+import {
+  acquireHostingLock,
+  inspectCleanCommit,
+  persistProjectId,
+  projectContext,
+  pushCommit,
+  readHosting,
+  resolveProjectId,
+} from "./local-project.mjs";
+import { facadeError, operationForTopic, resolveOperation } from "./operations.mjs";
+import { boundedJson, redact } from "./redact.mjs";
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), "docs");
+const mode = process.argv[2];
+
+try {
+  const input = await readStdin();
+  const result = mode === "documentation" ? await documentation(input) : await call(input);
+  process.stdout.write(typeof result === "string" ? result : boundedJson(result));
+} catch (error) {
+  process.stdout.write(
+    boundedJson({
+      ok: false,
+      error: {
+        code: error.code || "sites_error",
+        message: error.message || "Sites operation failed",
+        topic: error.topic,
+        terms_url: error.termsUrl,
+        status: error.status,
+        details: error.details,
+      },
+    }),
+  );
+}
+
+async function call(input) {
+  let request;
+  try {
+    request = JSON.parse(input);
+  } catch {
+    throw facadeError("invalid_json", "sites expects one JSON object", "index");
+  }
+  if (!request || typeof request !== "object" || Array.isArray(request)) {
+    throw facadeError("invalid_request", "sites expects one JSON object", "index");
+  }
+  const operation = resolveOperation(request.resource, request.action);
+  const params = request.params === undefined ? {} : request.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw facadeError("invalid_params", "params must be an object", operation.topic);
+  }
+
+  const client = new SitesClient();
+  const prepared = await prepare(operation, { ...params }, client);
+  try {
+    validateAgainstSchema(prepared.args, await client.schema(prepared.tool), prepared.allowedExtra);
+    const raw = await client.call(prepared.tool, prepared.args);
+    const completed = await prepared.after(raw);
+    return {
+      ok: true,
+      operation: operation.key,
+      result: redact(selectResult(operation, completed)),
+    };
+  } finally {
+    await prepared.cleanup();
+  }
+}
+
+async function prepare(operation, params, client) {
+  const project = await projectContext(params.project_dir);
+  delete params.project_dir;
+  let tool = operation.tool;
+  let after = async (value) => value;
+  let cleanup = async () => {};
+  const allowedExtra = [];
+
+  if (operation.local === "create") {
+    cleanup = await acquireHostingLock(project);
+    try {
+      const manifest = await readHosting(project);
+      if (manifest.project_id) {
+        throw facadeError(
+          "site_already_linked",
+          ".openai/hosting.json already has project_id; reuse that site",
+          "site",
+        );
+      }
+    } catch (error) {
+      await cleanup();
+      throw error;
+    }
+    after = async (value) => {
+      const projectId = unwrapResult(value)?.id;
+      if (typeof projectId !== "string" || !projectId) {
+        throw new Error("Sites created a site but returned no project ID");
+      }
+      try {
+        await persistProjectId(project, projectId);
+      } catch (error) {
+        throw facadeError(
+          "manifest_persist_failed",
+          `Site was created as ${projectId}, but ${project.manifestPath} could not be updated: ${error.message}`,
+          "site",
+          { project_id: projectId, manifest_path: project.manifestPath },
+        );
+      }
+      return value;
+    };
+  } else if (operation.local === "save") {
+    rejectKeys(params, ["commit_sha", "archive"], "version.save derives commit_sha and does not accept archives");
+    const manifest = await readHosting(project);
+    if (typeof manifest.project_id !== "string" || !manifest.project_id) {
+      throw facadeError(
+        "unbound_repository",
+        "version.save requires project_id in the repository's .openai/hosting.json",
+        "version",
+      );
+    }
+    params.project_id = await resolveProjectId(params, project);
+    const { root, commitSha } = await inspectCleanCommit(project);
+    const credentialResponse = await client.call("create_source_repository_write_credential", {
+      project_id: params.project_id,
+    });
+    await pushCommit({ root, commitSha, credential: unwrapResult(credentialResponse) });
+    params.commit_sha = commitSha;
+  } else {
+    const schema = await client.schema(tool);
+    if (schema?.properties?.project_id && !params.project_id) {
+      params.project_id = await resolveProjectId(params, project);
+    }
+  }
+
+  if (operation.local === "deploy") {
+    const visibility = params.visibility;
+    if (visibility !== "private" && visibility !== "shared") {
+      throw facadeError(
+        "visibility_required",
+        'deployment.deploy requires params.visibility as "private" or "shared"',
+        "deployment",
+      );
+    }
+    tool = visibility === "private" ? "deploy_private_site_version" : "deploy_site_version";
+    delete params.visibility;
+  }
+
+  if (operation.tool === "list_sites" && params.limit === undefined) params.limit = 20;
+  if (operation.tool === "list_site_versions" && params.limit === undefined) params.limit = 20;
+  return { tool, args: params, after, cleanup, allowedExtra };
+}
+
+function rejectKeys(params, keys, message) {
+  if (keys.some((key) => key in params)) throw new Error(message);
+}
+
+function validateAgainstSchema(params, schema, allowedExtra = []) {
+  const properties = schema?.properties ?? {};
+  const unknown = Object.keys(params).filter(
+    (key) => !(key in properties) && !allowedExtra.includes(key),
+  );
+  if (unknown.length > 0) {
+    throw new Error(`Unknown parameter${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`);
+  }
+  const missing = (schema?.required ?? []).filter((key) => params[key] === undefined);
+  if (missing.length > 0) {
+    throw new Error(`Missing required parameter${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`);
+  }
+}
+
+function selectResult(operation, value) {
+  if (operation.select !== "access") return value;
+  const site = unwrapResult(value);
+  return {
+    result: {
+      id: site?.id,
+      title: site?.title,
+      current_live_url: site?.current_live_url,
+      access_mode: site?.access_mode,
+      access_policy: site?.access_policy,
+      available_access_modes: site?.available_access_modes,
+    },
+  };
+}
+
+function unwrapResult(value) {
+  return value?.result ?? value;
+}
+
+async function documentation(input) {
+  const requested = input.trim() || "index";
+  const topic = requested.replace(/^['"]|['"]$/g, "");
+  const operation = operationForTopic(topic);
+  if (operation) {
+    const guide = await readTopic(operation.topic);
+    const client = new SitesClient();
+    const schemas = operation.local === "deploy"
+      ? {
+          private: await client.schema("deploy_private_site_version"),
+          shared: await client.schema("deploy_site_version"),
+        }
+      : await client.schema(operation.tool);
+    return boundedDocumentation(
+      `${guide}\n\n## Current backend schema for ${operation.key}\n\n` +
+        `${operationSchemaNote(operation)}\n\n\`\`\`json\n${JSON.stringify(schemas, null, 2)}\n\`\`\`\n`,
+    );
+  }
+  const known = new Set([
+    "index",
+    "workflow",
+    "site",
+    "version",
+    "deployment",
+    "access",
+    "environment",
+    "domains",
+    "analytics",
+  ]);
+  return readTopic(known.has(topic) ? topic : "index");
+}
+
+function operationSchemaNote(operation) {
+  if (operation.local === "save") {
+    return "The facade requires a committed Site binding, derives `commit_sha`, obtains Git credentials, pushes internally, and rejects caller-supplied `commit_sha` or `archive`.";
+  }
+  if (operation.local === "deploy") {
+    return 'The facade additionally requires `visibility: "private" | "shared"`; this facade field is stripped before the backend call.';
+  }
+  return "Pass the backend fields inside `params`. `project_id` may be omitted when `.openai/hosting.json` supplies it.";
+}
+
+async function readTopic(topic) {
+  const text = await readFile(join(docsDir, `${topic}.md`), "utf8");
+  return boundedDocumentation(text);
+}
+
+function boundedDocumentation(text) {
+  const max = 16_000;
+  if (Buffer.byteLength(text) <= max) return text;
+  const suffix = "\n\n[Documentation truncated; request the narrower topic.]\n";
+  const budget = max - Buffer.byteLength(suffix);
+  let prefix = Buffer.from(text).subarray(0, budget).toString("utf8");
+  while (Buffer.byteLength(prefix) > budget) prefix = prefix.slice(0, -1);
+  return `${prefix}${suffix}`;
+}
+
+async function readStdin() {
+  let value = "";
+  for await (const chunk of process.stdin) value += chunk;
+  return value;
+}

--- a/packages/pi-codex-conversion/examples/custom-tools/sites_documentation.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites_documentation.toml
@@ -4,4 +4,3 @@ command = "./sites/sites.mjs"
 args = ["documentation"]
 input = "stdin"
 defer_loading = true
-

--- a/packages/pi-codex-conversion/examples/custom-tools/sites_documentation.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/sites_documentation.toml
@@ -1,0 +1,7 @@
+usage = '''await tools.sites_documentation("index" | "workflow" | "site" | "version" | "deployment" | "access" | "environment" | "domains" | "analytics" | "resource.action")'''
+description = "Return one bounded ChatGPT Sites documentation topic or one operation's current schema."
+command = "./sites/sites.mjs"
+args = ["documentation"]
+input = "stdin"
+defer_loading = true
+

--- a/packages/pi-codex-conversion/examples/custom-tools/spawn-agent/spawn-agent.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/spawn-agent/spawn-agent.mjs
@@ -8,12 +8,12 @@ import { fileURLToPath } from "node:url";
 const EXAMPLE_DIR = dirname(fileURLToPath(import.meta.url));
 const AGENT_CONFIG = {
 	explorer: {
-		model: "openai-codex/gpt-5.6-luna",
+		model: "openai-codex/gpt-5.6-terra",
 		thinking: "low",
 		promptPath: resolve(EXAMPLE_DIR, "explorer.prompt.md"),
 	},
 	reviewer: {
-		model: "openai-codex/gpt-5.6-sol",
+		model: "openai-codex/gpt-5.6-luna",
 		thinking: "medium",
 		promptPath: resolve(EXAMPLE_DIR, "reviewer.prompt.md"),
 	},

--- a/packages/pi-codex-conversion/examples/custom-tools/spawn_agent.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/spawn_agent.toml
@@ -3,3 +3,4 @@ description = "Relative cwd resolves from Pi's working directory."
 command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
 defer_loading = false
+yield_time_ms = 30000

--- a/packages/pi-codex-conversion/examples/custom-tools/workflows_create.toml
+++ b/packages/pi-codex-conversion/examples/custom-tools/workflows_create.toml
@@ -2,4 +2,3 @@ usage = '''await tools.workflows_create(JSON.stringify({ name: string, descripti
 description = "Creates or updates .pi/workflows/<slug>/SKILL.md in Pi's working directory."
 command = "./workflows-create/workflows-create.mjs"
 input = "stdin"
-defer_loading = false

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -35,7 +35,7 @@ Optional fields:
 - `defer_loading`: defaults to `true`.
 - `yield_time_ms`: non-negative integer controlling how long `exec` initially waits when the source directly invokes this tool. It overrides the `// @exec` value and is not exposed as a model-facing argument. If one cell directly invokes several configured tools, the largest value wins.
 
-Unknown fields and invalid definitions fail explicitly. Bare commands resolve through `PATH`; relative commands resolve from the TOML directory. JavaScript commands run with Pi's JavaScript runtime. Commands run directly without shell expansion.
+Unknown fields and invalid definitions are reported and omitted individually; valid custom tools and built-in Code Mode tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior. Bare commands resolve through `PATH`; relative commands resolve from the TOML directory. JavaScript commands run with Pi's JavaScript runtime. Commands run directly without shell expansion.
 
 ## Deferred tools
 
@@ -52,8 +52,11 @@ Set `defer_loading = false` only for stable, frequently used tools. Promotion ad
 
 Working, disabled templates ship under the package root's `examples/custom-tools/` directory:
 
+- `herdr_agent`: finds and coordinates Pi agents in Herdr panels; use with `more_skills` for advanced Herdr orchestration.
+- `more_skills`: lists or loads additional skills from the corresponding global or project-local `more-skills/` directory.
 - `port_info`: cross-platform listener and process diagnostics.
 - `semantic_grep`: queries an existing index owned by an installed and configured `@howaboua/pi-semantic-grep`.
+- `sites` and `sites_documentation`: a curated, private-API bridge to the ChatGPT Sites beta using Pi's OpenAI Codex OAuth; keep both definitions together.
 - `spawn_agent`: launches isolated explorer or reviewer Pi processes.
 - `vent`: appends batched workflow-friction notes to `VENT.md`.
 - `workflows_create`: creates or updates repo-local workflow skills.

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -35,7 +35,7 @@ Optional fields:
 - `defer_loading`: defaults to `true`.
 - `yield_time_ms`: non-negative integer controlling how long `exec` initially waits when the source directly invokes this tool. It overrides the `// @exec` value and is not exposed as a model-facing argument. If one cell directly invokes several configured tools, the largest value wins.
 
-Unknown fields and invalid definitions are reported and omitted individually; valid custom tools and built-in Code Mode tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior. Bare commands resolve through `PATH`; relative commands resolve from the TOML directory. JavaScript commands run with Pi's JavaScript runtime. Commands run directly without shell expansion.
+Unknown fields and invalid definitions disable only that named tool. The tool remains visible in `exec` and throws its configuration error when called, while valid custom tools and built-in Code Mode tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior. Invalid JavaScript identifiers and unreadable tool directories, which cannot be represented as named tools, are reported through Pi. Bare commands resolve through `PATH`; relative commands resolve from the TOML directory. JavaScript commands run with Pi's JavaScript runtime. Commands run directly without shell expansion.
 
 ## Deferred tools
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -4,7 +4,12 @@ Use this reference when asked to add, change, debug, or explain custom tools use
 
 ## Definitions
 
-Definitions are top-level `*.toml` files under `~/.pi/agent/codex-conversion-custom-tools/`, or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/` when configured. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
+Definitions are top-level `*.toml` files in either location:
+
+- global: `~/.pi/agent/codex-conversion-custom-tools/`, or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/` when configured
+- project-local: `<launch-directory>/.pi/codex-conversion-custom-tools/`
+
+Only the directory where Pi was launched is checked; parent directories are not searched. A project-local definition replaces a global definition with the same tool name. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
 
 ```toml
 usage = 'await tools.port_info(port_number)'
@@ -13,6 +18,7 @@ output = "Normalized JSON."
 command = "./port-info/port-info.mjs"
 input = "arg"
 defer_loading = true
+yield_time_ms = 30000
 ```
 
 Required fields:
@@ -27,6 +33,7 @@ Optional fields:
 - `args`: fixed string arguments before model input.
 - `input`: `"arg"` (default) or `"stdin"`.
 - `defer_loading`: defaults to `true`.
+- `yield_time_ms`: non-negative integer controlling how long `exec` initially waits when the source directly invokes this tool. It overrides the `// @exec` value and is not exposed as a model-facing argument. If one cell directly invokes several configured tools, the largest value wins.
 
 Unknown fields and invalid definitions fail explicitly. Bare commands resolve through `PATH`; relative commands resolve from the TOML directory. JavaScript commands run with Pi's JavaScript runtime. Commands run directly without shell expansion.
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -7,9 +7,9 @@ Use this reference when asked to add, change, debug, or explain custom tools use
 Definitions are top-level `*.toml` files in either location:
 
 - global: `~/.pi/agent/codex-conversion-custom-tools/`, or `$PI_CODING_AGENT_DIR/codex-conversion-custom-tools/` when configured
-- project-local: `<launch-directory>/.pi/codex-conversion-custom-tools/`
+- project-local in trusted projects: `<launch-directory>/.pi/codex-conversion-custom-tools/`
 
-Only the directory where Pi was launched is checked; parent directories are not searched. A project-local definition replaces a global definition with the same tool name. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
+Only the directory where Pi was launched is checked; parent directories are not searched. Project-local definitions are ignored unless Pi trusts the project. A project-local definition replaces a global definition with the same tool name. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
 
 ```toml
 usage = 'await tools.port_info(port_number)'

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-runner.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-runner.ts
@@ -10,6 +10,8 @@ export async function runCustomTool(
 	cwd: string,
 	signal?: AbortSignal,
 ): Promise<string> {
+	if (tool.disabledReason)
+		throw new Error(`${tool.name} is disabled: ${tool.disabledReason}`);
 	if (typeof input !== "string")
 		throw new Error(`${tool.name} expects a string input`);
 	if (signal?.aborted) throw new Error(`${tool.name} aborted`);

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -169,7 +169,7 @@ function customToolPaths(
 ): string[] {
 	try {
 		return readdirSync(dir, { withFileTypes: true })
-			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
+			.filter((entry) => entry.name.endsWith(".toml"))
 			.sort((left, right) => left.name.localeCompare(right.name))
 			.map((entry) => join(dir, entry.name));
 	} catch (error) {

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -11,6 +11,16 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { parse } from "smol-toml";
 import type { CustomToolDefinition, CustomToolInputMode } from "./types.js";
 
+export interface CustomToolDiscoveryError {
+	path: string;
+	message: string;
+}
+
+export interface CustomToolDiscoveryResult {
+	tools: CustomToolDefinition[];
+	errors: CustomToolDiscoveryError[];
+}
+
 export const CUSTOM_TOOLS_DIRNAME = "codex-conversion-custom-tools";
 const TOOL_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 const NODE_SCRIPT_PATTERN = /\.(?:cjs|mjs|js)$/i;
@@ -122,24 +132,66 @@ export function parseCustomTool(
 
 export function discoverCustomToolsFromDirectories(
 	dirs: readonly string[],
-): CustomToolDefinition[] {
+): CustomToolDiscoveryResult {
 	const byName = new Map<string, CustomToolDefinition>();
-	for (const dir of dirs)
-		for (const tool of discoverCustomTools(dir)) byName.set(tool.name, tool);
-	return [...byName.values()].sort((left, right) =>
-		left.name.localeCompare(right.name),
-	);
+	const errors: CustomToolDiscoveryError[] = [];
+	for (const dir of dirs) {
+		for (const path of customToolPaths(dir, errors)) {
+			const name = basename(path, extname(path));
+			// A project-local definition claims its name even when invalid. Never
+			// silently fall back to a global tool with different behavior.
+			byName.delete(name);
+			const tool = loadCustomTool(path, errors);
+			if (tool) byName.set(tool.name, tool);
+		}
+	}
+	return {
+		tools: [...byName.values()].sort((left, right) =>
+			left.name.localeCompare(right.name),
+		),
+		errors,
+	};
 }
 
 export function discoverCustomTools(
 	dir: string = getCustomToolsDir(),
-): CustomToolDefinition[] {
+): CustomToolDiscoveryResult {
+	const errors: CustomToolDiscoveryError[] = [];
+	const tools = customToolPaths(dir, errors)
+		.map((path) => loadCustomTool(path, errors))
+		.filter((tool): tool is CustomToolDefinition => tool !== undefined);
+	return { tools, errors };
+}
+
+function customToolPaths(
+	dir: string,
+	errors: CustomToolDiscoveryError[],
+): string[] {
 	if (!existsSync(dir)) return [];
-	return readdirSync(dir, { withFileTypes: true })
-		.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
-		.sort((left, right) => left.name.localeCompare(right.name))
-		.map((entry) => {
-			const path = join(dir, entry.name);
-			return parseCustomTool(path, readFileSync(path, "utf8"));
+	try {
+		return readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
+			.sort((left, right) => left.name.localeCompare(right.name))
+			.map((entry) => join(dir, entry.name));
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		errors.push({ path: dir, message: `${dir}: ${detail}` });
+		return [];
+	}
+}
+
+function loadCustomTool(
+	path: string,
+	errors: CustomToolDiscoveryError[],
+): CustomToolDefinition | undefined {
+	try {
+		return parseCustomTool(path, readFileSync(path, "utf8"));
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		errors.push({
+			path,
+			message: detail.startsWith(`${path}:`) ? detail : `${path}: ${detail}`,
 		});
+		return undefined;
+	}
 }

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -19,6 +19,12 @@ export function getCustomToolsDir(agentDir: string = getAgentDir()): string {
 	return join(agentDir, CUSTOM_TOOLS_DIRNAME);
 }
 
+export function getProjectCustomToolsDir(
+	launchDir: string = process.cwd(),
+): string {
+	return join(launchDir, ".pi", CUSTOM_TOOLS_DIRNAME);
+}
+
 function requiredString(value: unknown, field: string, path: string): string {
 	if (typeof value !== "string" || !value.trim())
 		throw new Error(`${path}: ${field} must be a non-empty string`);
@@ -53,6 +59,17 @@ function deferLoading(value: unknown, path: string): boolean {
 	throw new Error(`${path}: defer_loading must be a boolean`);
 }
 
+function optionalNonNegativeInteger(
+	value: unknown,
+	field: string,
+	path: string,
+): number | undefined {
+	if (value === undefined) return undefined;
+	if (!Number.isSafeInteger(value) || Number(value) < 0)
+		throw new Error(`${path}: ${field} must be a non-negative safe integer`);
+	return Number(value);
+}
+
 export function parseCustomTool(
 	path: string,
 	text: string,
@@ -71,6 +88,7 @@ export function parseCustomTool(
 		"command",
 		"args",
 		"input",
+		"yield_time_ms",
 	]);
 	const unknown = Object.keys(value).filter((key) => !known.has(key));
 	if (unknown.length > 0)
@@ -93,8 +111,24 @@ export function parseCustomTool(
 		command: nodeScript ? process.execPath : resolvedCommand,
 		args: nodeScript ? [resolvedCommand, ...args] : args,
 		input: inputMode(value["input"], path),
+		yieldTimeMs: optionalNonNegativeInteger(
+			value["yield_time_ms"],
+			"yield_time_ms",
+			path,
+		),
 		sourcePath: path,
 	};
+}
+
+export function discoverCustomToolsFromDirectories(
+	dirs: readonly string[],
+): CustomToolDefinition[] {
+	const byName = new Map<string, CustomToolDefinition>();
+	for (const dir of dirs)
+		for (const tool of discoverCustomTools(dir)) byName.set(tool.name, tool);
+	return [...byName.values()].sort((left, right) =>
+		left.name.localeCompare(right.name),
+	);
 }
 
 export function discoverCustomTools(

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import {
 	basename,
 	dirname,
@@ -167,13 +167,19 @@ function customToolPaths(
 	dir: string,
 	errors: CustomToolDiscoveryError[],
 ): string[] {
-	if (!existsSync(dir)) return [];
 	try {
 		return readdirSync(dir, { withFileTypes: true })
 			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
 			.sort((left, right) => left.name.localeCompare(right.name))
 			.map((entry) => join(dir, entry.name));
 	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		)
+			return [];
 		const detail = error instanceof Error ? error.message : String(error);
 		errors.push({ path: dir, message: `${dir}: ${detail}` });
 		return [];

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -194,10 +194,24 @@ function loadCustomTool(
 		return parseCustomTool(path, readFileSync(path, "utf8"));
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error);
-		errors.push({
-			path,
-			message: detail.startsWith(`${path}:`) ? detail : `${path}: ${detail}`,
-		});
-		return undefined;
+		const message = detail.startsWith(`${path}:`)
+			? detail
+			: `${path}: ${detail}`;
+		const name = basename(path, extname(path));
+		if (!TOOL_NAME_PATTERN.test(name)) {
+			errors.push({ path, message });
+			return undefined;
+		}
+		return {
+			name,
+			usage: "Disabled: fix this tool's TOML definition before calling it.",
+			description: message,
+			deferLoading: true,
+			command: "",
+			args: [],
+			input: "arg",
+			sourcePath: path,
+			disabledReason: message,
+		};
 	}
 }

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -169,7 +169,7 @@ function customToolPaths(
 ): string[] {
 	try {
 		return readdirSync(dir, { withFileTypes: true })
-			.filter((entry) => entry.name.endsWith(".toml"))
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
 			.sort((left, right) => left.name.localeCompare(right.name))
 			.map((entry) => join(dir, entry.name));
 	} catch (error) {

--- a/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
@@ -9,6 +9,7 @@ import { CodeModeDelegateRuntime } from "./delegate-runtime.js";
 import {
 	executionCellId,
 	type HostMessage,
+	isMissingRuntimeOutcome,
 	parseHostMessage,
 	parseExecSource,
 	parseRuntimeResponse,
@@ -206,7 +207,10 @@ export class CodeModeHostClient {
 			const wrapped = runtimeOutcome(value);
 			if (!wrapped)
 				throw new Error("Code-mode host returned an invalid wait outcome");
-			return this.delegateRuntime.attach(parseRuntimeResponse(wrapped));
+			return {
+				...this.delegateRuntime.attach(parseRuntimeResponse(wrapped)),
+				...(isMissingRuntimeOutcome(value) ? { missingCell: true as const } : {}),
+			};
 		} finally {
 			signal?.removeEventListener("abort", abort);
 		}
@@ -245,7 +249,10 @@ export class CodeModeHostClient {
 			const wrapped = runtimeOutcome(value);
 			if (!wrapped)
 				throw new Error("Code-mode host returned an invalid termination outcome");
-			return this.delegateRuntime.attach(parseRuntimeResponse(wrapped));
+			return {
+				...this.delegateRuntime.attach(parseRuntimeResponse(wrapped)),
+				...(isMissingRuntimeOutcome(value) ? { missingCell: true as const } : {}),
+			};
 		} finally {
 			signal?.removeEventListener("abort", abort);
 		}
@@ -416,17 +423,66 @@ function customToolYieldTime(
 	code: string,
 	tools: CodeModeToolDefinition[],
 ): number | null {
+	const executableCode = maskJavaScriptCommentsAndStrings(code);
 	let forced: number | undefined;
 	for (const tool of tools) {
 		if (!("command" in tool) || tool.yieldTimeMs === undefined) continue;
 		const name = escapeRegExp(tool.name);
 		const directReference = new RegExp(
-			`\\btools\\s*(?:\\.\\s*${name}(?![a-zA-Z0-9_$])|\\[\\s*(["'])${name}\\1\\s*\\])`,
+			`\\btools\\s*\\.\\s*${name}(?![a-zA-Z0-9_$])\\s*\\(`,
 		);
-		if (!directReference.test(code)) continue;
+		if (!directReference.test(executableCode)) continue;
 		forced = forced === undefined ? tool.yieldTimeMs : Math.max(forced, tool.yieldTimeMs);
 	}
 	return forced ?? null;
+}
+
+function maskJavaScriptCommentsAndStrings(code: string): string {
+	const output = code.split("");
+	let state: "code" | "line-comment" | "block-comment" | "string" = "code";
+	let quote = "";
+	for (let index = 0; index < code.length; index += 1) {
+		const current = code[index]!;
+		const next = code[index + 1];
+		if (state === "code") {
+			if (current === "/" && next === "/") {
+				output[index] = output[index + 1] = " ";
+				state = "line-comment";
+				index += 1;
+			} else if (current === "/" && next === "*") {
+				output[index] = output[index + 1] = " ";
+				state = "block-comment";
+				index += 1;
+			} else if (current === '"' || current === "'" || current === "`") {
+				output[index] = " ";
+				quote = current;
+				state = "string";
+			}
+			continue;
+		}
+		if (state === "line-comment") {
+			if (current === "\n" || current === "\r") state = "code";
+			else output[index] = " ";
+			continue;
+		}
+		output[index] = current === "\n" || current === "\r" ? current : " ";
+		if (state === "block-comment") {
+			if (current === "*" && next === "/") {
+				output[index + 1] = " ";
+				state = "code";
+				index += 1;
+			}
+			continue;
+		}
+		if (current === "\\") {
+			if (next !== undefined) output[index + 1] = " ";
+			index += 1;
+		} else if (current === quote) {
+			state = "code";
+			quote = "";
+		}
+	}
+	return output.join("");
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
@@ -117,6 +117,7 @@ export class CodeModeHostClient {
 		await this.start();
 		throwIfAborted(signal);
 		const { code, yieldTimeMs, maxOutputTokens } = parseExecSource(source);
+		const effectiveYieldTimeMs = customToolYieldTime(code, tools) ?? yieldTimeMs;
 		const id = ++this.requestId;
 		const initial = new Promise<unknown>((resolve, reject) =>
 			this.initial.set(id, { resolve, reject }),
@@ -132,7 +133,7 @@ export class CodeModeHostClient {
 					tool_call_id: `exec-${id}`,
 					enabled_tools: tools.map(toWireToolDefinition),
 					source: code,
-					yield_time_ms: yieldTimeMs,
+					yield_time_ms: effectiveYieldTimeMs,
 					max_output_tokens: maxOutputTokens,
 				},
 			},
@@ -409,6 +410,27 @@ export class CodeModeHostClient {
 		if (child && !child.killed) child.kill();
 	}
 
+}
+
+function customToolYieldTime(
+	code: string,
+	tools: CodeModeToolDefinition[],
+): number | null {
+	let forced: number | undefined;
+	for (const tool of tools) {
+		if (!("command" in tool) || tool.yieldTimeMs === undefined) continue;
+		const name = escapeRegExp(tool.name);
+		const directReference = new RegExp(
+			`\\btools\\s*(?:\\.\\s*${name}(?![a-zA-Z0-9_$])|\\[\\s*(["'])${name}\\1\\s*\\])`,
+		);
+		if (!directReference.test(code)) continue;
+		forced = forced === undefined ? tool.yieldTimeMs : Math.max(forced, tool.yieldTimeMs);
+	}
+	return forced ?? null;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function shutdownDeadline(delayMs: number): Promise<void> {

--- a/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
@@ -439,14 +439,50 @@ function customToolYieldTime(
 
 function maskJavaScriptCommentsAndStrings(code: string): string {
 	const output = code.split("");
-	let state: "code" | "line-comment" | "block-comment" | "string" | "regex" = "code";
+	let state:
+		| "code"
+		| "line-comment"
+		| "block-comment"
+		| "string"
+		| "regex"
+		| "template" = "code";
 	let quote = "";
 	let regexClass = false;
+	let templateExpressionDepth: number | undefined;
+	const templateReturnDepths: Array<number | undefined> = [];
 	for (let index = 0; index < code.length; index += 1) {
 		const current = code[index]!;
 		const next = code[index + 1];
+		if (state === "template") {
+			output[index] = current === "\n" || current === "\r" ? current : " ";
+			if (current === "\\") {
+				if (next !== undefined) output[index + 1] = " ";
+				index += 1;
+			} else if (current === "$" && next === "{") {
+				output[index + 1] = " ";
+				templateExpressionDepth = 1;
+				state = "code";
+				index += 1;
+			} else if (current === "`") {
+				templateExpressionDepth = templateReturnDepths.pop();
+				state = "code";
+			}
+			continue;
+		}
 		if (state === "code") {
-			if (current === "/" && next === "/") {
+			if (templateExpressionDepth !== undefined && current === "{") {
+				templateExpressionDepth += 1;
+			} else if (
+				templateExpressionDepth !== undefined &&
+				current === "}"
+			) {
+				templateExpressionDepth -= 1;
+				if (templateExpressionDepth === 0) {
+					output[index] = " ";
+					templateExpressionDepth = undefined;
+					state = "template";
+				}
+			} else if (current === "/" && next === "/") {
 				output[index] = output[index + 1] = " ";
 				state = "line-comment";
 				index += 1;
@@ -458,10 +494,15 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 				output[index] = " ";
 				regexClass = false;
 				state = "regex";
-			} else if (current === '"' || current === "'" || current === "`") {
+			} else if (current === '"' || current === "'") {
 				output[index] = " ";
 				quote = current;
 				state = "string";
+			} else if (current === "`") {
+				output[index] = " ";
+				templateReturnDepths.push(templateExpressionDepth);
+				templateExpressionDepth = undefined;
+				state = "template";
 			}
 			continue;
 		}

--- a/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/host-client.ts
@@ -439,8 +439,9 @@ function customToolYieldTime(
 
 function maskJavaScriptCommentsAndStrings(code: string): string {
 	const output = code.split("");
-	let state: "code" | "line-comment" | "block-comment" | "string" = "code";
+	let state: "code" | "line-comment" | "block-comment" | "string" | "regex" = "code";
 	let quote = "";
+	let regexClass = false;
 	for (let index = 0; index < code.length; index += 1) {
 		const current = code[index]!;
 		const next = code[index + 1];
@@ -453,6 +454,10 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 				output[index] = output[index + 1] = " ";
 				state = "block-comment";
 				index += 1;
+			} else if (current === "/" && isRegexLiteralStart(code, index)) {
+				output[index] = " ";
+				regexClass = false;
+				state = "regex";
 			} else if (current === '"' || current === "'" || current === "`") {
 				output[index] = " ";
 				quote = current;
@@ -463,6 +468,16 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 		if (state === "line-comment") {
 			if (current === "\n" || current === "\r") state = "code";
 			else output[index] = " ";
+			continue;
+		}
+		if (state === "regex") {
+			output[index] = current === "\n" || current === "\r" ? current : " ";
+			if (current === "\\") {
+				if (next !== undefined) output[index + 1] = " ";
+				index += 1;
+			} else if (current === "[") regexClass = true;
+			else if (current === "]") regexClass = false;
+			else if (current === "/" && !regexClass) state = "code";
 			continue;
 		}
 		output[index] = current === "\n" || current === "\r" ? current : " ";
@@ -483,6 +498,13 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 		}
 	}
 	return output.join("");
+}
+
+function isRegexLiteralStart(code: string, index: number): boolean {
+	const previous = code.slice(0, index).trimEnd();
+	if (!previous) return true;
+	if ("([{:;,=!?&|+-*%^~<>".includes(previous.at(-1)!)) return true;
+	return /(?:^|[^\w$])(return|throw|case|delete|void|typeof|instanceof|in|of|yield|await|else|do)$/.test(previous);
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/pi-codex-conversion/src/tools/code-mode/host-protocol.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/host-protocol.ts
@@ -220,6 +220,14 @@ export function runtimeOutcome(value: unknown): unknown {
 	return value["outcome"]["LiveCell"] ?? value["outcome"]["MissingCell"];
 }
 
+export function isMissingRuntimeOutcome(value: unknown): boolean {
+	return Boolean(
+		isRecord(value) &&
+			isRecord(value["outcome"]) &&
+			"MissingCell" in value["outcome"],
+	);
+}
+
 function parseDelegateRequest(value: Record<string, unknown>): DelegateRequestMessage {
 	const id = parseMessageId(value["id"]);
 	const request = value["request"];

--- a/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
@@ -18,6 +18,7 @@ import {
 } from "./rendering.js";
 import type { SharedCodeModeRuntime } from "./shared-runtime.js";
 import { toCodeModeToolResult } from "./tool-result.js";
+import type { ToolExecutionContext } from "./types.js";
 
 const DEFAULT_WAIT_MS = 10_000;
 const MIN_ADAPTIVE_WAIT_MS = 5_000;
@@ -127,6 +128,25 @@ function createWaitTool(
 							context,
 							signal,
 						);
+				const recovered =
+					!params.terminate &&
+					response.kind === "result" &&
+					response.errorText
+						? await continueExecSessionFromMistakenWait(
+								response.errorText,
+								params.cell_id,
+								params.yield_time_ms ?? DEFAULT_WAIT_MS,
+								params.max_tokens,
+								runtime,
+								context,
+								signal,
+							)
+						: undefined;
+				if (recovered) {
+					waitAttempts.delete(params.cell_id);
+					tracker.finish(id, recovered.running ? "yielded" : "done");
+					return recovered.result;
+				}
 				if (response.kind === "yielded")
 					waitAttempts.set(params.cell_id, attempt + 1);
 				else waitAttempts.delete(params.cell_id);
@@ -136,6 +156,22 @@ function createWaitTool(
 				);
 				return toCodeModeToolResult(response, params.max_tokens);
 			} catch (error) {
+				const recovered = params.terminate
+					? undefined
+					: await continueExecSessionFromMistakenWait(
+							error,
+							params.cell_id,
+							params.yield_time_ms ?? DEFAULT_WAIT_MS,
+							params.max_tokens,
+							runtime,
+							{ cwd: ctx.cwd, extensionContext: ctx, onUpdate, toolCallId: id },
+							signal,
+						);
+				if (recovered) {
+					waitAttempts.delete(params.cell_id);
+					tracker.finish(id, recovered.running ? "yielded" : "done");
+					return recovered.result;
+				}
 				waitAttempts.delete(params.cell_id);
 				tracker.finish(id);
 				throw error;
@@ -154,6 +190,82 @@ function createWaitTool(
 				runtime.useRichRendering(),
 			)) as any,
 		renderResult: renderResult as any,
+	};
+}
+
+async function continueExecSessionFromMistakenWait(
+	error: unknown,
+	cellId: string,
+	yieldTimeMs: number,
+	maxOutputTokens: number | undefined,
+	runtime: SharedCodeModeRuntime,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<
+	| {
+			running: boolean;
+			result: {
+				content: Array<{ type: "text"; text: string }>;
+				details: unknown;
+			};
+	  }
+	| undefined
+> {
+	const message = error instanceof Error ? error.message : String(error);
+	if (!/^exec cell \d+ not found$/i.test(message) || !/^\d+$/.test(cellId))
+		return undefined;
+	const sessionId = Number(cellId);
+	if (!Number.isSafeInteger(sessionId)) return undefined;
+	const writeStdin = runtime
+		.collectTools(context.extensionContext)
+		.find((tool) => tool.name === "write_stdin" && "invoke" in tool);
+	if (!writeStdin || !("invoke" in writeStdin)) return undefined;
+	let value: unknown;
+	try {
+		value = await writeStdin.invoke(
+			{
+				session_id: sessionId,
+				yield_time_ms: yieldTimeMs,
+				...(maxOutputTokens === undefined
+					? {}
+					: { max_output_tokens: maxOutputTokens }),
+			},
+			context,
+			signal ?? new AbortController().signal,
+		);
+	} catch (fallbackError) {
+		const fallbackMessage =
+			fallbackError instanceof Error
+				? fallbackError.message
+				: String(fallbackError);
+		if (/unknown process id/i.test(fallbackMessage)) return undefined;
+		throw fallbackError;
+	}
+	if (!value || typeof value !== "object" || !("output" in value))
+		return undefined;
+	const output = typeof value.output === "string" ? value.output : "";
+	const running =
+		"session_id" in value && typeof value.session_id === "number";
+	return {
+		running,
+		result: {
+			content: [
+				{
+					type: "text",
+					text: `Recovered wait cell_id ${cellId} as exec_command session_id ${sessionId} and continued it with write_stdin.`,
+				},
+				...(output ? [{ type: "text" as const, text: output }] : []),
+				...(running
+					? [
+							{
+								type: "text" as const,
+								text: `exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} }).`,
+							},
+						]
+					: []),
+			],
+			details: value,
+		},
 	};
 }
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
@@ -130,10 +130,8 @@ function createWaitTool(
 						);
 				const recovered =
 					!params.terminate &&
-					response.kind === "result" &&
-					response.errorText
+					response.missingCell === true
 						? await continueExecSessionFromMistakenWait(
-								response.errorText,
 								params.cell_id,
 								params.yield_time_ms ?? DEFAULT_WAIT_MS,
 								params.max_tokens,
@@ -156,22 +154,6 @@ function createWaitTool(
 				);
 				return toCodeModeToolResult(response, params.max_tokens);
 			} catch (error) {
-				const recovered = params.terminate
-					? undefined
-					: await continueExecSessionFromMistakenWait(
-							error,
-							params.cell_id,
-							params.yield_time_ms ?? DEFAULT_WAIT_MS,
-							params.max_tokens,
-							runtime,
-							{ cwd: ctx.cwd, extensionContext: ctx, onUpdate, toolCallId: id },
-							signal,
-						);
-				if (recovered) {
-					waitAttempts.delete(params.cell_id);
-					tracker.finish(id, recovered.running ? "yielded" : "done");
-					return recovered.result;
-				}
 				waitAttempts.delete(params.cell_id);
 				tracker.finish(id);
 				throw error;
@@ -194,7 +176,6 @@ function createWaitTool(
 }
 
 async function continueExecSessionFromMistakenWait(
-	error: unknown,
 	cellId: string,
 	yieldTimeMs: number,
 	maxOutputTokens: number | undefined,
@@ -211,11 +192,10 @@ async function continueExecSessionFromMistakenWait(
 	  }
 	| undefined
 > {
-	const message = error instanceof Error ? error.message : String(error);
-	if (!/^exec cell \d+ not found$/i.test(message) || !/^\d+$/.test(cellId))
-		return undefined;
+	if (!/^\d+$/.test(cellId)) return undefined;
 	const sessionId = Number(cellId);
-	if (!Number.isSafeInteger(sessionId)) return undefined;
+	if (!Number.isSafeInteger(sessionId) || String(sessionId) !== cellId)
+		return undefined;
 	const writeStdin = runtime
 		.collectTools(context.extensionContext)
 		.find((tool) => tool.name === "write_stdin" && "invoke" in tool);
@@ -244,6 +224,10 @@ async function continueExecSessionFromMistakenWait(
 	if (!value || typeof value !== "object" || !("output" in value))
 		return undefined;
 	const output = typeof value.output === "string" ? value.output : "";
+	const exitCode =
+		"exit_code" in value && typeof value.exit_code === "number"
+			? value.exit_code
+			: undefined;
 	const running =
 		"session_id" in value && typeof value.session_id === "number";
 	return {
@@ -255,6 +239,14 @@ async function continueExecSessionFromMistakenWait(
 					text: `Recovered wait cell_id ${cellId} as exec_command session_id ${sessionId} and continued it with write_stdin.`,
 				},
 				...(output ? [{ type: "text" as const, text: output }] : []),
+				...(exitCode === undefined
+					? []
+					: [
+							{
+								type: "text" as const,
+								text: `Process exited with code ${exitCode}.`,
+							},
+						]),
 				...(running
 					? [
 							{

--- a/packages/pi-codex-conversion/src/tools/code-mode/rendering.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/rendering.ts
@@ -122,11 +122,13 @@ export function renderCodeModeResult(
 			? "accent"
 			: "dim";
 	const renderedText = outputText ? theme.fg(tone, outputText) : "";
+	const tracedImages = traceImages(details.traces ?? []);
 	const images = content.filter(
 		(item): item is ToolContent & { data: string; mimeType: string } =>
 			item.type === "image" &&
 			typeof item.data === "string" &&
-			typeof item.mimeType === "string",
+			typeof item.mimeType === "string" &&
+			!tracedImages.get(item.mimeType)?.has(item.data),
 	);
 
 	const showOutput =
@@ -150,6 +152,24 @@ export function renderCodeModeResult(
 		theme,
 		context,
 	);
+}
+
+function traceImages(traces: RuntimeToolTrace[]): Map<string, Set<string>> {
+	const images = new Map<string, Set<string>>();
+	for (const trace of traces) {
+		for (const item of trace.result?.content ?? []) {
+			if (
+				item.type !== "image" ||
+				typeof item.data !== "string" ||
+				typeof item.mimeType !== "string"
+			)
+				continue;
+			const data = images.get(item.mimeType) ?? new Set<string>();
+			data.add(item.data);
+			images.set(item.mimeType, data);
+		}
+	}
+	return images;
 }
 
 export function renderTrackedCodeModeResult(

--- a/packages/pi-codex-conversion/src/tools/code-mode/tool-result.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tool-result.ts
@@ -39,6 +39,12 @@ export function toCodeModeToolResult(
 			return content;
 		})
 		.filter((item): item is NonNullable<typeof item> => Boolean(item));
+	output.unshift(
+		...runningExecSessionGuidance(response.traces ?? []).map((text) => ({
+			type: "text" as const,
+			text,
+		})),
+	);
 	if (omittedImages > 0)
 		output.push({
 			type: "text",
@@ -67,6 +73,41 @@ export function toCodeModeToolResult(
 			...(scriptError ? { scriptError } : {}),
 		},
 	};
+}
+
+function runningExecSessionGuidance(
+	traces: NonNullable<RuntimeResponse["traces"]>,
+): string[] {
+	const sessionIds = new Set<number>();
+	for (const trace of traces) {
+		if (trace.status !== "done") continue;
+		const details = trace.result?.details;
+		const resultSessionId = numericSessionId(details);
+		if (trace.name === "exec_command" && resultSessionId !== undefined) {
+			sessionIds.add(resultSessionId);
+			continue;
+		}
+		if (trace.name !== "write_stdin") continue;
+		const inputSessionId = numericSessionId(trace.input);
+		if (inputSessionId === undefined) continue;
+		if (resultSessionId === undefined) sessionIds.delete(inputSessionId);
+		else sessionIds.add(resultSessionId);
+	}
+	return [...sessionIds].map(
+		(sessionId) =>
+			`exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} }); wait is only for a yielded exec cell_id.`,
+	);
+}
+
+function numericSessionId(value: unknown): number | undefined {
+	if (
+		value &&
+		typeof value === "object" &&
+		"session_id" in value &&
+		typeof value.session_id === "number"
+	)
+		return value.session_id;
+	return undefined;
 }
 
 function toPiContent(

--- a/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
@@ -1,7 +1,11 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { discoverCustomTools, getCustomToolsDir } from "./custom-tools.js";
+import {
+	discoverCustomToolsFromDirectories,
+	getCustomToolsDir,
+	getProjectCustomToolsDir,
+} from "./custom-tools.js";
 import { registerPublicCodeModeTools } from "./public-tools.js";
 import {
 	SharedCodeModeRuntime,
@@ -28,11 +32,17 @@ export interface CodeModeRegistration {
 
 export async function registerCustomTools(
 	pi: ExtensionAPI,
-	toolsDir: string = getCustomToolsDir(),
+	toolsDir?: string | readonly string[],
 	options: { isActive?(ctx: unknown): boolean } = {},
 ): Promise<CodeModeRegistration> {
+	const toolsDirs =
+		toolsDir === undefined
+			? [getCustomToolsDir(), getProjectCustomToolsDir()]
+			: typeof toolsDir === "string"
+				? [toolsDir]
+				: [...toolsDir];
 	return registerCodeModeTools(pi, {
-		getTools: () => discoverCustomTools(toolsDir),
+		getTools: () => discoverCustomToolsFromDirectories(toolsDirs),
 		documentationPath: customToolsDocumentationPath(),
 		...options,
 	});

--- a/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
@@ -1,7 +1,11 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import {
+	type CustomToolDiscoveryError,
 	discoverCustomToolsFromDirectories,
 	getCustomToolsDir,
 	getProjectCustomToolsDir,
@@ -41,11 +45,46 @@ export async function registerCustomTools(
 			: typeof toolsDir === "string"
 				? [toolsDir]
 				: [...toolsDir];
+	let previousErrors = new Map<string, string>();
 	return registerCodeModeTools(pi, {
-		getTools: () => discoverCustomToolsFromDirectories(toolsDirs),
+		getTools: (ctx) => {
+			const discovery = discoverCustomToolsFromDirectories(toolsDirs);
+			previousErrors = reportCustomToolErrors(
+				ctx,
+				discovery.errors,
+				previousErrors,
+			);
+			return discovery.tools;
+		},
 		documentationPath: customToolsDocumentationPath(),
 		...options,
 	});
+}
+
+function reportCustomToolErrors(
+	ctx: unknown,
+	errors: CustomToolDiscoveryError[],
+	previous: Map<string, string>,
+): Map<string, string> {
+	if (!isExtensionContext(ctx)) return previous;
+	const current = new Map(errors.map((error) => [error.path, error.message]));
+	for (const error of errors) {
+		if (previous.get(error.path) === error.message) continue;
+		ctx.ui.notify(`Code Mode custom tool disabled: ${error.message}`, "error");
+	}
+	return current;
+}
+
+function isExtensionContext(value: unknown): value is ExtensionContext {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"ui" in value &&
+			value.ui &&
+			typeof value.ui === "object" &&
+			"notify" in value.ui &&
+			typeof value.ui.notify === "function",
+	);
 }
 
 export async function registerCodeModeTools(

--- a/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
@@ -39,6 +39,7 @@ export async function registerCustomTools(
 	toolsDir?: string | readonly string[],
 	options: { isActive?(ctx: unknown): boolean } = {},
 ): Promise<CodeModeRegistration> {
+	const usesDefaultDirs = toolsDir === undefined;
 	const toolsDirs =
 		toolsDir === undefined
 			? [getCustomToolsDir(), getProjectCustomToolsDir()]
@@ -48,7 +49,11 @@ export async function registerCustomTools(
 	let previousErrors = new Map<string, string>();
 	return registerCodeModeTools(pi, {
 		getTools: (ctx) => {
-			const discovery = discoverCustomToolsFromDirectories(toolsDirs);
+			const activeDirs =
+				usesDefaultDirs && !isTrustedProjectContext(ctx)
+					? toolsDirs.slice(0, 1)
+					: toolsDirs;
+			const discovery = discoverCustomToolsFromDirectories(activeDirs);
 			previousErrors = reportCustomToolErrors(
 				ctx,
 				discovery.errors,
@@ -84,6 +89,16 @@ function isExtensionContext(value: unknown): value is ExtensionContext {
 			typeof value.ui === "object" &&
 			"notify" in value.ui &&
 			typeof value.ui.notify === "function",
+	);
+}
+
+function isTrustedProjectContext(value: unknown): value is ExtensionContext {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"isProjectTrusted" in value &&
+			typeof value.isProjectTrusted === "function" &&
+			value.isProjectTrusted(),
 	);
 }
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/types.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/types.ts
@@ -20,6 +20,7 @@ export interface CustomToolDefinition extends CodeModeToolMetadata {
 	input: CustomToolInputMode;
 	yieldTimeMs?: number | undefined;
 	sourcePath: string;
+	disabledReason?: string | undefined;
 }
 
 export interface ProgrammaticCodeModeToolDefinition

--- a/packages/pi-codex-conversion/src/tools/code-mode/types.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/types.ts
@@ -106,6 +106,7 @@ export type RuntimeResponse = (
 	  }
 ) & {
 	maxOutputTokens?: number | undefined;
+	missingCell?: true | undefined;
 	traces?: RuntimeToolTrace[] | undefined;
 	droppedTraceCount?: number | undefined;
 };

--- a/packages/pi-codex-conversion/src/tools/code-mode/types.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/types.ts
@@ -18,6 +18,7 @@ export interface CustomToolDefinition extends CodeModeToolMetadata {
 	command: string;
 	args: string[];
 	input: CustomToolInputMode;
+	yieldTimeMs?: number | undefined;
 	sourcePath: string;
 }
 

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -64,6 +64,8 @@ interface BaseExecSession {
 interface RustExecSession extends BaseExecSession {
 	kind: "rust";
 	processId: string;
+	startup: Promise<void>;
+	started: boolean;
 	tty: boolean;
 	lastSeq: number;
 	terminalCommitted: string;
@@ -214,11 +216,13 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		}
 	}
 
-	function createRustSession(input: ExecCommandInput, workdir: string, shell: string): RustExecSession {
+	function createRustSession(input: ExecCommandInput, workdir: string, shell: string, signal?: AbortSignal): RustExecSession {
 		const session: RustExecSession = {
 			kind: "rust",
 			id: nextSessionId++,
 			processId: "",
+			startup: Promise.resolve(),
+			started: false,
 			command: input.cmd,
 			buffer: "",
 			emittedBuffer: "",
@@ -237,7 +241,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			terminalCursor: 0,
 		};
 		session.processId = `pi-${session.id}`;
-		void (async () => {
+		session.startup = (async () => {
 			try {
 				const login = input.login ?? true;
 				const execution = resolveExecution(input.shell, input.cmd, input.env, baseEnv);
@@ -252,6 +256,11 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 					pipe_stdin: Boolean(input.tty),
 					arg0: null,
 				});
+				session.started = true;
+				if (signal?.aborted) {
+					session.terminating = true;
+					await bridge.request({ op: "terminate", process_id: session.processId });
+				}
 				void pollSessionLoop(session);
 			} catch (error) {
 				appendOutput(session, `${error instanceof Error ? error.message : String(error)}\n`);
@@ -260,6 +269,22 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			}
 		})();
 		return session;
+	}
+
+	async function waitForStartup(session: RustExecSession, signal?: AbortSignal): Promise<void> {
+		if (!signal) return session.startup;
+		if (signal.aborted) throw new Error("exec_command aborted");
+		let removeAbortListener = () => {};
+		const aborted = new Promise<never>((_, reject) => {
+			const onAbort = () => reject(new Error("exec_command aborted"));
+			signal.addEventListener("abort", onAbort, { once: true });
+			removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+		});
+		try {
+			await Promise.race([session.startup, aborted]);
+		} finally {
+			removeAbortListener();
+		}
 	}
 
 	async function pollSessionLoop(session: RustExecSession): Promise<void> {
@@ -280,7 +305,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		exec: async (input, cwd, signal, onUpdate) => {
 			const shell = resolveShell(input.shell);
 			const workdir = resolveWorkdir(cwd, input.workdir);
-			const session = createRustSession(input, workdir, shell);
+			const session = createRustSession(input, workdir, shell, signal);
 			sessions.set(session.id, session);
 			rememberCommand(session.id, session.command);
 			const abortCleanup = registerAbortHandler(signal, () => {
@@ -297,8 +322,12 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 					signal,
 					onUpdate ? (elapsedMs) => onUpdate(makeSnapshotResult(session, elapsedMs, input.max_output_tokens)) : undefined,
 				);
-				await pollSession(session, 0);
+				await waitForStartup(session, signal);
+				if (session.started) await pollSession(session, 0);
 				return makeExecResult(session, waitedMs, input.max_output_tokens, exposeSession, (sessionId) => sessions.delete(sessionId));
+			} catch (error) {
+				if (signal?.aborted) sessions.delete(session.id);
+				throw error;
 			} finally {
 				abortCleanup();
 			}
@@ -334,7 +363,8 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 							onUpdate ? (elapsedMs) => onUpdate(makeSnapshotSince(session, elapsedMs, updateBaseline, input.max_output_tokens)) : undefined,
 					)
 					: 0;
-			await pollSession(session, 0);
+			await waitForStartup(session, signal);
+			if (session.started) await pollSession(session, 0);
 			return makeExecResult(session, waitedMs, input.max_output_tokens, exposeSession, (sessionId) => sessions.delete(sessionId));
 		},
 		hasSession: (sessionId) => sessions.has(sessionId),

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -69,7 +69,7 @@ text(result);
 
 ## TOML fields
 
-`usage` and `command` are required. Unknown fields, invalid TOML, missing contracts, invalid filename identifiers, and unreadable directories are reported independently. Invalid definitions are omitted while `exec`, `wait`, and valid tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior.
+`usage` and `command` are required. Unknown fields, invalid TOML, and missing contracts disable only that named tool. The tool remains visible in `exec` and throws its configuration error when called, while `exec`, `wait`, and valid tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior. Invalid filename identifiers and unreadable directories, which cannot be represented as named tools, are reported through Pi.
 
 - `command`: executable name or path.
 - `args`: fixed string arguments placed before the model-provided input. Defaults to `[]`.

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -13,7 +13,7 @@ tools.<filename>(input string)
   → string result
 ```
 
-Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured). Companion scripts may live in subdirectories. Pi rediscovers definitions before every `exec`; already-running cells keep the definitions they started with.
+Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured) and `<launch-directory>/.pi/dynamic-tools/` for project-only tools. Only the launch directory is checked; parent directories are not searched. Project-local definitions override same-named global definitions. Companion scripts may live in subdirectories. Pi rediscovers definitions before every `exec`; already-running cells keep the definitions they started with.
 
 The JavaScript cell is isolated V8 with no direct filesystem, network, or Node access. The delegated command is not sandboxed by code mode: it runs locally with the user's permissions, Pi's working directory, and inherited environment.
 
@@ -69,7 +69,7 @@ text(result);
 
 ## TOML fields
 
-`usage` and `command` are required. Unknown fields, invalid TOML, missing contracts, and invalid filename identifiers prevent the extension from loading its tool catalog until corrected.
+`usage` and `command` are required. Unknown fields, invalid TOML, missing contracts, invalid filename identifiers, and unreadable directories are reported independently. Invalid definitions are omitted while `exec`, `wait`, and valid tools remain available. An invalid project-local definition still suppresses a same-named global definition rather than silently changing behavior.
 
 - `command`: executable name or path.
 - `args`: fixed string arguments placed before the model-provided input. Defaults to `[]`.
@@ -78,6 +78,7 @@ text(result);
 - `description`: optional discovery help not already clear from the name and usage.
 - `output`: optional discovery help about a reliable result contract. It does not control, validate, or transform command output. Omit it when the result is free-form.
 - `defer_loading`: defaults to `true`. Set to `false` only when the user wants the tool named in the system prompt.
+- `yield_time_ms`: non-negative integer controlling how long `exec` initially waits when the source directly invokes this tool. It overrides the model's `// @exec` value and is not exposed as a model-facing argument. If one cell directly invokes several configured tools, the largest value wins.
 
 Command resolution:
 
@@ -128,11 +129,23 @@ Every dynamic method accepts one string and resolves to one string.
 
 The `exec` cell can compose calls with normal JavaScript, including `Promise.all`, `store`/`load`, progress notifications, images, yielding, and resumable `wait` cells. Read the `exec` tool contract for those runtime details rather than duplicating it here.
 
-For long-running commands, set `yield_time_ms` near the expected runtime and prefer one long `wait` over repeated short waits. Long waits remain cancellable, and `notify()` progress remains visible.
+For long-running commands, set the definition's private `yield_time_ms` near the expected runtime and prefer one long `wait` over repeated short waits. Long waits remain cancellable, and `notify()` progress remains visible.
 
 ## Bundled examples
 
 Examples are documentation and working reference code. Installing the package does not register or enable them. Do not copy an example merely because you read this file.
+
+### `herdr_agent`
+
+`herdr_agent.toml` and `herdr-agent/herdr-agent.mjs` find and coordinate Pi agents in Herdr panels. The calling Pi session must run inside Herdr. The tool handles focused panel discovery, messaging, waits, reads, and answers; use the `herdr` skill from `more_skills` for advanced workspace and pane orchestration.
+
+### `more_skills`
+
+`more_skills.toml` and `more-skills/more-skills.mjs` list additional skill names or return one skill's Markdown body. When copied into a global definitions directory it reads the Pi agent directory's `more-skills/`; from a project-local definitions directory it reads `<launch-directory>/.pi/more-skills/`.
+
+### `sites` and `sites_documentation`
+
+Keep `sites.toml`, `sites_documentation.toml`, and the shared `sites/` directory together. These deferred tools provide a curated private-API bridge to the ChatGPT Sites beta and bounded local/backend documentation. They use Pi's configured OpenAI Codex OAuth, keep credentials and secret values out of output, and require explicit user intent for production effects such as deployment, access, environment, or domain changes.
 
 ### `spawn_agent`
 
@@ -146,7 +159,7 @@ examples/spawn-agent/
   reviewer.prompt.md
 ```
 
-When the user explicitly asks to enable the example, copy `examples/spawn_agent.toml` into the definitions directory and copy `examples/spawn-agent/` beside it, preserving that layout. The TOML's relative command then resolves to `spawn-agent/spawn-agent.mjs`.
+When the user explicitly asks to enable the example, copy `examples/spawn_agent.toml` into the chosen global or project-local definitions directory and copy `examples/spawn-agent/` beside it, preserving that layout. The TOML's relative command then resolves to `spawn-agent/spawn-agent.mjs`.
 
 The example demonstrates a promoted tool with JSON input:
 
@@ -165,11 +178,11 @@ Its contract is:
 - `message`: required standalone instructions.
 - `cwd`: optional; defaults to Pi's working directory and resolves relative to it.
 
-`explorer` runs GPT-5.6 Luna with low reasoning and a discovery-only appended system prompt.
+`explorer` runs GPT-5.6 Terra with low reasoning and a discovery-only appended system prompt.
 
-`reviewer` runs GPT-5.6 Sol with medium reasoning and the same rubric as the review extension. Before starting Pi, the example resolves the Git repository root and prepares a user message with the current ref, selected local base branch, merge base, working-tree status, appropriate diff commands, and the caller's instructions. The rubric is appended to Pi's normal system prompt; project context remains loaded.
+`reviewer` runs GPT-5.6 Luna with medium reasoning and the same rubric as the review extension. Before starting Pi, the example resolves the Git repository root and prepares a user message with the current ref, selected local base branch, merge base, working-tree status, appropriate diff commands, and the caller's instructions. The rubric is appended to Pi's normal system prompt; project context remains loaded.
 
-Both roles disable child extensions, skills, and prompt templates. Their appended prompts prohibit further subagent delegation, while project context files and Pi's built-in discovery tools remain available.
+Both roles disable child skills and prompt templates. Their appended prompts prohibit further subagent delegation, while project context files and Pi's built-in discovery tools remain available.
 
 ### `port_info`
 
@@ -206,7 +219,7 @@ examples/vent.toml
 examples/vent/vent.mjs
 ```
 
-This promoted tool validates JSON containing `thought` and optional `trigger`, then appends one timestamped entry to `VENT.md`. It creates the file with a short purpose heading when needed. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
+This tool validates JSON containing `thought` and optional `trigger`, then appends one timestamped entry to `VENT.md`. It creates the file with a short purpose heading when needed. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
 
 ### `workflows_create`
 
@@ -217,7 +230,7 @@ examples/workflows_create.toml
 examples/workflows-create/workflows-create.mjs
 ```
 
-This promoted tool validates `name`, `description`, and Markdown `body`, then atomically creates or updates `.pi/workflows/<slug>/SKILL.md`. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
+This tool validates `name`, `description`, and Markdown `body`, then atomically creates or updates `.pi/workflows/<slug>/SKILL.md`. Copy the TOML and companion directory into `dynamic-tools/`, preserving the layout, only when the user asks to enable it.
 
 ### `semantic_grep`
 

--- a/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
+++ b/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md
@@ -13,7 +13,7 @@ tools.<filename>(input string)
   → string result
 ```
 
-Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured) and `<launch-directory>/.pi/dynamic-tools/` for project-only tools. Only the launch directory is checked; parent directories are not searched. Project-local definitions override same-named global definitions. Companion scripts may live in subdirectories. Pi rediscovers definitions before every `exec`; already-running cells keep the definitions they started with.
+Definitions are top-level `*.toml` files under the Pi agent directory's `dynamic-tools/` folder (`~/.pi/agent/dynamic-tools/` by default, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when configured) and `<launch-directory>/.pi/dynamic-tools/` for trusted project-only tools. Only the launch directory is checked; parent directories are not searched. Project-local definitions are ignored unless Pi trusts the project and override same-named global definitions when active. Companion scripts may live in subdirectories. Pi rediscovers definitions before every `exec`; already-running cells keep the definitions they started with.
 
 The JavaScript cell is isolated V8 with no direct filesystem, network, or Node access. The delegated command is not sandboxed by code mode: it runs locally with the user's permissions, Pi's working directory, and inherited environment.
 

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -8,7 +8,7 @@ Exposes command-line programs to Pi through Codex-style JavaScript Code Mode. To
 pi install npm:@howaboua/pi-dynamic-tools
 ```
 
-Definitions live globally in `~/.pi/agent/dynamic-tools/` (or `$PI_CODING_AGENT_DIR/dynamic-tools/`) and per project in `<launch-directory>/.pi/dynamic-tools/`. Only the directory where Pi was launched is checked; project-local definitions override same-named global definitions. Installing the package does not enable the bundled examples.
+Definitions live globally in `~/.pi/agent/dynamic-tools/` (or `$PI_CODING_AGENT_DIR/dynamic-tools/`) and in trusted projects at `<launch-directory>/.pi/dynamic-tools/`. Only the directory where Pi was launched is checked; project-local definitions override same-named global definitions. Installing the package does not enable the bundled examples.
 
 The first `exec` with at least one definition downloads the pinned OpenAI Codex Code Mode host for the current platform and verifies its SHA-256 checksum. No host is downloaded while the definitions directory is empty.
 

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -30,7 +30,7 @@ input = "stdin"
 - Set `defer_loading = false` to put a frequent tool in the prompt.
 - Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool. This private policy overrides the model's `// @exec` value.
 
-Definitions are rediscovered before each `exec`, so additions and edits take effect during the session. Invalid definitions are reported and omitted without disabling `exec`, `wait`, or other valid tools. Deferred help stays local until the model looks up the tool through `ALL_TOOLS`.
+Definitions are rediscovered before each `exec`, so additions and edits take effect during the session. Invalid definitions with valid tool names remain callable and throw their configuration error; unrepresentable definitions are reported separately without disabling `exec`, `wait`, or other valid tools. Deferred help stays local until the model looks up the tool through `ALL_TOOLS`.
 
 Use dynamic tools for command-backed capabilities. Use a full Pi extension when the capability needs lifecycle hooks, UI, session state, provider integration, or a provider-visible schema.
 

--- a/packages/pi-dynamic-tools/README.md
+++ b/packages/pi-dynamic-tools/README.md
@@ -8,7 +8,7 @@ Exposes command-line programs to Pi through Codex-style JavaScript Code Mode. To
 pi install npm:@howaboua/pi-dynamic-tools
 ```
 
-Definitions live in `~/.pi/agent/dynamic-tools/`, or `$PI_CODING_AGENT_DIR/dynamic-tools/` when that variable is set. Installing the package does not enable the bundled examples.
+Definitions live globally in `~/.pi/agent/dynamic-tools/` (or `$PI_CODING_AGENT_DIR/dynamic-tools/`) and per project in `<launch-directory>/.pi/dynamic-tools/`. Only the directory where Pi was launched is checked; project-local definitions override same-named global definitions. Installing the package does not enable the bundled examples.
 
 The first `exec` with at least one definition downloads the pinned OpenAI Codex Code Mode host for the current platform and verifies its SHA-256 checksum. No host is downloaded while the definitions directory is empty.
 
@@ -28,12 +28,13 @@ input = "stdin"
 - `input` is `"arg"` (default) or `"stdin"`.
 - `description` and `output` are optional on-demand help.
 - Set `defer_loading = false` to put a frequent tool in the prompt.
+- Set `yield_time_ms` to force the initial `exec` wait for a directly invoked long-running tool. This private policy overrides the model's `// @exec` value.
 
-Definitions are rediscovered before each `exec`, so additions and edits take effect during the session. Deferred help stays local until the model looks up the tool through `ALL_TOOLS`.
+Definitions are rediscovered before each `exec`, so additions and edits take effect during the session. Invalid definitions are reported and omitted without disabling `exec`, `wait`, or other valid tools. Deferred help stays local until the model looks up the tool through `ALL_TOOLS`.
 
 Use dynamic tools for command-backed capabilities. Use a full Pi extension when the capability needs lifecycle hooks, UI, session state, provider integration, or a provider-visible schema.
 
-Disabled examples cover `spawn_agent`, `port_info`, `semantic_grep`, `vent`, and `workflows_create`. See [`DYNAMIC-TOOLS.md`](./DYNAMIC-TOOLS.md) for setup and troubleshooting.
+Disabled examples cover `herdr_agent`, `more_skills`, `port_info`, `semantic_grep`, `sites`, `sites_documentation`, `spawn_agent`, `vent`, and `workflows_create`. See [`DYNAMIC-TOOLS.md`](./DYNAMIC-TOOLS.md) for setup and troubleshooting.
 
 ## Runtime boundary
 

--- a/packages/pi-dynamic-tools/examples/herdr-agent/herdr-agent.mjs
+++ b/packages/pi-dynamic-tools/examples/herdr-agent/herdr-agent.mjs
@@ -1,0 +1,1090 @@
+#!/usr/bin/env node
+
+import { readFile, stat } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const ACTION_FIELDS = {
+	help: new Set(["action"]),
+	find: new Set(["action", "query", "status", "include_self"]),
+	send: new Set([
+		"action",
+		"target",
+		"text",
+		"queue",
+		// Accepted for live sessions that cached the previous contract. New callers
+		// use queue; prompt/steer are both Pi's context-sensitive submit action.
+		"mode",
+		"wait",
+		"timeout_ms",
+	]),
+	wait: new Set(["action", "target", "timeout_ms"]),
+	read: new Set(["action", "target", "source", "lines"]),
+	answer: new Set(["action", "target", "answers", "wait", "timeout_ms"]),
+};
+const STATUSES = new Set(["blocked", "done", "idle", "unknown", "working"]);
+const TERMINAL_STATUSES = new Set(["done", "idle"]);
+const LEGACY_MODES = new Set(["auto", "prompt", "steer", "follow_up"]);
+const SOURCES = new Set(["latest", "visible", "recent"]);
+const DEFAULT_TIMEOUT_MS = 300_000;
+const MAX_TIMEOUT_MS = 1_800_000;
+const MAX_TEXT_CHARS = 36_000;
+// Pi can accept PTY input before the appended session message becomes readable.
+// Leave enough time for that persistence lag before retrying the submit key.
+const DELIVERY_TIMEOUT_MS = 5_000;
+const STATUS_ORDER = { blocked: 0, working: 1, done: 2, idle: 3, unknown: 4 };
+const AGENT_DIR =
+	process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+
+function isObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanString(value, field) {
+	if (typeof value !== "string" || !value.trim())
+		throw new Error(`${field} must be a non-empty string`);
+	return value.trim();
+}
+
+function optionalBoolean(value, field) {
+	if (value !== undefined && typeof value !== "boolean")
+		throw new Error(`${field} must be a boolean when provided`);
+	return value;
+}
+
+function parseTimeout(value) {
+	if (value === undefined) return DEFAULT_TIMEOUT_MS;
+	if (!Number.isInteger(value) || value < 1 || value > MAX_TIMEOUT_MS)
+		throw new Error(
+			`timeout_ms must be an integer from 1 to ${MAX_TIMEOUT_MS}`,
+		);
+	return value;
+}
+
+function parseAnswers(value) {
+	if (!Array.isArray(value)) throw new Error("answers must be an array");
+	return value.map((answer, index) => {
+		if (!isObject(answer))
+			throw new Error(`answers[${index}] must be an object`);
+		const allowed = new Set(["selections", "other", "comment"]);
+		const unknown = Object.keys(answer).filter((key) => !allowed.has(key));
+		if (unknown.length)
+			throw new Error(
+				`unknown answers[${index}] field(s): ${unknown.join(", ")}`,
+			);
+		if (
+			answer.selections !== undefined &&
+			(!Array.isArray(answer.selections) ||
+				answer.selections.some((item) => typeof item !== "string" || !item))
+		)
+			throw new Error(`answers[${index}].selections must be string labels`);
+		for (const field of ["other", "comment"])
+			if (answer[field] !== undefined && typeof answer[field] !== "string")
+				throw new Error(`answers[${index}].${field} must be a string`);
+		return {
+			...(answer.selections ? { selections: answer.selections } : {}),
+			...(answer.other !== undefined ? { other: answer.other } : {}),
+			...(answer.comment !== undefined ? { comment: answer.comment } : {}),
+		};
+	});
+}
+
+export function parseRequest(text) {
+	if (text.trim() === "help") return { action: "help" };
+	let value;
+	try {
+		value = JSON.parse(text);
+	} catch (error) {
+		throw new Error(
+			`input must be \"help\" or valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isObject(value)) throw new Error("input must be a JSON object");
+	if (
+		typeof value.action !== "string" ||
+		!Object.hasOwn(ACTION_FIELDS, value.action)
+	)
+		throw new Error(
+			`action must be one of: ${Object.keys(ACTION_FIELDS).join(", ")}`,
+		);
+	const unknown = Object.keys(value).filter(
+		(key) => !ACTION_FIELDS[value.action].has(key),
+	);
+	if (unknown.length)
+		throw new Error(`unknown ${value.action} field(s): ${unknown.join(", ")}`);
+	if (value.action === "help") return { action: "help" };
+
+	if (value.action === "find") {
+		if (value.query !== undefined && typeof value.query !== "string")
+			throw new Error("query must be a string when provided");
+		if (value.status !== undefined && !STATUSES.has(value.status))
+			throw new Error("status is invalid");
+		return {
+			action: "find",
+			...(value.query?.trim() ? { query: value.query.trim() } : {}),
+			...(value.status ? { status: value.status } : {}),
+			include_self:
+				optionalBoolean(value.include_self, "include_self") === true,
+		};
+	}
+
+	const target = cleanString(value.target, "target");
+	if (value.action === "wait")
+		return {
+			action: "wait",
+			target,
+			timeout_ms: parseTimeout(value.timeout_ms),
+		};
+	if (value.action === "read") {
+		const source = value.source ?? "latest";
+		if (!SOURCES.has(source)) throw new Error("source is invalid");
+		const lines = value.lines ?? 40;
+		if (!Number.isInteger(lines) || lines < 1 || lines > 200)
+			throw new Error("lines must be an integer from 1 to 200");
+		return { action: "read", target, source, lines };
+	}
+	if (value.action === "answer")
+		return {
+			action: "answer",
+			target,
+			answers: parseAnswers(value.answers),
+			wait: optionalBoolean(value.wait, "wait") ?? true,
+			timeout_ms: parseTimeout(value.timeout_ms),
+		};
+
+	if (value.mode !== undefined && !LEGACY_MODES.has(value.mode))
+		throw new Error("mode is invalid");
+	if (value.mode !== undefined && value.queue !== undefined)
+		throw new Error("use queue or legacy mode, not both");
+	const queue =
+		optionalBoolean(value.queue, "queue") ?? value.mode === "follow_up";
+	return {
+		action: "send",
+		target,
+		text: cleanString(value.text, "text"),
+		queue,
+		wait: optionalBoolean(value.wait, "wait") ?? true,
+		timeout_ms: parseTimeout(value.timeout_ms),
+	};
+}
+
+class HerdrClient {
+	constructor(socketPath = process.env.HERDR_SOCKET_PATH) {
+		if (!socketPath)
+			throw new Error(
+				"HERDR_SOCKET_PATH is not set; run the calling Pi session inside Herdr",
+			);
+		this.socketPath = socketPath;
+	}
+
+	request(method, params = {}) {
+		return new Promise((resolve, reject) => {
+			const id = `herdr-agent:${crypto.randomUUID()}`;
+			let buffer = "";
+			let settled = false;
+			const socket = createConnection(this.socketPath, () =>
+				socket.write(`${JSON.stringify({ id, method, params })}\n`),
+			);
+			socket.setEncoding("utf8");
+			const timer = setTimeout(
+				() => finish(new Error(`Herdr ${method} timed out`)),
+				10_000,
+			);
+			timer.unref();
+			function finish(error, result) {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				socket.destroy();
+				if (error) reject(error);
+				else resolve(result);
+			}
+			socket.on("error", (error) => finish(error));
+			socket.on("data", (chunk) => {
+				buffer += chunk;
+				if (buffer.length > 16 * 1024 * 1024)
+					return finish(new Error(`Herdr ${method} response is too large`));
+				const newline = buffer.indexOf("\n");
+				if (newline < 0) return;
+				let response;
+				try {
+					response = JSON.parse(buffer.slice(0, newline));
+				} catch (error) {
+					return finish(
+						new Error(`Herdr returned invalid JSON: ${error.message}`),
+					);
+				}
+				if (response.error)
+					return finish(
+						new Error(response.error.message || JSON.stringify(response.error)),
+					);
+				if (!("result" in response))
+					return finish(new Error(`Herdr ${method} returned no result`));
+				finish(undefined, response.result);
+			});
+		});
+	}
+}
+
+function optionalString(value) {
+	return typeof value === "string" ? value : undefined;
+}
+
+function parseAskChoice(value) {
+	if (!isObject(value) || typeof value.label !== "string") return undefined;
+	return {
+		label: value.label,
+		...(typeof value.description === "string"
+			? { description: value.description }
+			: {}),
+	};
+}
+
+function parseAskPrompt(value) {
+	if (!isObject(value) || typeof value.title !== "string") return undefined;
+	return {
+		title: value.title,
+		multiple: value.multiple === true,
+		choices: (Array.isArray(value.choices) ? value.choices : [])
+			.map(parseAskChoice)
+			.filter(Boolean),
+		...(typeof value.body === "string" ? { body: value.body } : {}),
+	};
+}
+
+function parseAskCall(part) {
+	if (!isObject(part) || part.type !== "toolCall" || part.name !== "ask")
+		return undefined;
+	if (typeof part.id !== "string" || !isObject(part.arguments))
+		return undefined;
+	const prompts = (
+		Array.isArray(part.arguments.prompts) ? part.arguments.prompts : []
+	)
+		.map(parseAskPrompt)
+		.filter(Boolean);
+	if (!prompts.length) return undefined;
+	return {
+		tool_call_id: part.id,
+		handoff: part.arguments.handoff === true,
+		prompts,
+	};
+}
+
+export function parseSessionLines(lines) {
+	const nodes = new Map();
+	let leaf_id;
+	for (const line of lines) {
+		let entry;
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (!isObject(entry) || typeof entry.id !== "string") continue;
+		const node = {
+			parent_id: typeof entry.parentId === "string" ? entry.parentId : null,
+			asks: [],
+		};
+		const message = entry.message;
+		if (isObject(message) && message.role === "assistant") {
+			const text = [];
+			if (typeof message.content === "string") text.push(message.content);
+			if (Array.isArray(message.content))
+				for (const part of message.content) {
+					if (
+						isObject(part) &&
+						part.type === "text" &&
+						typeof part.text === "string"
+					)
+						text.push(part.text);
+					const ask = parseAskCall(part);
+					if (ask) node.asks.push(ask);
+				}
+			node.assistant_entry = {
+				id: entry.id,
+				...(typeof message.stopReason === "string"
+					? { stop_reason: message.stopReason }
+					: {}),
+			};
+			const joined = text.join("");
+			if (joined)
+				node.assistant = {
+					id: entry.id,
+					text: joined,
+					...(typeof message.stopReason === "string"
+						? { stop_reason: message.stopReason }
+						: {}),
+				};
+		}
+		if (isObject(message) && message.role === "user") {
+			const text = [];
+			if (typeof message.content === "string") text.push(message.content);
+			if (Array.isArray(message.content))
+				for (const part of message.content)
+					if (
+						isObject(part) &&
+						part.type === "text" &&
+						typeof part.text === "string"
+					)
+						text.push(part.text);
+			const joined = text.join("");
+			if (joined) node.user = { id: entry.id, text: joined };
+		}
+		if (
+			isObject(message) &&
+			(message.role === "toolResult" || message.role === "tool")
+		)
+			node.resolved_tool_call_id = optionalString(
+				message.toolCallId ?? message.tool_call_id,
+			);
+		nodes.set(entry.id, node);
+		leaf_id = entry.id;
+	}
+
+	let current = leaf_id;
+	let assistant;
+	let assistant_entry;
+	let user;
+	let ask;
+	const resolved = new Set();
+	const visited = new Set();
+	while (current && !visited.has(current)) {
+		visited.add(current);
+		const node = nodes.get(current);
+		if (!node) break;
+		if (node.resolved_tool_call_id) resolved.add(node.resolved_tool_call_id);
+		if (!ask)
+			ask = [...node.asks]
+				.reverse()
+				.find((candidate) => !resolved.has(candidate.tool_call_id));
+		assistant ??= node.assistant;
+		assistant_entry ??= node.assistant_entry;
+		user ??= node.user;
+		current = node.parent_id;
+	}
+	return {
+		leaf_id,
+		assistant,
+		assistant_entry,
+		user,
+		ask,
+	};
+}
+
+class SessionReader {
+	cache = new Map();
+
+	async read(path) {
+		if (!path) return { leaf_id: undefined };
+		let metadata;
+		try {
+			metadata = await stat(path);
+		} catch (error) {
+			if (error?.code === "ENOENT") return { leaf_id: undefined, path };
+			throw error;
+		}
+		const prior = this.cache.get(path);
+		if (prior?.size === metadata.size && prior?.mtime_ms === metadata.mtimeMs)
+			return prior.view;
+		const text = await readFile(path, "utf8");
+		const view = {
+			...parseSessionLines(text.split("\n")),
+			path,
+			size: metadata.size,
+			mtime_ms: metadata.mtimeMs,
+		};
+		this.cache.set(path, {
+			size: metadata.size,
+			mtime_ms: metadata.mtimeMs,
+			view,
+		});
+		return view;
+	}
+}
+
+async function getAgent(client, target) {
+	return (await client.request("agent.get", { target })).agent;
+}
+
+async function getSnapshot(client) {
+	return (await client.request("session.snapshot", {})).snapshot;
+}
+
+function enrichPanels(snapshot) {
+	const tabs = new Map(snapshot.tabs.map((tab) => [tab.tab_id, tab.label]));
+	const workspaces = new Map(
+		snapshot.workspaces.map((workspace) => [
+			workspace.workspace_id,
+			workspace.label,
+		]),
+	);
+	return (snapshot.agents.length ? snapshot.agents : snapshot.panes).map(
+		(panel) => ({
+			...panel,
+			tab_label: tabs.get(panel.tab_id),
+			workspace_label: workspaces.get(panel.workspace_id),
+		}),
+	);
+}
+
+function panelHaystack(panel) {
+	return [
+		panel.pane_id,
+		panel.terminal_id,
+		panel.name,
+		panel.cwd,
+		panel.foreground_cwd,
+		panel.tab_label,
+		panel.workspace_label,
+	]
+		.filter(Boolean)
+		.join("\n")
+		.toLowerCase();
+}
+
+async function findPanels(client, request) {
+	const query = request.query?.toLowerCase();
+	return enrichPanels(await getSnapshot(client))
+		.filter((panel) => panel.agent === "pi")
+		.filter(
+			(panel) =>
+				request.include_self || panel.pane_id !== process.env.HERDR_PANE_ID,
+		)
+		.filter((panel) => !request.status || panel.agent_status === request.status)
+		.filter((panel) => !query || panelHaystack(panel).includes(query))
+		.sort(
+			(a, b) =>
+				STATUS_ORDER[a.agent_status] - STATUS_ORDER[b.agent_status] ||
+				a.pane_id.localeCompare(b.pane_id),
+		);
+}
+
+function compactPanel(panel) {
+	return {
+		id: panel.pane_id,
+		status: panel.agent_status,
+		cwd: panel.foreground_cwd,
+		...(panel.name || panel.tab_label || panel.workspace_label
+			? { label: panel.name || panel.tab_label || panel.workspace_label }
+			: {}),
+	};
+}
+
+async function resolvePanel(client, target) {
+	let directError;
+	try {
+		const direct = await getAgent(client, target);
+		if (direct.agent === "pi") return direct;
+		directError = new Error(`${target} is not a Pi panel`);
+	} catch (error) {
+		directError = error;
+	}
+	const matches = await findPanels(client, {
+		action: "find",
+		query: target,
+		include_self: true,
+	});
+	if (matches.length === 1) return matches[0];
+	if (matches.length > 1)
+		throw new Error(
+			`ambiguous target ${JSON.stringify(target)}; candidates: ${matches
+				.slice(0, 10)
+				.map((panel) => panel.pane_id)
+				.join(", ")}`,
+		);
+	throw directError instanceof Error
+		? directError
+		: new Error(`no Pi panel matches ${JSON.stringify(target)}`);
+}
+
+function assertRemote(panel) {
+	if (panel.pane_id === process.env.HERDR_PANE_ID)
+		throw new Error(
+			"refusing to target the calling Pi panel from its own tool call",
+		);
+}
+
+function sessionPath(panel) {
+	return panel.agent_session?.kind === "path"
+		? panel.agent_session.value
+		: undefined;
+}
+
+async function terminalRead(client, target, source = "visible", lines = 40) {
+	return (
+		await client.request("agent.read", {
+			target,
+			source,
+			format: "text",
+			lines,
+			strip_ansi: true,
+		})
+	).read.text;
+}
+
+export function isBusyScreen(text) {
+	const tail = text.split("\n").slice(-18).join("\n");
+	return /Auto-compacting\.\.\.|Queued message for after compaction|(?:^|\s)Working\.\.\.|Retrying(?:\s|…|\.\.\.)/m.test(
+		tail,
+	);
+}
+
+async function isBusy(client, panel) {
+	if (panel.agent_status === "working") return true;
+	if (!TERMINAL_STATUSES.has(panel.agent_status)) return false;
+	return isBusyScreen(await terminalRead(client, panel.pane_id, "visible", 30));
+}
+
+function sleep(milliseconds) {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function boundText(text) {
+	if (text.length <= MAX_TEXT_CHARS) return { text };
+	return { text: `${text.slice(0, MAX_TEXT_CHARS)}\n…`, truncated: true };
+}
+
+function askOutput(ask) {
+	if (!ask) return undefined;
+	return {
+		handoff: ask.handoff,
+		prompts: ask.prompts.map((prompt) => ({
+			title: prompt.title,
+			multiple: prompt.multiple,
+			choices: prompt.choices.map((choice) => choice.label),
+			...(prompt.body ? { body: prompt.body } : {}),
+		})),
+	};
+}
+
+export function herdrHelp() {
+	return {
+		call: "await tools.herdr_agent(JSON.stringify(request))",
+		actions: {
+			find: {
+				request: {
+					action: "find",
+					query: "string?",
+					status: "idle | working | blocked | done?",
+					include_self: "boolean?",
+				},
+				returns: "compact matching Pi panels",
+			},
+			send: {
+				request: {
+					action: "send",
+					target: "string",
+					text: "string",
+					queue: "boolean? (default false)",
+					wait: "boolean? (default true)",
+					timeout_ms: "integer? (default 300000)",
+				},
+				returns: "new assistant text, blocked ask, timeout, or acknowledgement",
+			},
+			wait: {
+				request: { action: "wait", target: "string", timeout_ms: "integer?" },
+				returns: "settled latest assistant text or blocked ask",
+			},
+			read: {
+				request: {
+					action: "read",
+					target: "string",
+					source: "latest | visible | recent? (default latest)",
+					lines: "1..200?",
+				},
+				returns: "latest assistant text or bounded terminal output",
+			},
+			answer: {
+				request: {
+					action: "answer",
+					target: "string",
+					answers:
+						"Array<{ selections?: string[], other?: string, comment?: string }>",
+					wait: "boolean? (default true)",
+					timeout_ms: "integer?",
+				},
+				returns: "next assistant text, next ask, or completion",
+			},
+		},
+		advanced: {
+			load: 'await tools.more_skills("herdr")',
+			covers: [
+				"workspace/tab/pane lifecycle",
+				"generic command panes",
+				"raw terminal input",
+				"output and agent-status waits",
+			],
+		},
+	};
+}
+
+function stableKey(panel, view) {
+	return [
+		panel.agent_status,
+		view.path,
+		view.size,
+		view.mtime_ms,
+		view.leaf_id,
+		view.assistant_entry?.id,
+	].join(":");
+}
+
+async function waitForPanel(
+	client,
+	reader,
+	paneId,
+	baseline,
+	timeoutMs,
+	options = {},
+) {
+	const deadline = Date.now() + timeoutMs;
+	let latestPanel = await getAgent(client, paneId);
+	let latestView = await reader.read(sessionPath(latestPanel));
+	let candidate;
+	let candidateSince = 0;
+	while (Date.now() < deadline) {
+		latestPanel = await getAgent(client, paneId);
+		latestView = await reader.read(sessionPath(latestPanel));
+		if (latestPanel.agent_status === "blocked") {
+			const priorAskStillClearing =
+				options.ignore_blocked_ask_id &&
+				latestView.ask?.tool_call_id === options.ignore_blocked_ask_id;
+			if (
+				!(options.ignore_blocked_without_ask && !latestView.ask) &&
+				!priorAskStillClearing
+			)
+				return {
+					pane: paneId,
+					status: "blocked",
+					...(askOutput(latestView.ask)
+						? { ask: askOutput(latestView.ask) }
+						: {}),
+				};
+			await sleep(100);
+			continue;
+		}
+		const terminal = TERMINAL_STATUSES.has(latestPanel.agent_status);
+		const busy = terminal ? await isBusy(client, latestPanel) : false;
+		const sessionChanged = baseline.path !== latestView.path;
+		const assistantChanged =
+			sessionChanged ||
+			latestView.assistant_entry?.id !== baseline.assistant_entry_id;
+		const branchAdvanced =
+			sessionChanged || latestView.leaf_id !== baseline.leaf_id;
+		const qualifies =
+			!baseline.require_new ||
+			assistantChanged ||
+			(options.allow_branch_advance && branchAdvanced);
+		if (terminal && !busy && qualifies) {
+			const key = stableKey(latestPanel, latestView);
+			if (candidate === key && Date.now() - candidateSince >= 500) {
+				if (
+					assistantChanged &&
+					latestView.assistant_entry?.stop_reason === "error"
+				)
+					throw new Error(
+						latestView.assistant?.text ||
+							`${paneId} assistant stopped with an error`,
+					);
+				const newReply =
+					latestView.assistant?.id !== baseline.reply_id
+						? latestView.assistant
+						: undefined;
+				return {
+					pane: paneId,
+					status: latestPanel.agent_status,
+					...(newReply ? boundText(newReply.text) : { completed: true }),
+					...(sessionChanged ? { session_changed: true } : {}),
+				};
+			}
+			if (candidate !== key) {
+				candidate = key;
+				candidateSince = Date.now();
+			}
+		} else {
+			candidate = undefined;
+			candidateSince = 0;
+		}
+		await sleep(250);
+	}
+	return {
+		pane: paneId,
+		status: latestPanel.agent_status,
+		timed_out: true,
+	};
+}
+
+async function readKeybindings() {
+	try {
+		const value = JSON.parse(
+			await readFile(join(AGENT_DIR, "keybindings.json"), "utf8"),
+		);
+		return isObject(value) ? value : {};
+	} catch {
+		return {};
+	}
+}
+
+function keyFor(bindings, action, fallback) {
+	const configured = bindings[action];
+	if (typeof configured === "string" && configured) return configured;
+	if (Array.isArray(configured)) {
+		const first = configured.find((key) => typeof key === "string" && key);
+		if (first) return first;
+		if (configured.length === 0)
+			throw new Error(`${action} has no configured keybinding`);
+	}
+	return fallback;
+}
+
+export function resolveSendDisposition({ busy, queue }) {
+	if (busy && queue)
+		return {
+			keybinding: "app.message.followUp",
+			fallback: "alt+enter",
+			mode: "follow_up",
+		};
+	return {
+		keybinding: "tui.input.submit",
+		fallback: "enter",
+		mode: busy ? "steer" : "prompt",
+	};
+}
+
+async function sendInput(client, paneId, input) {
+	await client.request("pane.send_input", {
+		pane_id: paneId,
+		...(input.text !== undefined ? { text: input.text } : {}),
+		...(input.keys ? { keys: input.keys } : {}),
+	});
+}
+
+function normalizeDeliveryText(value) {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+export function detectDelivery(baseline, view, screen, text) {
+	if (view.user?.id !== baseline.user?.id && view.user?.text === text)
+		return "delivered";
+	const normalizedScreen = normalizeDeliveryText(screen);
+	const prefix = normalizeDeliveryText(text).slice(0, 80);
+	if (prefix && normalizedScreen.includes(`Follow-up: ${prefix}`))
+		return "queued_follow_up";
+	if (prefix && normalizedScreen.includes(`Steering: ${prefix}`))
+		return "queued_steer";
+	return undefined;
+}
+
+async function waitForDelivery(client, reader, paneId, baseline, text) {
+	const deadline = Date.now() + DELIVERY_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		const panel = await getAgent(client, paneId);
+		const [view, screen] = await Promise.all([
+			reader.read(sessionPath(panel)),
+			terminalRead(client, paneId, "visible", 50),
+		]);
+		const delivery = detectDelivery(baseline, view, screen, text);
+		if (delivery) return delivery;
+		await sleep(50);
+	}
+	return undefined;
+}
+
+function down(count, key) {
+	return Array.from({ length: Math.max(0, count) }, () => key);
+}
+
+export function planAskAnswer(prompts, answers, controls = {}) {
+	if (answers.length !== prompts.length)
+		throw new Error(
+			`answer requires ${prompts.length} response${prompts.length === 1 ? "" : "s"}, in prompt order`,
+		);
+	const keys = {
+		down: controls.down || "down",
+		confirm: controls.confirm || "enter",
+		next: controls.next || "tab",
+	};
+	const steps = [];
+	for (const [promptIndex, prompt] of prompts.entries()) {
+		const answer = answers[promptIndex];
+		const labels = answer.selections ?? [];
+		const indexes = labels.map((label) => {
+			const index = prompt.choices.findIndex(
+				(choice) => choice.label === label,
+			);
+			if (index < 0)
+				throw new Error(
+					`unknown choice ${JSON.stringify(label)} for ${JSON.stringify(prompt.title)}`,
+				);
+			return index;
+		});
+		if (new Set(indexes).size !== indexes.length)
+			throw new Error(`duplicate choice for ${JSON.stringify(prompt.title)}`);
+		if (!prompt.multiple && indexes.length > 1)
+			throw new Error(`${JSON.stringify(prompt.title)} accepts one choice`);
+		if (!prompt.multiple && indexes.length && answer.other !== undefined)
+			throw new Error(
+				`${JSON.stringify(prompt.title)} cannot combine a choice with Other/rephrase`,
+			);
+		indexes.sort((a, b) => a - b);
+		let focus = 0;
+		for (const index of indexes) {
+			steps.push({ keys: [...down(index - focus, keys.down), keys.confirm] });
+			focus = index;
+		}
+		const needsOther =
+			answer.other !== undefined ||
+			(indexes.length === 0 && answer.comment !== undefined);
+		if (needsOther) {
+			steps.push({
+				keys: [...down(prompt.choices.length - focus, keys.down), keys.confirm],
+			});
+			steps.push({ text: answer.other ?? "", keys: [keys.confirm] });
+			focus = prompt.choices.length;
+		}
+		if (answer.comment !== undefined) {
+			steps.push({
+				keys: [
+					...down(prompt.choices.length + 1 - focus, keys.down),
+					keys.confirm,
+				],
+			});
+			steps.push({ text: answer.comment, keys: [keys.next] });
+		} else {
+			steps.push({ keys: [keys.next] });
+		}
+	}
+	steps.push({ keys: [keys.confirm], final: true });
+	return steps;
+}
+
+function askFrame(screen) {
+	const lines = screen.split("\n");
+	const review = lines.map((line) => line.includes("Review")).lastIndexOf(true);
+	return (review >= 0 ? lines.slice(review) : lines.slice(-30)).join("\n");
+}
+
+export function inspectAskScreen(screen, ask) {
+	const frame = askFrame(screen);
+	const selected = frame.match(/^>\s+(.*?)\s*$/m)?.[1];
+	const review =
+		/^\s*Review\s*$/m.test(frame) && frame.includes("enter submit");
+	const current_prompt = review
+		? "Review"
+		: ask?.prompts.find((prompt) =>
+				frame.split("\n").some((line) => line.trim() === prompt.title),
+			)?.title;
+	const prompt =
+		frame.includes("Review") &&
+		frame.includes("Other/rephrase") &&
+		frame.includes("Comment (optional)");
+	return { recognized: prompt || review, current_prompt, selected };
+}
+
+async function answerAsk(client, reader, panel, request) {
+	if (panel.agent_status !== "blocked")
+		throw new Error(
+			`${panel.pane_id} is ${panel.agent_status}, not blocked on ask`,
+		);
+	const baseline = await reader.read(sessionPath(panel));
+	if (!baseline.ask)
+		throw new Error(
+			`${panel.pane_id} has no pending pi-ask call on its active branch`,
+		);
+	const screen = await terminalRead(client, panel.pane_id, "visible", 80);
+	const inspection = inspectAskScreen(screen, baseline.ask);
+	const first = baseline.ask.prompts[0];
+	const expectedSelection = first?.choices[0]?.label ?? "Other/rephrase";
+	if (
+		!inspection.recognized ||
+		inspection.current_prompt !== first?.title ||
+		inspection.selected !== expectedSelection
+	)
+		throw new Error(
+			"ask UI is not at the first prompt's default selection; refusing to send guessed keys",
+		);
+	const bindings = await readKeybindings();
+	const steps = planAskAnswer(baseline.ask.prompts, request.answers, {
+		down: keyFor(bindings, "tui.select.down", "down"),
+		confirm: keyFor(bindings, "tui.select.confirm", "enter"),
+		next: keyFor(bindings, "tui.input.tab", "tab"),
+	});
+	for (const step of steps) {
+		await sendInput(client, panel.pane_id, step);
+		await sleep(35);
+		if (!step.final) {
+			const current = await getAgent(client, panel.pane_id);
+			if (current.agent_status !== "blocked")
+				throw new Error("ask closed before all requested answers were entered");
+			const currentScreen = await terminalRead(
+				client,
+				panel.pane_id,
+				"visible",
+				80,
+			);
+			if (!inspectAskScreen(currentScreen, baseline.ask).recognized)
+				throw new Error(
+					"ask UI became unrecognized; stopped without retrying input",
+				);
+		}
+	}
+	if (!request.wait) return { pane: panel.pane_id, answered: true };
+	return waitForPanel(
+		client,
+		reader,
+		panel.pane_id,
+		{
+			path: baseline.path,
+			leaf_id: baseline.leaf_id,
+			assistant_entry_id: baseline.assistant_entry?.id,
+			reply_id: baseline.assistant?.id,
+			require_new: true,
+		},
+		request.timeout_ms,
+		{
+			allow_branch_advance: true,
+			ignore_blocked_without_ask: true,
+			ignore_blocked_ask_id: baseline.ask.tool_call_id,
+		},
+	);
+}
+
+async function execute(request) {
+	if (request.action === "help") return herdrHelp();
+	const client = new HerdrClient();
+	const reader = new SessionReader();
+	if (request.action === "find") {
+		const panels = await findPanels(client, request);
+		return { panels: panels.slice(0, 30).map(compactPanel) };
+	}
+	const panel = await resolvePanel(client, request.target);
+	if (request.action === "read") {
+		if (request.source !== "latest") {
+			const output = boundText(
+				await terminalRead(
+					client,
+					panel.pane_id,
+					request.source,
+					request.lines,
+				),
+			);
+			return { pane: panel.pane_id, status: panel.agent_status, ...output };
+		}
+		const view = await reader.read(sessionPath(panel));
+		return {
+			pane: panel.pane_id,
+			status: panel.agent_status,
+			...(view.assistant ? boundText(view.assistant.text) : { text: null }),
+			...(panel.agent_status === "blocked" && askOutput(view.ask)
+				? { ask: askOutput(view.ask) }
+				: {}),
+		};
+	}
+	assertRemote(panel);
+	if (request.action === "wait") {
+		const view = await reader.read(sessionPath(panel));
+		return waitForPanel(
+			client,
+			reader,
+			panel.pane_id,
+			{
+				path: view.path,
+				leaf_id: view.leaf_id,
+				assistant_entry_id: view.assistant_entry?.id,
+				reply_id: undefined,
+				require_new: false,
+			},
+			request.timeout_ms,
+		);
+	}
+	if (request.action === "answer")
+		return answerAsk(client, reader, panel, request);
+
+	const baseline = await reader.read(sessionPath(panel));
+	if (panel.agent_status === "blocked")
+		throw new Error(
+			`${panel.pane_id} is blocked${baseline.ask ? " on ask; use action=answer" : ""}`,
+		);
+	const busy = await isBusy(client, panel);
+	const disposition = resolveSendDisposition({ busy, queue: request.queue });
+	const bindings = await readKeybindings();
+	const key = keyFor(bindings, disposition.keybinding, disposition.fallback);
+	// Paste and submit separately. A combined PTY write can hit Pi's
+	// streaming-to-idle transition before the editor has consumed the paste.
+	await sendInput(client, panel.pane_id, { text: request.text });
+	await sleep(40);
+	await sendInput(client, panel.pane_id, { keys: [key] });
+	let delivery = await waitForDelivery(
+		client,
+		reader,
+		panel.pane_id,
+		baseline,
+		request.text,
+	);
+	if (!delivery) {
+		// Retrying only the submit key is duplicate-safe: if Pi accepted the first
+		// key, its editor is empty; if it missed the key, the pasted text remains.
+		const current = await getAgent(client, panel.pane_id);
+		const retryDisposition = resolveSendDisposition({
+			busy: await isBusy(client, current),
+			queue: request.queue,
+		});
+		const retryKey = keyFor(
+			bindings,
+			retryDisposition.keybinding,
+			retryDisposition.fallback,
+		);
+		await sendInput(client, panel.pane_id, { keys: [retryKey] });
+		delivery = await waitForDelivery(
+			client,
+			reader,
+			panel.pane_id,
+			baseline,
+			request.text,
+		);
+	}
+	if (!delivery)
+		throw new Error(
+			`${panel.pane_id} did not accept the message; the text may remain in Pi's editor`,
+		);
+	if (!request.wait)
+		return {
+			pane: panel.pane_id,
+			sent: true,
+			mode: disposition.mode,
+			delivery,
+		};
+	return waitForPanel(
+		client,
+		reader,
+		panel.pane_id,
+		{
+			path: baseline.path,
+			leaf_id: baseline.leaf_id,
+			assistant_entry_id: baseline.assistant_entry?.id,
+			reply_id: baseline.assistant?.id,
+			require_new: true,
+		},
+		request.timeout_ms,
+	);
+}
+
+async function readStdin() {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	return input;
+}
+
+async function main() {
+	const result = await execute(parseRequest(await readStdin()));
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname)
+	main().catch((error) => {
+		process.stderr.write(
+			`herdr_agent: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
+		process.exitCode = 1;
+	});

--- a/packages/pi-dynamic-tools/examples/herdr_agent.toml
+++ b/packages/pi-dynamic-tools/examples/herdr_agent.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.herdr_agent("help") // Pi-panel messaging; advanced orchestration: await tools.more_skills("herdr")'''
+description = '''Find and coordinate with Pi agents in Herdr panels. send automatically prompts an idle Pi or steers a working Pi; queue=true waits behind current work. It waits by default and returns only the new assistant text. For advanced workspace/tab/pane orchestration, generic command panes, raw terminal input, or output waits, load the extra skill exactly with: await tools.more_skills("herdr")'''
+output = "Compact JSON: pane/status plus only relevant panels, text, ask, acknowledgement, timeout, or truncation fields."
+command = "./herdr-agent/herdr-agent.mjs"
+input = "stdin"
+defer_loading = false

--- a/packages/pi-dynamic-tools/examples/more-skills/more-skills.mjs
+++ b/packages/pi-dynamic-tools/examples/more-skills/more-skills.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_OUTPUT_BYTES = 48 * 1024;
+const MAX_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const SKILL_FILENAMES = ["SKILL.md", "SKILL.MD"];
+
+export function defaultSkillsDir() {
+	const scriptPath = fileURLToPath(import.meta.url);
+	const agentDir = dirname(dirname(dirname(scriptPath)));
+	return join(agentDir, "more-skills");
+}
+
+function decodeQuotedScalar(value, path, field) {
+	if (value.startsWith('"')) {
+		try {
+			const parsed = JSON.parse(value);
+			if (typeof parsed !== "string") throw new Error();
+			return parsed;
+		} catch {
+			throw new Error(`${path}: ${field} must be a valid quoted YAML string`);
+		}
+	}
+	if (value.startsWith("'")) {
+		if (!value.endsWith("'") || value.length < 2) {
+			throw new Error(`${path}: ${field} must be a valid quoted YAML string`);
+		}
+		return value.slice(1, -1).replace(/''/g, "'");
+	}
+	return value;
+}
+
+function parseBlockScalar(lines, start, parentIndent, style) {
+	const values = [];
+	let commonIndent;
+	let index = start;
+	for (; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (!line.trim()) {
+			values.push("");
+			continue;
+		}
+		const indent = line.match(/^\s*/)[0].length;
+		if (indent <= parentIndent) break;
+		commonIndent =
+			commonIndent === undefined ? indent : Math.min(commonIndent, indent);
+		values.push(line);
+	}
+	const indent = commonIndent ?? parentIndent + 1;
+	const normalized = values.map((line) =>
+		line.slice(Math.min(indent, line.length)),
+	);
+	const value =
+		style === ">"
+			? normalized.join("\n").replace(/([^\n])\n(?=[^\n])/g, "$1 ")
+			: normalized.join("\n");
+	return { value: value.trim(), nextIndex: index };
+}
+
+export function parseSkillDocument(content, label) {
+	const normalized = content.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+	const lines = normalized.split("\n");
+	if (lines[0] !== "---") {
+		throw new Error(`${label}: missing YAML frontmatter`);
+	}
+	const end = lines.findIndex(
+		(line, index) => index > 0 && (line === "---" || line === "..."),
+	);
+	if (end < 0) throw new Error(`${label}: unterminated YAML frontmatter`);
+
+	const fields = {};
+	for (let index = 1; index < end; index += 1) {
+		const line = lines[index];
+		const match = /^(\s*)(name|description):\s*(.*)$/.exec(line);
+		if (!match) continue;
+		const [, whitespace, field, rawValue] = match;
+		const block = /^([>|])[-+]?\s*$/.exec(rawValue);
+		if (block) {
+			const parsed = parseBlockScalar(
+				lines.slice(0, end),
+				index + 1,
+				whitespace.length,
+				block[1],
+			);
+			fields[field] = parsed.value;
+			index = parsed.nextIndex - 1;
+			continue;
+		}
+		fields[field] = decodeQuotedScalar(rawValue.trim(), label, field);
+	}
+	return {
+		frontmatter: fields,
+		body: lines
+			.slice(end + 1)
+			.join("\n")
+			.trim(),
+	};
+}
+
+function validateSkill(skill) {
+	const errors = [];
+	if (!skill.name) errors.push("name is required");
+	else {
+		if (skill.name === "list")
+			errors.push('name "list" is reserved by the loader');
+		if (skill.name.length > MAX_NAME_LENGTH)
+			errors.push(`name exceeds ${MAX_NAME_LENGTH} characters`);
+		if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(skill.name)) {
+			errors.push(
+				"name must contain only lowercase letters, numbers, and single hyphens",
+			);
+		}
+	}
+	if (!skill.description?.trim()) errors.push("description is required");
+	else if (skill.description.length > MAX_DESCRIPTION_LENGTH) {
+		errors.push(`description exceeds ${MAX_DESCRIPTION_LENGTH} characters`);
+	}
+	if (!skill.body) errors.push("Markdown body is required");
+	if (errors.length)
+		throw new Error(`${skill.packageName}: ${errors.join("; ")}`);
+}
+
+function skillFileIn(directory, packageName) {
+	const matches = SKILL_FILENAMES.map((name) => join(directory, name)).filter(
+		existsSync,
+	);
+	if (matches.length > 1) {
+		throw new Error(`${packageName}: keep only one of SKILL.md or SKILL.MD`);
+	}
+	return matches[0];
+}
+
+function directoryEntries(directory) {
+	return readdirSync(directory, { withFileTypes: true })
+		.sort((a, b) => a.name.localeCompare(b.name))
+		.filter((entry) => !entry.name.startsWith("."));
+}
+
+function isDirectoryEntry(entry, path) {
+	if (entry.isDirectory()) return true;
+	if (!entry.isSymbolicLink()) return false;
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function loadSkill(directory, packageName, category) {
+	const path = skillFileIn(directory, packageName);
+	if (!path) return undefined;
+	const content = readFileSync(path, "utf8");
+	const document = parseSkillDocument(content, packageName);
+	const skill = {
+		name: document.frontmatter.name || packageName.split("/").at(-1),
+		description: document.frontmatter.description,
+		packageName,
+		category,
+		body: document.body,
+	};
+	validateSkill(skill);
+	return skill;
+}
+
+export function discoverSkills(root = defaultSkillsDir()) {
+	if (!existsSync(root)) return [];
+	const skills = [];
+	for (const entry of directoryEntries(root)) {
+		const directory = join(root, entry.name);
+		if (!isDirectoryEntry(entry, directory)) continue;
+
+		const directSkill = loadSkill(directory, entry.name, "other");
+		if (directSkill) {
+			skills.push(directSkill);
+			continue;
+		}
+
+		if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry.name)) {
+			throw new Error(
+				`${entry.name}: category names must contain only lowercase letters, numbers, and single hyphens`,
+			);
+		}
+		for (const child of directoryEntries(directory)) {
+			const childDirectory = join(directory, child.name);
+			if (!isDirectoryEntry(child, childDirectory)) continue;
+			const skill = loadSkill(
+				childDirectory,
+				`${entry.name}/${child.name}`,
+				entry.name,
+			);
+			if (skill) skills.push(skill);
+		}
+	}
+
+	const names = new Map();
+	for (const skill of skills) {
+		const existing = names.get(skill.name);
+		if (existing)
+			throw new Error(
+				`Duplicate additional skill name "${skill.name}" in packages ${existing} and ${skill.packageName}`,
+			);
+		names.set(skill.name, skill.packageName);
+	}
+	return skills.sort(
+		(a, b) =>
+			a.category.localeCompare(b.category) || a.name.localeCompare(b.name),
+	);
+}
+
+export function formatSkillList(skills) {
+	if (!skills.length) {
+		return "No additional skills available.";
+	}
+	const groups = new Map();
+	for (const skill of skills) {
+		const group = groups.get(skill.category) ?? [];
+		group.push(skill);
+		groups.set(skill.category, group);
+	}
+	const categories = [...groups].sort(([left], [right]) => {
+		if (left === "other") return 1;
+		if (right === "other") return -1;
+		return left.localeCompare(right);
+	});
+	const lines = [];
+	for (const [category, categorySkills] of categories) {
+		lines.push(`# ${category.replace(/-/g, " ").toUpperCase()}`);
+		for (const skill of categorySkills) {
+			lines.push(
+				`- ${skill.name}: ${skill.description.replace(/\s+/g, " ").trim()}`,
+			);
+		}
+	}
+	const output = lines.join("\n");
+	const bytes = Buffer.byteLength(output);
+	if (bytes > MAX_OUTPUT_BYTES) {
+		throw new Error(
+			`Additional skill catalog is ${bytes} bytes; shorten descriptions to keep it under ${MAX_OUTPUT_BYTES} bytes`,
+		);
+	}
+	return output;
+}
+
+export function run(argument, root = defaultSkillsDir()) {
+	if (typeof argument !== "string" || !argument) {
+		throw new Error('Expected "list" or an exact skill name.');
+	}
+	const skills = discoverSkills(root);
+	if (argument === "list") return formatSkillList(skills);
+	const skill = skills.find((candidate) => candidate.name === argument);
+	if (!skill) {
+		const available = skills.map(({ name }) => name).join(", ") || "none";
+		throw new Error(
+			`Unknown additional skill "${argument}". Available names: ${available}. Call with "list" to inspect descriptions.`,
+		);
+	}
+	const bytes = Buffer.byteLength(skill.body);
+	if (bytes > MAX_OUTPUT_BYTES) {
+		throw new Error(
+			`Skill "${skill.name}" is ${bytes} bytes; maximum loadable size is ${MAX_OUTPUT_BYTES} bytes`,
+		);
+	}
+	return skill.body;
+}
+
+function isMainModule() {
+	return process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+}
+
+if (isMainModule()) {
+	try {
+		process.stdout.write(run(process.argv[2]));
+	} catch (error) {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : String(error)}\n`,
+		);
+		process.exitCode = 1;
+	}
+}

--- a/packages/pi-dynamic-tools/examples/more_skills.toml
+++ b/packages/pi-dynamic-tools/examples/more_skills.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.more_skills("list" | "<exact-skill-name>") // extra categories: design, engineering, media, operations, writing; list when core skills do not fit, then load an exact match'''
+description = "Lists additional skill names and descriptions, or returns one skill's Markdown body by exact name."
+output = "A concise skill list or the selected skill's Markdown instructions."
+command = "./more-skills/more-skills.mjs"
+input = "arg"
+defer_loading = false

--- a/packages/pi-dynamic-tools/examples/semantic_grep.toml
+++ b/packages/pi-dynamic-tools/examples/semantic_grep.toml
@@ -1,4 +1,4 @@
-usage = '''await tools.semantic_grep(JSON.stringify({ query: string, top_k?: number })) // conceptual or cross-file discovery; use exact grep for literals'''
+usage = '''await tools.semantic_grep(JSON.stringify({ query: string, top_k?: number })) // query with terse search intent, pseudocode, or half-sentences—not questions; use exact grep for literals'''
 description = "Searches the current repository's existing semantic-grep index and returns ranked paths, line ranges, scores, and snippets."
 command = "./semantic-grep/semantic-grep.mjs"
 input = "stdin"

--- a/packages/pi-dynamic-tools/examples/sites.toml
+++ b/packages/pi-dynamic-tools/examples/sites.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.sites(JSON.stringify({ resource: string, action: string, params?: object }))'''
+description = "Manage ChatGPT Sites through a curated facade. Read sites_documentation before first use."
+command = "./sites/sites.mjs"
+args = ["call"]
+input = "stdin"
+defer_loading = true

--- a/packages/pi-dynamic-tools/examples/sites/auth.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/auth.mjs
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export async function getSitesAuth() {
+	const authPath =
+		process.env.PI_AUTH_FILE ||
+		join(
+			process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent"),
+			"auth.json",
+		);
+	let credential;
+	try {
+		const stored = JSON.parse(await readFile(authPath, "utf8"));
+		credential = stored?.["openai-codex"];
+	} catch (error) {
+		throw new Error(
+			`Could not read Pi authentication from ${authPath}: ${error.message}`,
+		);
+	}
+	if (typeof credential?.access !== "string" || !credential.access) {
+		throw new Error("OpenAI Codex OAuth is not configured in Pi");
+	}
+	if (Number.isFinite(credential.expires) && credential.expires <= Date.now()) {
+		throw new Error(
+			"Pi's OpenAI Codex OAuth token is expired; run a Codex prompt in Pi to refresh it, then retry",
+		);
+	}
+
+	const accountId = credential.accountId || accountIdFromJwt(credential.access);
+	if (typeof accountId !== "string" || !accountId) {
+		throw new Error("The Pi Codex OAuth token has no ChatGPT account ID");
+	}
+	return { token: credential.access, accountId };
+}
+
+function accountIdFromJwt(token) {
+	try {
+		const payload = JSON.parse(
+			Buffer.from(token.split(".")[1], "base64url").toString("utf8"),
+		);
+		return payload["https://api.openai.com/auth"]?.chatgpt_account_id;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/pi-dynamic-tools/examples/sites/client.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/client.mjs
@@ -1,0 +1,188 @@
+import { getSitesAuth } from "./auth.mjs";
+
+const ENDPOINT = "https://chatgpt.com/backend-api/wham/apps";
+const CONNECTOR_ID = "connector_20205bf7d4e99a89d7154bb849718324";
+
+export class SitesClient {
+	constructor({ fetchImpl = fetch, authProvider = getSitesAuth } = {}) {
+		this.fetchImpl = fetchImpl;
+		this.authProvider = authProvider;
+		this.requestId = 0;
+		this.tools = undefined;
+		this.headers = undefined;
+	}
+
+	async initialize() {
+		if (this.headers) return;
+		const { token, accountId } = await this.authProvider();
+		this.headers = {
+			authorization: `Bearer ${token}`,
+			"chatgpt-account-id": accountId,
+			"x-openai-product-sku": "codex",
+			originator: "pi",
+			accept: "application/json, text/event-stream",
+			"content-type": "application/json",
+		};
+		const initialized = await this.rpc("initialize", {
+			protocolVersion: "2025-03-26",
+			capabilities: {},
+			clientInfo: { name: "pi-sites", version: "0.1.0" },
+		});
+		this.headers["mcp-protocol-version"] =
+			initialized?.protocolVersion ?? "2025-03-26";
+		await this.rpc("notifications/initialized", {}, { notification: true });
+	}
+
+	async listSitesTools() {
+		if (this.tools) return this.tools;
+		await this.initialize();
+		const response = await this.rpc("tools/list", {});
+		const tools = Array.isArray(response?.tools) ? response.tools : [];
+		this.tools = tools.filter((tool) => isSitesTool(tool));
+		if (this.tools.length === 0) {
+			throw new Error("The ChatGPT account did not expose the Sites connector");
+		}
+		return this.tools;
+	}
+
+	async schema(toolSuffix) {
+		const tool = await this.findTool(toolSuffix);
+		return tool.inputSchema;
+	}
+
+	async call(toolSuffix, args) {
+		const tool = await this.findTool(toolSuffix);
+		const response = await this.rpc("tools/call", {
+			name: tool.name,
+			arguments: args,
+		});
+		return decodeToolResult(response);
+	}
+
+	async findTool(toolSuffix) {
+		const expected = `sites_${toolSuffix}`.toLowerCase();
+		const tools = await this.listSitesTools();
+		const tool = tools.find((candidate) => {
+			const names = [candidate.name, candidate._meta?.resource_name]
+				.filter((value) => typeof value === "string")
+				.map(normalizeToolName);
+			return names.includes(expected);
+		});
+		if (!tool) throw new Error(`Sites backend no longer exposes ${toolSuffix}`);
+		return tool;
+	}
+
+	async rpc(method, params, { notification = false } = {}) {
+		const payload = { jsonrpc: "2.0", method, params };
+		if (!notification) payload.id = ++this.requestId;
+		const response = await this.fetchImpl(ENDPOINT, {
+			method: "POST",
+			headers: this.headers,
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(45_000),
+		});
+		const sessionId = response.headers.get("mcp-session-id");
+		if (sessionId) this.headers["mcp-session-id"] = sessionId;
+		const body = await readCappedBody(response);
+		if (notification && response.ok && !body) return undefined;
+		const result = parseRpcBody(body, response.headers.get("content-type"));
+		if (!response.ok || result?.error) {
+			throw backendError(response.status, result?.error ?? result ?? body);
+		}
+		return result?.result;
+	}
+}
+
+function isSitesTool(tool) {
+	return tool?._meta?.connector_id === CONNECTOR_ID;
+}
+
+function normalizeToolName(name) {
+	return name.toLowerCase().replaceAll(".", "_");
+}
+
+function parseRpcBody(body, contentType = "") {
+	if (contentType?.includes("text/event-stream")) {
+		const messages = body
+			.split(/\r?\n/)
+			.filter((line) => line.startsWith("data:"))
+			.map((line) => line.slice(5).trim())
+			.filter((line) => line && line !== "[DONE]");
+		if (messages.length === 0)
+			throw new Error("Sites backend returned an empty event stream");
+		return JSON.parse(messages.at(-1));
+	}
+	try {
+		return JSON.parse(body);
+	} catch {
+		throw new Error("Sites backend returned a non-JSON response");
+	}
+}
+
+async function readCappedBody(response, maxBytes = 4 * 1024 * 1024) {
+	if (!response.body) return "";
+	const reader = response.body.getReader();
+	const chunks = [];
+	let total = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			total += value.byteLength;
+			if (total > maxBytes) {
+				await reader.cancel();
+				throw new Error(
+					"Sites backend response exceeded the 4 MiB safety limit",
+				);
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return Buffer.concat(
+		chunks.map((chunk) => Buffer.from(chunk)),
+		total,
+	).toString("utf8");
+}
+
+function decodeToolResult(result) {
+	if (result?.isError) throw backendError(200, result);
+	if (result?.structuredContent !== undefined) return result.structuredContent;
+	const texts = Array.isArray(result?.content)
+		? result.content
+				.filter((item) => item?.type === "text")
+				.map((item) => item.text)
+		: [];
+	if (texts.length === 1) {
+		try {
+			return JSON.parse(texts[0]);
+		} catch {
+			return { message: texts[0] };
+		}
+	}
+	return texts.length > 0 ? { messages: texts } : result;
+}
+
+function backendError(status, payload) {
+	const serialized = safeStringify(payload);
+	const terms = serialized.match(
+		/sites_publication_terms_required:\s*(https?:\/\/[^\s"}]+)/i,
+	);
+	const message = terms
+		? "ChatGPT Sites publication terms must be accepted before this operation can continue"
+		: `Sites backend request failed${status ? ` (HTTP ${status})` : ""}`;
+	return Object.assign(new Error(message), {
+		code: terms ? "terms_required" : "backend_error",
+		status,
+		termsUrl: terms?.[1],
+	});
+}
+
+function safeStringify(value) {
+	try {
+		return typeof value === "string" ? value : JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}

--- a/packages/pi-dynamic-tools/examples/sites/docs/access.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/access.md
@@ -1,0 +1,21 @@
+# Access operations
+
+Hosting does not automatically make a Site public. New Sites normally begin with owner/admin-only access, subject to workspace policy.
+
+## `access.get`
+
+Returns only the Site ID, title, live URL, access mode, access policy, and currently available modes. This intentionally omits unrelated Site fields.
+
+## `access.update`
+
+Change access only when the user asks. Pi custom tools have no trusted approval callback, so calling this action applies the change immediately.
+
+Backend modes can include:
+
+- `public`: anyone with the URL;
+- `workspace_all`: active users in the workspace;
+- `custom`: supplied user and group allowlists.
+
+For `custom`, omitted allowlists preserve existing values; empty lists clear non-owner entries. IDs and eligible modes depend on workspace policy. Never invent group IDs. The owner remains allowed.
+
+Before widening access, review the deployed content, data handling, forms, uploads, links, and sign-in behavior. Public publishing may be disabled by an admin.

--- a/packages/pi-dynamic-tools/examples/sites/docs/analytics.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/analytics.md
@@ -1,0 +1,17 @@
+# Analytics operations
+
+Analytics queries require a Site project and an explicit millisecond time range. Keep ranges bounded and paginate or narrow queries instead of requesting unbounded output.
+
+## `analytics.overview`
+
+Get aggregate Site analytics between `start_time_ms` and `end_time_ms`. Optional `granularity` values are defined by the current backend schema.
+
+## `analytics.events`
+
+List event names observed in the requested time range. Use this before querying an unfamiliar event.
+
+## `analytics.query`
+
+Query one exact `event_name` over a bounded time range. Event names and IDs are opaque backend values; do not invent or normalize them.
+
+Analytics can contain operational or visitor-derived information. Return only what the task needs and avoid copying large event payloads into model context.

--- a/packages/pi-dynamic-tools/examples/sites/docs/deployment.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/deployment.md
@@ -1,0 +1,29 @@
+# Deployment operations
+
+Every Sites deployment URL is production. Deploy only a saved `version_id` after the intended audience and content have been reviewed.
+
+## `deployment.deploy`
+
+Required facade parameters: `project_id` (or local manifest), `version_id`, and `visibility`.
+
+- `visibility: "private"` uses the owner-only deployment path. The backend refuses it unless the caller is the sole explicitly allowed viewer and no groups are allowed.
+- `visibility: "shared"` is an open-world production deployment for shared, workspace, public, or unverifiable access.
+
+Pi has no trusted approval callback for custom tools. Calling this action is the production effect; the agent must obtain user approval before calling it. Shared deployment warrants an explicit audience warning.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "deployment",
+  action: "deploy",
+  params: {
+    version_id: "<opaque-version-id>",
+    visibility: "private"
+  }
+}))
+```
+
+If private deployment is rejected because access is not owner-only, do not silently fall back. Ask the user before making a shared deployment.
+
+## `deployment.status`
+
+Pass the exact `project_id`, `version_id`, and deployment `id` returned by deploy as `deployment_id`. Poll only while status is `pending`, `building`, or `publishing`, or when the user asks for progress.

--- a/packages/pi-dynamic-tools/examples/sites/docs/domains.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/domains.md
@@ -1,0 +1,19 @@
+# Custom-domain operations
+
+Use resource name `domain` in calls. Sites does not register domains; the user must own the hostname and control its DNS. Availability depends on plan and workspace policy.
+
+## Actions
+
+- `domain.list`: list current custom domains for a Site.
+- `domain.add`: add a hostname and return required DNS records.
+- `domain.refresh`: recheck DNS using the exact `custom_domain_id`.
+- `domain.remove`: immediately detach the exact custom domain. Pi custom tools have no separate approval callback.
+
+Typical flow:
+
+1. Add the apex domain or subdomain.
+2. Show the returned DNS names, record types, and values to the user.
+3. Wait for the user to update DNS at their provider.
+4. Refresh status after propagation.
+
+Do not claim that DNS was changed merely because the domain was added in Sites. Never remove or replace a domain to solve a transient propagation delay.

--- a/packages/pi-dynamic-tools/examples/sites/docs/environment.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/environment.md
@@ -1,0 +1,31 @@
+# Runtime environment operations
+
+Sites runtime values are separate from local `.env` files and `.openai/hosting.json`.
+
+## `environment.get`
+
+Get configured production runtime entries and their revision. The facade recursively redacts secret values even if the backend returns one unexpectedly.
+
+## `environment.update`
+
+Pass `set_values` and optional `remove`:
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "environment",
+  action: "update",
+  params: {
+    set_values: [
+      { key: "API_ORIGIN", value: "https://example.test", is_secret: false },
+      { key: "SERVICE_TOKEN", value: "<secret>", is_secret: true }
+    ],
+    remove: []
+  }
+}))
+```
+
+Keys are case-sensitive. Do not repeat a key or put it in both lists. Only listed keys change. Mark sensitive values with `is_secret: true` and do not echo them in prose or logs. The tool deliberately cannot read values from arbitrary environment variables or files. For secrets that should never enter model context, use the Sites settings UI instead.
+
+Calling this action changes production runtime configuration immediately; Pi custom tools have no separate approval callback.
+
+Environment changes do not alter an existing deployment. Redeploy an approved saved version when the new revision should become active.

--- a/packages/pi-dynamic-tools/examples/sites/docs/index.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/index.md
@@ -1,0 +1,34 @@
+# ChatGPT Sites custom tool
+
+This is an exploratory, private-API bridge from Pi to ChatGPT Sites. The backend is in public beta and may change. Use the facade rather than guessing remote MCP names.
+
+## First use
+
+1. Read `sites_documentation("workflow")`.
+2. Read the resource topic you need.
+3. For exact parameters, read `sites_documentation("resource.action")`.
+4. Call `sites` with one resource, action, and `params` object.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "site",
+  action: "list",
+  params: { limit: 10 }
+}))
+```
+
+## Topics and resources
+
+| Topic | Actions |
+|---|---|
+| `site` | `list`, `get`, `create`, `update` |
+| `version` | `list`, `get`, `save` |
+| `deployment` | `deploy`, `status` |
+| `access` | `get`, `update` |
+| `environment` | `get`, `update` |
+| `domains` | resource `domain`: `list`, `add`, `refresh`, `remove` |
+| `analytics` | `overview`, `events`, `query` |
+
+`project_id` is read from `<project>/.openai/hosting.json` when omitted. Pass `project_dir` when Pi's current directory is not the Site project.
+
+The tool never returns OAuth tokens, source-repository credentials, secret environment values, or SIWC bypass tokens. Unknown operations return one documentation pointer instead of the full catalog.

--- a/packages/pi-dynamic-tools/examples/sites/docs/site.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/site.md
@@ -1,0 +1,31 @@
+# Site operations
+
+## `site.list`
+
+List accessible Sites. `limit` defaults to 20; use the returned cursor for another page.
+
+## `site.get`
+
+Get metadata, current URLs, version state, and access configuration for one opaque `project_id`.
+
+## `site.create`
+
+Create only when the local `.openai/hosting.json` has no `project_id`.
+
+Required facade parameters: `title`, `slug`. Optional: `description`, `project_dir`.
+
+The slug must start with a lowercase ASCII letter, be at least five characters, and contain only lowercase letters, digits, and single hyphens. The facade persists the new project ID atomically. It removes the short-lived source credential from model-visible output.
+
+## `site.update`
+
+Update user-facing metadata. The current backend supports `title`; inspect `sites_documentation("site.update")` before calling.
+
+Examples:
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "site",
+  action: "get",
+  params: { project_dir: "/absolute/project/path" }
+}))
+```

--- a/packages/pi-dynamic-tools/examples/sites/docs/version.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/version.md
@@ -1,0 +1,33 @@
+# Version operations
+
+A saved version is a reviewable deployment candidate. Saving is not deployment.
+
+## `version.list`
+
+List saved versions for a Site. Use `limit` and `cursor` for pagination.
+
+## `version.get`
+
+Inspect one opaque `version_id` within its `project_id`.
+
+## `version.save`
+
+Run only after local validation and review. The facade:
+
+1. finds the Git project from `project_dir` or the current directory;
+2. requires a committed `.openai/hosting.json` bound to the Site;
+3. requires a clean worktree, including no untracked files;
+4. derives the exact HEAD commit SHA;
+5. obtains a short-lived Sites repository credential;
+6. pushes HEAD to the backend-selected source branch without exposing the token or running repository hooks;
+7. saves that exact commit and returns the opaque `version_id` and user-facing version number.
+
+Do not pass `commit_sha` or `archive`; the facade rejects both. It currently supports repository-backed saves, not uploaded build archives.
+
+```js
+await tools.sites(JSON.stringify({
+  resource: "version",
+  action: "save",
+  params: { project_dir: "/absolute/project/path" }
+}))
+```

--- a/packages/pi-dynamic-tools/examples/sites/docs/workflow.md
+++ b/packages/pi-dynamic-tools/examples/sites/docs/workflow.md
@@ -1,0 +1,24 @@
+# Sites workflow
+
+Sites publishing has two separate stages: save a version, then deploy that saved version. Every deployment URL is production.
+
+## Existing local project
+
+1. Confirm the project can produce a Sites-compatible build and validate it locally.
+2. Commit all intended source. `version.save` rejects dirty or untracked worktrees.
+3. If `.openai/hosting.json` has no `project_id`, call `site.create` once. The facade writes the returned ID into that file without replacing other bindings.
+4. Call `version.save`. The facade derives HEAD, obtains a temporary repository credential, pushes that exact commit internally, and saves it. Saving does not deploy.
+5. Review the saved candidate.
+6. Call `deployment.deploy` only when production publication is intended.
+7. Poll `deployment.status` when the initial deployment is non-terminal.
+
+## Invariants
+
+- Treat project, version, deployment, domain, and cursor IDs as opaque.
+- Never call `site.create` when `.openai/hosting.json` already has `project_id`.
+- Never treat a local build or Git commit as a saved `version_id`.
+- Never deploy an unsaved version.
+- Keep runtime secrets out of prompts, source, `.env.example`, and `.openai/hosting.json`.
+- Prefer the narrowest access mode that fits the audience.
+
+If the backend returns `terms_required`, give the URL to the user. They must accept the ChatGPT Sites publication terms in a browser, then retry the operation.

--- a/packages/pi-dynamic-tools/examples/sites/git-askpass.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/git-askpass.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const prompt = process.argv.slice(2).join(" ").toLowerCase();
+if (prompt.includes("username")) {
+	process.stdout.write(process.env.SITES_GIT_USERNAME || "x-access-token");
+} else {
+	process.stdout.write(process.env.SITES_GIT_TOKEN || "");
+}

--- a/packages/pi-dynamic-tools/examples/sites/local-project.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/local-project.mjs
@@ -1,0 +1,198 @@
+import { execFile } from "node:child_process";
+import {
+	mkdir,
+	open,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const runFile = promisify(execFile);
+const askPass = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"git-askpass.mjs",
+);
+
+export async function projectContext(projectDir) {
+	const requested = projectDir ? resolve(projectDir) : process.cwd();
+	const requestedStat = await stat(requested);
+	if (!requestedStat.isDirectory())
+		throw new Error("project_dir must name a directory");
+	let gitRoot;
+	try {
+		gitRoot = (await git(requested, ["rev-parse", "--show-toplevel"])).trim();
+	} catch {
+		// Site creation can precede Git initialization.
+	}
+	if (projectDir && gitRoot && resolve(gitRoot) !== requested) {
+		throw new Error(
+			"project_dir must be the Git repository root, not a nested directory",
+		);
+	}
+	const root = gitRoot || requested;
+	return { root, manifestPath: join(root, ".openai", "hosting.json") };
+}
+
+export async function acquireHostingLock(context) {
+	await mkdir(dirname(context.manifestPath), { recursive: true });
+	const lockPath = join(dirname(context.manifestPath), "hosting.lock");
+	let handle;
+	try {
+		handle = await open(lockPath, "wx", 0o600);
+		await handle.writeFile(`${process.pid}\n`);
+	} catch (error) {
+		await handle?.close();
+		if (error.code === "EEXIST") {
+			throw new Error(`Another Sites operation holds ${lockPath}`);
+		}
+		throw error;
+	}
+	let released = false;
+	return async () => {
+		if (released) return;
+		released = true;
+		await handle.close();
+		await rm(lockPath, { force: true });
+	};
+}
+
+export async function readHosting(context) {
+	try {
+		const value = JSON.parse(await readFile(context.manifestPath, "utf8"));
+		if (!value || typeof value !== "object" || Array.isArray(value)) {
+			throw new Error("manifest must contain a JSON object");
+		}
+		return value;
+	} catch (error) {
+		if (error.code === "ENOENT") return {};
+		throw new Error(`${context.manifestPath}: ${error.message}`);
+	}
+}
+
+export async function persistProjectId(context, projectId) {
+	const manifest = await readHosting(context);
+	if (manifest.project_id && manifest.project_id !== projectId) {
+		throw new Error(
+			`${context.manifestPath} already contains a different project_id`,
+		);
+	}
+	manifest.project_id = projectId;
+	await mkdir(dirname(context.manifestPath), { recursive: true });
+	const temporary = `${context.manifestPath}.${process.pid}.tmp`;
+	await writeFile(temporary, `${JSON.stringify(manifest, null, 2)}\n`, {
+		mode: 0o600,
+	});
+	await rename(temporary, context.manifestPath);
+}
+
+export async function resolveProjectId(params, context) {
+	const manifest = await readHosting(context);
+	const supplied = params.project_id;
+	if (supplied !== undefined && typeof supplied !== "string") {
+		throw new Error("project_id must be a string");
+	}
+	if (supplied && manifest.project_id && supplied !== manifest.project_id) {
+		throw new Error("project_id does not match .openai/hosting.json");
+	}
+	const projectId = supplied || manifest.project_id;
+	if (!projectId) {
+		throw new Error("No project_id supplied and .openai/hosting.json has none");
+	}
+	return projectId;
+}
+
+export async function inspectCleanCommit(context) {
+	const root = (
+		await git(context.root, ["rev-parse", "--show-toplevel"])
+	).trim();
+	const status = await git(root, [
+		"status",
+		"--porcelain=v1",
+		"--untracked-files=all",
+	]);
+	if (status.trim())
+		throw new Error("version.save requires a clean Git worktree");
+	const manifestRelative = ".openai/hosting.json";
+	await git(root, ["ls-files", "--error-unmatch", manifestRelative]);
+	const commitSha = (await git(root, ["rev-parse", "HEAD"])).trim();
+	if (!/^[0-9a-f]{40,64}$/i.test(commitSha))
+		throw new Error("Could not resolve the current Git commit");
+	return { root, commitSha };
+}
+
+export async function pushCommit({ root, commitSha, credential }) {
+	const remoteUrl = credential?.remote_url;
+	const branch = credential?.branch;
+	const token = credential?.token;
+	const authMode = String(credential?.auth_mode ?? "").toLowerCase();
+	if (
+		![remoteUrl, branch, token].every(
+			(value) => typeof value === "string" && value,
+		)
+	) {
+		throw new Error(
+			"Sites returned an incomplete source repository credential",
+		);
+	}
+	const url = new URL(remoteUrl);
+	if (url.protocol !== "https:" || url.username || url.password) {
+		throw new Error(
+			"Sites source repository URL must be credential-free HTTPS",
+		);
+	}
+	await git(root, ["check-ref-format", `refs/heads/${branch}`]);
+
+	const env = {
+		...process.env,
+		GIT_TERMINAL_PROMPT: "0",
+	};
+	if (authMode.includes("bearer")) {
+		env.GIT_CONFIG_COUNT = "1";
+		env.GIT_CONFIG_KEY_0 = "http.extraHeader";
+		env.GIT_CONFIG_VALUE_0 = `Authorization: Bearer ${token}`;
+	} else {
+		env.GIT_ASKPASS = askPass;
+		env.SITES_GIT_TOKEN = token;
+		env.SITES_GIT_USERNAME = "x-access-token";
+	}
+	await git(
+		root,
+		[
+			"-c",
+			"credential.helper=",
+			"-c",
+			"core.hooksPath=/dev/null",
+			"push",
+			"--no-verify",
+			"--porcelain",
+			remoteUrl,
+			`${commitSha}:refs/heads/${branch}`,
+		],
+		env,
+	);
+}
+
+async function git(cwd, args, env = process.env) {
+	if (!isAbsolute(cwd))
+		throw new Error("Git working directory must be absolute");
+	try {
+		const result = await runFile("git", args, {
+			cwd,
+			env,
+			encoding: "utf8",
+			maxBuffer: 1024 * 1024,
+			timeout: 120_000,
+		});
+		return result.stdout;
+	} catch (error) {
+		const detail = String(error.stderr || error.message || "Git command failed")
+			.replaceAll(env.SITES_GIT_TOKEN || "\0", "[redacted]")
+			.trim();
+		throw new Error(detail.slice(0, 2_000));
+	}
+}

--- a/packages/pi-dynamic-tools/examples/sites/operations.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/operations.mjs
@@ -1,0 +1,81 @@
+export const OPERATIONS = Object.freeze({
+	site: Object.freeze({
+		list: operation("list_sites", "site"),
+		get: operation("get_site", "site"),
+		create: operation("create_site", "site", { local: "create" }),
+		update: operation("update_site_metadata", "site"),
+	}),
+	version: Object.freeze({
+		list: operation("list_site_versions", "version"),
+		get: operation("get_site_version", "version"),
+		save: operation("save_site_version", "version", { local: "save" }),
+	}),
+	deployment: Object.freeze({
+		deploy: operation("deploy_site_version", "deployment", { local: "deploy" }),
+		status: operation("get_deployment_status", "deployment"),
+	}),
+	access: Object.freeze({
+		get: operation("get_site", "access", { select: "access" }),
+		update: operation("update_site_access", "access"),
+	}),
+	environment: Object.freeze({
+		get: operation("get_environment_variables", "environment"),
+		update: operation("update_environment_variables", "environment"),
+	}),
+	domain: Object.freeze({
+		list: operation("list_custom_domains", "domains"),
+		add: operation("add_custom_domain", "domains"),
+		refresh: operation("refresh_custom_domain_status", "domains"),
+		remove: operation("remove_custom_domain", "domains"),
+	}),
+	analytics: Object.freeze({
+		overview: operation("get_site_analytics_overview", "analytics"),
+		events: operation("list_site_analytics_events", "analytics"),
+		query: operation("query_site_analytics_event", "analytics"),
+	}),
+});
+
+function operation(tool, topic, options = {}) {
+	return Object.freeze({ tool, topic, ...options });
+}
+
+export function resolveOperation(resource, action) {
+	if (typeof resource !== "string" || typeof action !== "string") {
+		throw facadeError(
+			"invalid_operation",
+			"resource and action must both be strings",
+			"index",
+		);
+	}
+	const resourceOperations = OPERATIONS[resource];
+	const resolved = resourceOperations?.[action];
+	if (!resolved) {
+		const topic =
+			resource === "domain"
+				? "domains"
+				: resource in OPERATIONS
+					? resource
+					: "index";
+		throw facadeError(
+			"unknown_operation",
+			`Unknown Sites operation ${resource}.${action}; read sites_documentation(\"${topic}\")`,
+			topic,
+		);
+	}
+	return { resource, action, key: `${resource}.${action}`, ...resolved };
+}
+
+export function facadeError(code, message, topic, details) {
+	return Object.assign(new Error(message), { code, topic, details });
+}
+
+export function operationForTopic(topic) {
+	if (typeof topic !== "string" || !topic.includes(".")) return undefined;
+	const [resource, action, ...rest] = topic.split(".");
+	if (rest.length > 0) return undefined;
+	try {
+		return resolveOperation(resource, action);
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/pi-dynamic-tools/examples/sites/redact.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/redact.mjs
@@ -1,0 +1,71 @@
+const SENSITIVE_KEYS = new Set([
+	"token",
+	"access_token",
+	"api_key",
+	"client_secret",
+	"credential",
+	"credentials",
+	"private_key",
+	"refresh",
+	"refresh_token",
+	"password",
+	"secret",
+	"authorization",
+	"siwc_bypass_bearer_token",
+	"source_repository_credential",
+]);
+
+export function redact(value) {
+	return redactValue(value, new WeakSet());
+}
+
+function redactValue(value, seen) {
+	if (typeof value === "string") return redactString(value);
+	if (value === null || typeof value !== "object") return value;
+	if (seen.has(value)) return "[circular]";
+	seen.add(value);
+	if (Array.isArray(value))
+		return value.map((entry) => redactValue(entry, seen));
+
+	const output = {};
+	const secretEnvironmentEntry = value.is_secret === true;
+	for (const [key, entry] of Object.entries(value)) {
+		if (
+			SENSITIVE_KEYS.has(key.toLowerCase()) ||
+			(secretEnvironmentEntry && key === "value")
+		) {
+			output[key] = "[redacted]";
+		} else {
+			output[key] = redactValue(entry, seen);
+		}
+	}
+	return output;
+}
+
+function redactString(value) {
+	return value
+		.replace(/(https?:\/\/)[^/@\s:]+:[^/@\s]+@/gi, "$1[redacted]@")
+		.replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/gi, "$1 [redacted]")
+		.replace(
+			/([?&](?:token|access_token|key|signature|sig)=)[^&#\s]+/gi,
+			"$1[redacted]",
+		);
+}
+
+export function boundedJson(value, maxBytes = 32_000) {
+	const serialized = JSON.stringify(redact(value), null, 2);
+	if (Buffer.byteLength(serialized) <= maxBytes) return serialized;
+	return JSON.stringify(
+		{
+			ok: false,
+			error: {
+				code: "output_too_large",
+				message:
+					"Sites output was truncated; use narrower filters or pagination",
+				original_bytes: Buffer.byteLength(serialized),
+			},
+		},
+		null,
+		2,
+	);
+}

--- a/packages/pi-dynamic-tools/examples/sites/sites.mjs
+++ b/packages/pi-dynamic-tools/examples/sites/sites.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SitesClient } from "./client.mjs";
+import {
+	acquireHostingLock,
+	inspectCleanCommit,
+	persistProjectId,
+	projectContext,
+	pushCommit,
+	readHosting,
+	resolveProjectId,
+} from "./local-project.mjs";
+import {
+	facadeError,
+	operationForTopic,
+	resolveOperation,
+} from "./operations.mjs";
+import { boundedJson, redact } from "./redact.mjs";
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), "docs");
+const mode = process.argv[2];
+
+try {
+	const input = await readStdin();
+	const result =
+		mode === "documentation" ? await documentation(input) : await call(input);
+	process.stdout.write(
+		typeof result === "string" ? result : boundedJson(result),
+	);
+} catch (error) {
+	process.stdout.write(
+		boundedJson({
+			ok: false,
+			error: {
+				code: error.code || "sites_error",
+				message: error.message || "Sites operation failed",
+				topic: error.topic,
+				terms_url: error.termsUrl,
+				status: error.status,
+				details: error.details,
+			},
+		}),
+	);
+}
+
+async function call(input) {
+	let request;
+	try {
+		request = JSON.parse(input);
+	} catch {
+		throw facadeError("invalid_json", "sites expects one JSON object", "index");
+	}
+	if (!request || typeof request !== "object" || Array.isArray(request)) {
+		throw facadeError(
+			"invalid_request",
+			"sites expects one JSON object",
+			"index",
+		);
+	}
+	const operation = resolveOperation(request.resource, request.action);
+	const params = request.params === undefined ? {} : request.params;
+	if (!params || typeof params !== "object" || Array.isArray(params)) {
+		throw facadeError(
+			"invalid_params",
+			"params must be an object",
+			operation.topic,
+		);
+	}
+
+	const client = new SitesClient();
+	const prepared = await prepare(operation, { ...params }, client);
+	try {
+		validateAgainstSchema(
+			prepared.args,
+			await client.schema(prepared.tool),
+			prepared.allowedExtra,
+		);
+		const raw = await client.call(prepared.tool, prepared.args);
+		const completed = await prepared.after(raw);
+		return {
+			ok: true,
+			operation: operation.key,
+			result: redact(selectResult(operation, completed)),
+		};
+	} finally {
+		await prepared.cleanup();
+	}
+}
+
+async function prepare(operation, params, client) {
+	const project = await projectContext(params.project_dir);
+	delete params.project_dir;
+	let tool = operation.tool;
+	let after = async (value) => value;
+	let cleanup = async () => {};
+	const allowedExtra = [];
+
+	if (operation.local === "create") {
+		cleanup = await acquireHostingLock(project);
+		try {
+			const manifest = await readHosting(project);
+			if (manifest.project_id) {
+				throw facadeError(
+					"site_already_linked",
+					".openai/hosting.json already has project_id; reuse that site",
+					"site",
+				);
+			}
+		} catch (error) {
+			await cleanup();
+			throw error;
+		}
+		after = async (value) => {
+			const projectId = unwrapResult(value)?.id;
+			if (typeof projectId !== "string" || !projectId) {
+				throw new Error("Sites created a site but returned no project ID");
+			}
+			try {
+				await persistProjectId(project, projectId);
+			} catch (error) {
+				throw facadeError(
+					"manifest_persist_failed",
+					`Site was created as ${projectId}, but ${project.manifestPath} could not be updated: ${error.message}`,
+					"site",
+					{ project_id: projectId, manifest_path: project.manifestPath },
+				);
+			}
+			return value;
+		};
+	} else if (operation.local === "save") {
+		rejectKeys(
+			params,
+			["commit_sha", "archive"],
+			"version.save derives commit_sha and does not accept archives",
+		);
+		const manifest = await readHosting(project);
+		if (typeof manifest.project_id !== "string" || !manifest.project_id) {
+			throw facadeError(
+				"unbound_repository",
+				"version.save requires project_id in the repository's .openai/hosting.json",
+				"version",
+			);
+		}
+		params.project_id = await resolveProjectId(params, project);
+		const { root, commitSha } = await inspectCleanCommit(project);
+		const credentialResponse = await client.call(
+			"create_source_repository_write_credential",
+			{
+				project_id: params.project_id,
+			},
+		);
+		await pushCommit({
+			root,
+			commitSha,
+			credential: unwrapResult(credentialResponse),
+		});
+		params.commit_sha = commitSha;
+	} else {
+		const schema = await client.schema(tool);
+		if (schema?.properties?.project_id && !params.project_id) {
+			params.project_id = await resolveProjectId(params, project);
+		}
+	}
+
+	if (operation.local === "deploy") {
+		const visibility = params.visibility;
+		if (visibility !== "private" && visibility !== "shared") {
+			throw facadeError(
+				"visibility_required",
+				'deployment.deploy requires params.visibility as "private" or "shared"',
+				"deployment",
+			);
+		}
+		tool =
+			visibility === "private"
+				? "deploy_private_site_version"
+				: "deploy_site_version";
+		delete params.visibility;
+	}
+
+	if (operation.tool === "list_sites" && params.limit === undefined)
+		params.limit = 20;
+	if (operation.tool === "list_site_versions" && params.limit === undefined)
+		params.limit = 20;
+	return { tool, args: params, after, cleanup, allowedExtra };
+}
+
+function rejectKeys(params, keys, message) {
+	if (keys.some((key) => key in params)) throw new Error(message);
+}
+
+function validateAgainstSchema(params, schema, allowedExtra = []) {
+	const properties = schema?.properties ?? {};
+	const unknown = Object.keys(params).filter(
+		(key) => !(key in properties) && !allowedExtra.includes(key),
+	);
+	if (unknown.length > 0) {
+		throw new Error(
+			`Unknown parameter${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+		);
+	}
+	const missing = (schema?.required ?? []).filter(
+		(key) => params[key] === undefined,
+	);
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing required parameter${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`,
+		);
+	}
+}
+
+function selectResult(operation, value) {
+	if (operation.select !== "access") return value;
+	const site = unwrapResult(value);
+	return {
+		result: {
+			id: site?.id,
+			title: site?.title,
+			current_live_url: site?.current_live_url,
+			access_mode: site?.access_mode,
+			access_policy: site?.access_policy,
+			available_access_modes: site?.available_access_modes,
+		},
+	};
+}
+
+function unwrapResult(value) {
+	return value?.result ?? value;
+}
+
+async function documentation(input) {
+	const requested = input.trim() || "index";
+	const topic = requested.replace(/^['"]|['"]$/g, "");
+	const operation = operationForTopic(topic);
+	if (operation) {
+		const guide = await readTopic(operation.topic);
+		const client = new SitesClient();
+		const schemas =
+			operation.local === "deploy"
+				? {
+						private: await client.schema("deploy_private_site_version"),
+						shared: await client.schema("deploy_site_version"),
+					}
+				: await client.schema(operation.tool);
+		return boundedDocumentation(
+			`${guide}\n\n## Current backend schema for ${operation.key}\n\n` +
+				`${operationSchemaNote(operation)}\n\n\`\`\`json\n${JSON.stringify(schemas, null, 2)}\n\`\`\`\n`,
+		);
+	}
+	const known = new Set([
+		"index",
+		"workflow",
+		"site",
+		"version",
+		"deployment",
+		"access",
+		"environment",
+		"domains",
+		"analytics",
+	]);
+	return readTopic(known.has(topic) ? topic : "index");
+}
+
+function operationSchemaNote(operation) {
+	if (operation.local === "save") {
+		return "The facade requires a committed Site binding, derives `commit_sha`, obtains Git credentials, pushes internally, and rejects caller-supplied `commit_sha` or `archive`.";
+	}
+	if (operation.local === "deploy") {
+		return 'The facade additionally requires `visibility: "private" | "shared"`; this facade field is stripped before the backend call.';
+	}
+	return "Pass the backend fields inside `params`. `project_id` may be omitted when `.openai/hosting.json` supplies it.";
+}
+
+async function readTopic(topic) {
+	const text = await readFile(join(docsDir, `${topic}.md`), "utf8");
+	return boundedDocumentation(text);
+}
+
+function boundedDocumentation(text) {
+	const max = 16_000;
+	if (Buffer.byteLength(text) <= max) return text;
+	const suffix = "\n\n[Documentation truncated; request the narrower topic.]\n";
+	const budget = max - Buffer.byteLength(suffix);
+	let prefix = Buffer.from(text).subarray(0, budget).toString("utf8");
+	while (Buffer.byteLength(prefix) > budget) prefix = prefix.slice(0, -1);
+	return `${prefix}${suffix}`;
+}
+
+async function readStdin() {
+	let value = "";
+	for await (const chunk of process.stdin) value += chunk;
+	return value;
+}

--- a/packages/pi-dynamic-tools/examples/sites_documentation.toml
+++ b/packages/pi-dynamic-tools/examples/sites_documentation.toml
@@ -1,0 +1,6 @@
+usage = '''await tools.sites_documentation("index" | "workflow" | "site" | "version" | "deployment" | "access" | "environment" | "domains" | "analytics" | "resource.action")'''
+description = "Return one bounded ChatGPT Sites documentation topic or one operation's current schema."
+command = "./sites/sites.mjs"
+args = ["documentation"]
+input = "stdin"
+defer_loading = true

--- a/packages/pi-dynamic-tools/examples/spawn-agent/spawn-agent.mjs
+++ b/packages/pi-dynamic-tools/examples/spawn-agent/spawn-agent.mjs
@@ -8,12 +8,12 @@ import { fileURLToPath } from "node:url";
 const EXAMPLE_DIR = dirname(fileURLToPath(import.meta.url));
 const AGENT_CONFIG = {
 	explorer: {
-		model: "openai-codex/gpt-5.6-luna",
+		model: "openai-codex/gpt-5.6-terra",
 		thinking: "low",
 		promptPath: resolve(EXAMPLE_DIR, "explorer.prompt.md"),
 	},
 	reviewer: {
-		model: "openai-codex/gpt-5.6-sol",
+		model: "openai-codex/gpt-5.6-luna",
 		thinking: "medium",
 		promptPath: resolve(EXAMPLE_DIR, "reviewer.prompt.md"),
 	},
@@ -261,11 +261,8 @@ export function buildPiArgs(request, message) {
 	return [
 		"--print",
 		"--no-session",
-		"--no-extensions",
 		"--no-skills",
 		"--no-prompt-templates",
-		"--tools",
-		"read,bash,grep,find,ls",
 		"--model",
 		config.model,
 		"--thinking",

--- a/packages/pi-dynamic-tools/examples/spawn_agent.toml
+++ b/packages/pi-dynamic-tools/examples/spawn_agent.toml
@@ -3,3 +3,4 @@ description = "Relative cwd resolves from Pi's working directory."
 command = "./spawn-agent/spawn-agent.mjs"
 input = "stdin"
 defer_loading = false
+yield_time_ms = 30000

--- a/packages/pi-dynamic-tools/examples/workflows_create.toml
+++ b/packages/pi-dynamic-tools/examples/workflows_create.toml
@@ -2,4 +2,3 @@ usage = '''await tools.workflows_create(JSON.stringify({ name: string, descripti
 description = "Creates or updates .pi/workflows/<slug>/SKILL.md in Pi's working directory."
 command = "./workflows-create/workflows-create.mjs"
 input = "stdin"
-defer_loading = false

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -170,7 +170,7 @@ function dynamicToolPaths(
 ): string[] {
 	try {
 		return readdirSync(dir, { withFileTypes: true })
-			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
+			.filter((entry) => entry.name.endsWith(".toml"))
 			.sort((left, right) => left.name.localeCompare(right.name))
 			.map((entry) => join(dir, entry.name));
 	} catch (error) {

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -195,10 +195,24 @@ function loadDynamicTool(
 		return parseDynamicTool(path, readFileSync(path, "utf8"));
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error);
-		errors.push({
-			path,
-			message: detail.startsWith(`${path}:`) ? detail : `${path}: ${detail}`,
-		});
-		return undefined;
+		const message = detail.startsWith(`${path}:`)
+			? detail
+			: `${path}: ${detail}`;
+		const name = basename(path, extname(path));
+		if (!TOOL_NAME_PATTERN.test(name)) {
+			errors.push({ path, message });
+			return undefined;
+		}
+		return {
+			name,
+			usage: "Disabled: fix this tool's TOML definition before calling it.",
+			description: message,
+			deferLoading: true,
+			command: "",
+			args: [],
+			input: "arg",
+			sourcePath: path,
+			disabledReason: message,
+		};
 	}
 }

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -170,7 +170,7 @@ function dynamicToolPaths(
 ): string[] {
 	try {
 		return readdirSync(dir, { withFileTypes: true })
-			.filter((entry) => entry.name.endsWith(".toml"))
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
 			.sort((left, right) => left.name.localeCompare(right.name))
 			.map((entry) => join(dir, entry.name));
 	} catch (error) {

--- a/packages/pi-dynamic-tools/src/config.ts
+++ b/packages/pi-dynamic-tools/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import {
 	basename,
 	dirname,
@@ -17,6 +17,22 @@ const NODE_SCRIPT_PATTERN = /\.(?:cjs|mjs|js)$/i;
 
 export function getDynamicToolsDir(agentDir: string = getAgentDir()): string {
 	return join(agentDir, DYNAMIC_TOOLS_DIRNAME);
+}
+
+export function getProjectDynamicToolsDir(
+	launchDir: string = process.cwd(),
+): string {
+	return join(launchDir, ".pi", DYNAMIC_TOOLS_DIRNAME);
+}
+
+export interface DynamicToolDiscoveryError {
+	path: string;
+	message: string;
+}
+
+export interface DynamicToolDiscoveryResult {
+	tools: DynamicToolDefinition[];
+	errors: DynamicToolDiscoveryError[];
 }
 
 function requiredString(value: unknown, field: string, path: string): string {
@@ -53,6 +69,17 @@ function deferLoading(value: unknown, path: string): boolean {
 	throw new Error(`${path}: defer_loading must be a boolean`);
 }
 
+function optionalNonNegativeInteger(
+	value: unknown,
+	field: string,
+	path: string,
+): number | undefined {
+	if (value === undefined) return undefined;
+	if (!Number.isSafeInteger(value) || Number(value) < 0)
+		throw new Error(`${path}: ${field} must be a non-negative safe integer`);
+	return Number(value);
+}
+
 export function parseDynamicTool(
 	path: string,
 	text: string,
@@ -71,6 +98,7 @@ export function parseDynamicTool(
 		"command",
 		"args",
 		"input",
+		"yield_time_ms",
 	]);
 	const unknown = Object.keys(value).filter((key) => !known.has(key));
 	if (unknown.length > 0)
@@ -84,6 +112,11 @@ export function parseDynamicTool(
 		: command;
 	const nodeScript =
 		isAbsolute(resolvedCommand) && NODE_SCRIPT_PATTERN.test(resolvedCommand);
+	const yieldTimeMs = optionalNonNegativeInteger(
+		value["yield_time_ms"],
+		"yield_time_ms",
+		path,
+	);
 	return {
 		name,
 		usage: requiredString(value["usage"], "usage", path),
@@ -93,19 +126,79 @@ export function parseDynamicTool(
 		command: nodeScript ? process.execPath : resolvedCommand,
 		args: nodeScript ? [resolvedCommand, ...args] : args,
 		input: inputMode(value["input"], path),
+		...(yieldTimeMs === undefined ? {} : { yieldTimeMs }),
 		sourcePath: path,
+	};
+}
+
+export function discoverDynamicToolsFromDirectories(
+	dirs: readonly string[],
+): DynamicToolDiscoveryResult {
+	const byName = new Map<string, DynamicToolDefinition>();
+	const errors: DynamicToolDiscoveryError[] = [];
+	for (const dir of dirs) {
+		for (const path of dynamicToolPaths(dir, errors)) {
+			const name = basename(path, extname(path));
+			// A project-local definition claims its name even when invalid. Never
+			// silently fall back to a global tool with different behavior.
+			byName.delete(name);
+			const tool = loadDynamicTool(path, errors);
+			if (tool) byName.set(tool.name, tool);
+		}
+	}
+	return {
+		tools: [...byName.values()].sort((left, right) =>
+			left.name.localeCompare(right.name),
+		),
+		errors,
 	};
 }
 
 export function discoverDynamicTools(
 	dir: string = getDynamicToolsDir(),
-): DynamicToolDefinition[] {
-	if (!existsSync(dir)) return [];
-	return readdirSync(dir, { withFileTypes: true })
-		.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
-		.sort((left, right) => left.name.localeCompare(right.name))
-		.map((entry) => {
-			const path = join(dir, entry.name);
-			return parseDynamicTool(path, readFileSync(path, "utf8"));
+): DynamicToolDiscoveryResult {
+	const errors: DynamicToolDiscoveryError[] = [];
+	const tools = dynamicToolPaths(dir, errors)
+		.map((path) => loadDynamicTool(path, errors))
+		.filter((tool): tool is DynamicToolDefinition => tool !== undefined);
+	return { tools, errors };
+}
+
+function dynamicToolPaths(
+	dir: string,
+	errors: DynamicToolDiscoveryError[],
+): string[] {
+	try {
+		return readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".toml"))
+			.sort((left, right) => left.name.localeCompare(right.name))
+			.map((entry) => join(dir, entry.name));
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		)
+			return [];
+		const detail = error instanceof Error ? error.message : String(error);
+		errors.push({ path: dir, message: `${dir}: ${detail}` });
+		return [];
+	}
+}
+
+function loadDynamicTool(
+	path: string,
+	errors: DynamicToolDiscoveryError[],
+): DynamicToolDefinition | undefined {
+	try {
+		return parseDynamicTool(path, readFileSync(path, "utf8"));
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		errors.push({
+			path,
+			message: detail.startsWith(`${path}:`) ? detail : `${path}: ${detail}`,
 		});
+		return undefined;
+	}
 }

--- a/packages/pi-dynamic-tools/src/host-client.ts
+++ b/packages/pi-dynamic-tools/src/host-client.ts
@@ -458,15 +458,47 @@ function customToolYieldTime(
 
 function maskJavaScriptCommentsAndStrings(code: string): string {
 	const output = code.split("");
-	let state: "code" | "line-comment" | "block-comment" | "string" | "regex" =
-		"code";
+	let state:
+		| "code"
+		| "line-comment"
+		| "block-comment"
+		| "string"
+		| "regex"
+		| "template" = "code";
 	let quote = "";
 	let regexClass = false;
+	let templateExpressionDepth: number | undefined;
+	const templateReturnDepths: Array<number | undefined> = [];
 	for (let index = 0; index < code.length; index += 1) {
 		const current = code[index]!;
 		const next = code[index + 1];
+		if (state === "template") {
+			output[index] = current === "\n" || current === "\r" ? current : " ";
+			if (current === "\\") {
+				if (next !== undefined) output[index + 1] = " ";
+				index += 1;
+			} else if (current === "$" && next === "{") {
+				output[index + 1] = " ";
+				templateExpressionDepth = 1;
+				state = "code";
+				index += 1;
+			} else if (current === "`") {
+				templateExpressionDepth = templateReturnDepths.pop();
+				state = "code";
+			}
+			continue;
+		}
 		if (state === "code") {
-			if (current === "/" && next === "/") {
+			if (templateExpressionDepth !== undefined && current === "{") {
+				templateExpressionDepth += 1;
+			} else if (templateExpressionDepth !== undefined && current === "}") {
+				templateExpressionDepth -= 1;
+				if (templateExpressionDepth === 0) {
+					output[index] = " ";
+					templateExpressionDepth = undefined;
+					state = "template";
+				}
+			} else if (current === "/" && next === "/") {
 				output[index] = output[index + 1] = " ";
 				state = "line-comment";
 				index += 1;
@@ -478,10 +510,15 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 				output[index] = " ";
 				regexClass = false;
 				state = "regex";
-			} else if (current === '"' || current === "'" || current === "`") {
+			} else if (current === '"' || current === "'") {
 				output[index] = " ";
 				quote = current;
 				state = "string";
+			} else if (current === "`") {
+				output[index] = " ";
+				templateReturnDepths.push(templateExpressionDepth);
+				templateExpressionDepth = undefined;
+				state = "template";
 			}
 			continue;
 		}

--- a/packages/pi-dynamic-tools/src/host-client.ts
+++ b/packages/pi-dynamic-tools/src/host-client.ts
@@ -458,8 +458,10 @@ function customToolYieldTime(
 
 function maskJavaScriptCommentsAndStrings(code: string): string {
 	const output = code.split("");
-	let state: "code" | "line-comment" | "block-comment" | "string" = "code";
+	let state: "code" | "line-comment" | "block-comment" | "string" | "regex" =
+		"code";
 	let quote = "";
+	let regexClass = false;
 	for (let index = 0; index < code.length; index += 1) {
 		const current = code[index]!;
 		const next = code[index + 1];
@@ -472,6 +474,10 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 				output[index] = output[index + 1] = " ";
 				state = "block-comment";
 				index += 1;
+			} else if (current === "/" && isRegexLiteralStart(code, index)) {
+				output[index] = " ";
+				regexClass = false;
+				state = "regex";
 			} else if (current === '"' || current === "'" || current === "`") {
 				output[index] = " ";
 				quote = current;
@@ -482,6 +488,16 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 		if (state === "line-comment") {
 			if (current === "\n" || current === "\r") state = "code";
 			else output[index] = " ";
+			continue;
+		}
+		if (state === "regex") {
+			output[index] = current === "\n" || current === "\r" ? current : " ";
+			if (current === "\\") {
+				if (next !== undefined) output[index + 1] = " ";
+				index += 1;
+			} else if (current === "[") regexClass = true;
+			else if (current === "]") regexClass = false;
+			else if (current === "/" && !regexClass) state = "code";
 			continue;
 		}
 		output[index] = current === "\n" || current === "\r" ? current : " ";
@@ -502,6 +518,15 @@ function maskJavaScriptCommentsAndStrings(code: string): string {
 		}
 	}
 	return output.join("");
+}
+
+function isRegexLiteralStart(code: string, index: number): boolean {
+	const previous = code.slice(0, index).trimEnd();
+	if (!previous) return true;
+	if ("([{:;,=!?&|+-*%^~<>".includes(previous.at(-1)!)) return true;
+	return /(?:^|[^\w$])(return|throw|case|delete|void|typeof|instanceof|in|of|yield|await|else|do)$/.test(
+		previous,
+	);
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/pi-dynamic-tools/src/host-client.ts
+++ b/packages/pi-dynamic-tools/src/host-client.ts
@@ -89,6 +89,8 @@ export class CodeModeHostClient {
 	): Promise<RuntimeResponse> {
 		await this.start();
 		const { code, yieldTimeMs, maxOutputTokens } = parseExecSource(source);
+		const effectiveYieldTimeMs =
+			customToolYieldTime(code, tools) ?? yieldTimeMs;
 		const id = ++this.requestId;
 		const initial = new Promise<any>((resolve, reject) =>
 			this.initial.set(id, { resolve, reject }),
@@ -103,7 +105,7 @@ export class CodeModeHostClient {
 					tool_call_id: `exec-${id}`,
 					enabled_tools: tools.map(toWireToolDefinition),
 					source: code,
-					yield_time_ms: yieldTimeMs,
+					yield_time_ms: effectiveYieldTimeMs,
 					max_output_tokens: maxOutputTokens,
 				},
 			},
@@ -431,6 +433,79 @@ function parseExecSource(source: string): {
 		yieldTimeMs: integer(options["yield_time_ms"], "yield_time_ms"),
 		maxOutputTokens: integer(options["max_output_tokens"], "max_output_tokens"),
 	};
+}
+
+function customToolYieldTime(
+	code: string,
+	tools: DynamicToolDefinition[],
+): number | null {
+	const executableCode = maskJavaScriptCommentsAndStrings(code);
+	let forced: number | undefined;
+	for (const tool of tools) {
+		if (tool.yieldTimeMs === undefined) continue;
+		const name = escapeRegExp(tool.name);
+		const directCall = new RegExp(
+			`\\btools\\s*\\.\\s*${name}(?![a-zA-Z0-9_$])\\s*\\(`,
+		);
+		if (!directCall.test(executableCode)) continue;
+		forced =
+			forced === undefined
+				? tool.yieldTimeMs
+				: Math.max(forced, tool.yieldTimeMs);
+	}
+	return forced ?? null;
+}
+
+function maskJavaScriptCommentsAndStrings(code: string): string {
+	const output = code.split("");
+	let state: "code" | "line-comment" | "block-comment" | "string" = "code";
+	let quote = "";
+	for (let index = 0; index < code.length; index += 1) {
+		const current = code[index]!;
+		const next = code[index + 1];
+		if (state === "code") {
+			if (current === "/" && next === "/") {
+				output[index] = output[index + 1] = " ";
+				state = "line-comment";
+				index += 1;
+			} else if (current === "/" && next === "*") {
+				output[index] = output[index + 1] = " ";
+				state = "block-comment";
+				index += 1;
+			} else if (current === '"' || current === "'" || current === "`") {
+				output[index] = " ";
+				quote = current;
+				state = "string";
+			}
+			continue;
+		}
+		if (state === "line-comment") {
+			if (current === "\n" || current === "\r") state = "code";
+			else output[index] = " ";
+			continue;
+		}
+		output[index] = current === "\n" || current === "\r" ? current : " ";
+		if (state === "block-comment") {
+			if (current === "*" && next === "/") {
+				output[index + 1] = " ";
+				state = "code";
+				index += 1;
+			}
+			continue;
+		}
+		if (current === "\\") {
+			if (next !== undefined) output[index + 1] = " ";
+			index += 1;
+		} else if (current === quote) {
+			state = "code";
+			quote = "";
+		}
+	}
+	return output.join("");
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function parseRuntimeResponse(value: any): RuntimeResponse {

--- a/packages/pi-dynamic-tools/src/runner.ts
+++ b/packages/pi-dynamic-tools/src/runner.ts
@@ -9,6 +9,8 @@ export async function runDynamicTool(
 	cwd: string,
 	signal?: AbortSignal,
 ): Promise<string> {
+	if (tool.disabledReason)
+		throw new Error(`${tool.name} is disabled: ${tool.disabledReason}`);
 	if (typeof input !== "string")
 		throw new Error(`${tool.name} expects a string input`);
 	if (signal?.aborted) throw new Error(`${tool.name} aborted`);

--- a/packages/pi-dynamic-tools/src/tools.ts
+++ b/packages/pi-dynamic-tools/src/tools.ts
@@ -44,6 +44,7 @@ export async function registerDynamicTools(
 	const documentationPath = fileURLToPath(
 		new URL("../DYNAMIC-TOOLS.md", import.meta.url),
 	);
+	const usesDefaultDirs = toolsDir === undefined;
 	const toolsDirs =
 		toolsDir === undefined
 			? [getDynamicToolsDir(), getProjectDynamicToolsDir()]
@@ -52,7 +53,11 @@ export async function registerDynamicTools(
 				: [...toolsDir];
 	let previousErrors = new Map<string, string>();
 	const discoverTools = (ctx?: unknown) => {
-		const discovery = discoverDynamicToolsFromDirectories(toolsDirs);
+		const activeDirs =
+			usesDefaultDirs && !isTrustedProjectContext(ctx)
+				? toolsDirs.slice(0, 1)
+				: toolsDirs;
+		const discovery = discoverDynamicToolsFromDirectories(activeDirs);
 		previousErrors = reportDynamicToolErrors(
 			ctx,
 			discovery.errors,
@@ -220,6 +225,16 @@ function isExtensionContext(value: unknown): value is ExtensionContext {
 			typeof value.ui === "object" &&
 			"notify" in value.ui &&
 			typeof value.ui.notify === "function",
+	);
+}
+
+function isTrustedProjectContext(value: unknown): value is ExtensionContext {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"isProjectTrusted" in value &&
+			typeof value.isProjectTrusted === "function" &&
+			value.isProjectTrusted(),
 	);
 }
 

--- a/packages/pi-dynamic-tools/src/tools.ts
+++ b/packages/pi-dynamic-tools/src/tools.ts
@@ -1,8 +1,16 @@
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { ensureCodeModeHostBinary } from "./binary.js";
-import { discoverDynamicTools, getDynamicToolsDir } from "./config.js";
+import {
+	type DynamicToolDiscoveryError,
+	discoverDynamicToolsFromDirectories,
+	getDynamicToolsDir,
+	getProjectDynamicToolsDir,
+} from "./config.js";
 import { CodeModeHostClient } from "./host-client.js";
 import {
 	EXEC_DESCRIPTION,
@@ -26,7 +34,7 @@ const NOOP_RUNTIME = { async shutdown() {} };
 
 export async function registerDynamicTools(
 	pi: ExtensionAPI,
-	toolsDir: string = getDynamicToolsDir(),
+	toolsDir?: string | readonly string[],
 ): Promise<{ shutdown(): Promise<void> }> {
 	const sharedState = pi.events as typeof pi.events & {
 		[REGISTRATION_KEY]?: object;
@@ -36,10 +44,26 @@ export async function registerDynamicTools(
 	const documentationPath = fileURLToPath(
 		new URL("../DYNAMIC-TOOLS.md", import.meta.url),
 	);
-	pi.on("before_agent_start", (event) => {
+	const toolsDirs =
+		toolsDir === undefined
+			? [getDynamicToolsDir(), getProjectDynamicToolsDir()]
+			: typeof toolsDir === "string"
+				? [toolsDir]
+				: [...toolsDir];
+	let previousErrors = new Map<string, string>();
+	const discoverTools = (ctx?: unknown) => {
+		const discovery = discoverDynamicToolsFromDirectories(toolsDirs);
+		previousErrors = reportDynamicToolErrors(
+			ctx,
+			discovery.errors,
+			previousErrors,
+		);
+		return discovery.tools;
+	};
+	pi.on("before_agent_start", (event, ctx) => {
 		const systemPrompt = injectDynamicToolsPrompt(
 			event.systemPrompt,
-			discoverDynamicTools(toolsDir),
+			discoverTools(ctx),
 			documentationPath,
 		);
 		return systemPrompt === event.systemPrompt ? undefined : { systemPrompt };
@@ -79,7 +103,7 @@ export async function registerDynamicTools(
 		async execute(id, params, signal, onUpdate, ctx) {
 			renderTracker.start(id);
 			try {
-				const tools = discoverDynamicTools(toolsDir);
+				const tools = discoverTools(ctx);
 				const client = await getClient();
 				const response = await client.execute(
 					params.code,
@@ -171,6 +195,32 @@ export async function registerDynamicTools(
 			}
 		},
 	};
+}
+
+function reportDynamicToolErrors(
+	ctx: unknown,
+	errors: DynamicToolDiscoveryError[],
+	previous: Map<string, string>,
+): Map<string, string> {
+	if (!isExtensionContext(ctx)) return previous;
+	const current = new Map(errors.map((error) => [error.path, error.message]));
+	for (const error of errors) {
+		if (previous.get(error.path) === error.message) continue;
+		ctx.ui.notify(`Dynamic tool disabled: ${error.message}`, "error");
+	}
+	return current;
+}
+
+function isExtensionContext(value: unknown): value is ExtensionContext {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"ui" in value &&
+			value.ui &&
+			typeof value.ui === "object" &&
+			"notify" in value.ui &&
+			typeof value.ui.notify === "function",
+	);
 }
 
 function toToolResult(response: RuntimeResponse, maxTokens?: number) {

--- a/packages/pi-dynamic-tools/src/types.ts
+++ b/packages/pi-dynamic-tools/src/types.ts
@@ -9,6 +9,7 @@ export interface DynamicToolDefinition {
 	command: string;
 	args: string[];
 	input: DynamicToolInputMode;
+	yieldTimeMs?: number | undefined;
 	sourcePath: string;
 }
 

--- a/packages/pi-dynamic-tools/src/types.ts
+++ b/packages/pi-dynamic-tools/src/types.ts
@@ -11,6 +11,7 @@ export interface DynamicToolDefinition {
 	input: DynamicToolInputMode;
 	yieldTimeMs?: number | undefined;
 	sourcePath: string;
+	disabledReason?: string | undefined;
 }
 
 export interface ToolExecutionContext {

--- a/packages/pi-dynamic-tools/tests/spawn-agent.test.ts
+++ b/packages/pi-dynamic-tools/tests/spawn-agent.test.ts
@@ -63,14 +63,13 @@ describe("bundled spawn_agent", () => {
 			{ agent_type: "reviewer", message: "Review it." },
 			"Review base:\nInstructions:\nReview it.",
 		);
-		expect(explorer).toContain("openai-codex/gpt-5.6-luna");
+		expect(explorer).toContain("openai-codex/gpt-5.6-terra");
 		expect(explorer).toContain("low");
-		expect(reviewer).toContain("openai-codex/gpt-5.6-sol");
+		expect(reviewer).toContain("openai-codex/gpt-5.6-luna");
 		expect(reviewer).toContain("medium");
 		expect(explorer).toContain("--append-system-prompt");
 		expect(explorer).not.toContain("--system-prompt");
 		expect(explorer).not.toContain("--no-context-files");
-		expect(explorer).toContain("--no-extensions");
 		expect(explorer).toContain("--no-skills");
 	});
 


### PR DESCRIPTION
## Summary
- preserve actionable shell startup failures and make startup cancellation safe
- recover process `session_id` values mistakenly sent to code-cell `wait` by continuing the live process through `write_stdin`
- add private per-tool `yield_time_ms` policy that overrides the model's `exec` pragma
- discover trusted project-local command tools only from each package's `<launch-directory>/.pi/` catalog, with local definitions overriding global name collisions
- report and omit invalid definitions independently so one bad TOML cannot disable built-in or valid tools
- bundle `herdr_agent`, `more_skills`, `sites`, and `sites_documentation` examples and refresh existing examples in both Codex Conversion and Dynamic Tools
- align Dynamic Tools' discovery, failure isolation, and forced-yield behavior with Codex Conversion while keeping the packages independent

Closes #142
Closes #143

## Validation
- `bun run check:changed`
- manually reproduced invalid-cwd startup: retained `No such file or directory` instead of `unknown process id`
- manually reproduced process/cell ID confusion: mistaken `wait` recovered the live process and returned `finished` with exit code 0
- manually exercised forced yield precedence, local-over-global collision behavior, exact-directory discovery, invalid yield validation, and false-positive filtering for comments, strings, and regex literals
- manually verified untrusted projects cannot load project-local definitions and trusted projects apply local overrides
- manually verified invalid definitions are isolated, invalid local overrides suppress global fallback, non-regular TOML entries are handled explicitly, unchanged errors notify once, and unreadable directories remain visible
- syntax-checked every bundled script and smoke-tested the bundled/global examples, including live Sites schema discovery
- verified both npm packages include all 34 example files

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-dynamic-tools`
- Aggregates: generated by release automation
