### PR TITLE
fix: restore review preface after compaction

### DIFF
--- a/.changeset/review-preface-after-compaction.md
+++ b/.changeset/review-preface-after-compaction.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subagent-review": patch
+---
+
+Reinjects the review advisory preface when compaction has removed the earlier preface from active session context.

--- a/packages/pi-subagent-review/src/messages.ts
+++ b/packages/pi-subagent-review/src/messages.ts
@@ -30,7 +30,7 @@ function getReviewPrefaceMessageId(
 	ctx: ExtensionCommandContext,
 ): string | undefined {
 	let messageId: string | undefined;
-	for (const entry of ctx.sessionManager.getBranch()) {
+	for (const entry of ctx.sessionManager.buildContextEntries()) {
 		if (
 			entry.type === "custom_message" &&
 			entry.customType === REVIEW_LOOP_PREFACE_MESSAGE_TYPE


### PR DESCRIPTION
## Summary
- Check the review preface against active session context rather than all historical entries.
- Reinject it when compaction has removed the earlier preface from the model-visible context.

## Validation
- `packages/pi-subagent-review`: `bun run check`
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-subagent-review`
- Aggregates: generated by release automation
