### PR TITLE
Optimize Codex model-facing tool guidance

### DIFF
--- a/.changeset/four-weeks-invent.md
+++ b/.changeset/four-weeks-invent.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-skill-model-facing-api-design": patch
+---
+
+Document model-facing punctuation and token-cost hygiene

--- a/.changeset/grumpy-goats-bake.md
+++ b/.changeset/grumpy-goats-bake.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Document raw `cmd` strings and JavaScript template-literal considerations
+Trim cosmetic terminal punctuation from model-facing Codex prompts and tool metadata; document raw `cmd` strings and JavaScript template-literal considerations

--- a/.changeset/grumpy-goats-bake.md
+++ b/.changeset/grumpy-goats-bake.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Guide Code Mode shell commands through quote-safe raw command strings
+Document raw `cmd` strings and JavaScript template-literal considerations

--- a/.changeset/grumpy-goats-bake.md
+++ b/.changeset/grumpy-goats-bake.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Trim cosmetic terminal punctuation from model-facing Codex prompts and tool metadata; document raw `cmd` strings and JavaScript template-literal considerations
+Trim cosmetic terminal punctuation from model-facing Codex prompts and tool metadata; document raw `cmd` strings and JavaScript template-literal considerations; guide apply-patch hunk ordering and return clearer, trace-safe recovery errors

--- a/.changeset/grumpy-goats-bake.md
+++ b/.changeset/grumpy-goats-bake.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Guide Code Mode shell commands through quote-safe raw command strings

--- a/.pi/skills/model-facing-api-design/SKILL.md
+++ b/.pi/skills/model-facing-api-design/SKILL.md
@@ -69,6 +69,8 @@ If legacy markers are present, stop the normal wording/token review. If edits ar
    - Remove marketing language, implementation trivia, decorative formatting, and examples that do not prevent real misuse.
    - Do not compress away required evidence, caveats, recovery information, or trigger boundaries merely to improve a token count.
 
+   **Punctuation and token-cost pass:** treat model-facing copy as serialized API payload, not ordinary prose. Omit cosmetic terminal periods from terse labels, one-line fragments, and bullet guidelines when the emitted form saves a token. Preserve structural or meaningful punctuation: quotes, backticks, `${}`, URLs, paths, versions, regexes, decimals, ellipses, code/grammar delimiters, and internal sentence separators. Measure emitted values or serialized schemas rather than TypeScript source lines; compare each mode and conditional tool separately instead of summing mutually exclusive surfaces. Sweep schema descriptions, tool descriptions, `promptSnippet`/guidelines, model-visible results/errors, and secondary-model prompts together, removing duplication before micro-optimizing punctuation
+
 7. **Validate the complete loop.**
    - Check representative selection, valid calls, invalid calls, empty results, failures, and truncated results as relevant to the tool.
    - Confirm the model can distinguish neighboring tools and continue correctly from both success and failure output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 This repo publishes through Changesets; every merge to `main` feeds the version and npm publish workflow.
 
 - Agent-facing text is behavior: keep tool contracts, skill files, prompt metadata, and subagent prompts compact.
+- Agent-facing prose need not perform grammatical polish; optimize semantic signal per token and omit cosmetic punctuation when it saves tokens. Preserve syntax, structural delimiters, meaning, evidence, caveats, and recovery instructions.
 - Do not add tests that merely pin static prose; test parsing, construction, routing, or model-visible behavior instead.
 - Skills and extensions must work for any user. Never ship local paths, personal names, machine assumptions, or private workflow details.
 - Slash commands are for users; agents use tools. Prefer one routed entry command over several command names unless explicitly requested.

--- a/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
@@ -89,7 +89,7 @@ function toCodeModeTool(tool: unknown): unknown {
 		description:
 			typeof tool["description"] === "string"
 				? tool["description"]
-				: "Run JavaScript to compose tools.",
+				: "Run JavaScript to compose tools",
 		format: {
 			type: "grammar",
 			syntax: "lark",

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -60,7 +60,7 @@ function createNestedTools(
 				promptSnippet: false,
 				showDiffWhenCollapsed: !runtime.state.config.ui.compactTools,
 			}),
-			"await tools.apply_patch(patch)",
+			"await tools.apply_patch(patch) // each Update File: hunks top-to-bottom; indentation is literal",
 			{},
 			{
 				kind: "freeform",

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -86,7 +86,7 @@ function createNestedTools(
 		),
 		toNestedTool(
 			createExecCommandTool(runtime.tracker, runtime.sessions, options),
-			"await tools.exec_command({ cmd: string, workdir?: string, shell?: string, tty?: boolean, yield_time_ms?: number, max_output_tokens?: number, login?: boolean })",
+			"await tools.exec_command({ cmd: raw shell string, workdir?: string, shell?: string, tty?: boolean, yield_time_ms?: number, max_output_tokens?: number, login?: boolean })",
 			{
 				start(id, input) {
 					const cmd =

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -86,7 +86,7 @@ function createNestedTools(
 		),
 		toNestedTool(
 			createExecCommandTool(runtime.tracker, runtime.sessions, options),
-			"await tools.exec_command({ cmd: raw shell string, workdir?: string, shell?: string, tty?: boolean, yield_time_ms?: number, max_output_tokens?: number, login?: boolean })",
+			"await tools.exec_command({ cmd: string, workdir?: string, shell?: string, tty?: boolean, yield_time_ms?: number, max_output_tokens?: number, login?: boolean })",
 			{
 				start(id, input) {
 					const cmd =

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -23,7 +23,7 @@ const NORMAL_CODEX_GUIDELINES = [
 const PATH_CODEX_GUIDELINES = [
 	"Use exec_command for shell/file/build/test; prefer rg/rg --files",
 	"Use tty=true for interactive commands",
-	"Use apply_patch for file edits",
+	"Use apply_patch for file edits; order each file's hunks top-to-bottom; indentation is literal",
 	"Do not probe listed PATH tools",
 	"Use stdin/heredoc for quoted or multiline PATH args",
 	"Chain dependent shell commands with &&",

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -12,40 +12,40 @@ export interface StructuredPromptSkill {
 }
 
 const NORMAL_CODEX_GUIDELINES = [
-	"Use exec_command for shell commands, file inspection, builds, and tests; prefer rg / rg --files for discovery and focused commands over truncation.",
-	"Use tty=true for dev servers, watchers, REPLs, and prompts.",
-	"Use apply_patch for text-file changes, including creates/deletes/moves; split oversized patches.",
-	"Prefer the apply_patch tool; use shell apply_patch only when chaining edits with other shell steps.",
-	"Use write_stdin only for running exec_command sessions; poll sparingly.",
-	"Run independent tool calls in parallel when practical.",
+	"Use exec_command for shell commands, file inspection, builds, and tests; prefer rg / rg --files for discovery and focused commands over truncation",
+	"Use tty=true for dev servers, watchers, REPLs, and prompts",
+	"Use apply_patch for text-file changes, including creates/deletes/moves; split oversized patches",
+	"Prefer the apply_patch tool; use shell apply_patch only when chaining edits with other shell steps",
+	"Use write_stdin only for running exec_command sessions; poll sparingly",
+	"Run independent tool calls in parallel when practical",
 ];
 
 const PATH_CODEX_GUIDELINES = [
-	"Use exec_command for shell/file/build/test; prefer rg/rg --files.",
-	"Use tty=true for interactive commands.",
-	"Use apply_patch for file edits; split oversized patches.",
-	"Do not probe listed PATH tools.",
-	"Use stdin/heredoc for quoted or multiline PATH args.",
-	"Chain dependent shell commands with &&.",
-	"Run independent exec_command calls in parallel when practical.",
+	"Use exec_command for shell/file/build/test; prefer rg/rg --files",
+	"Use tty=true for interactive commands",
+	"Use apply_patch for file edits",
+	"Do not probe listed PATH tools",
+	"Use stdin/heredoc for quoted or multiline PATH args",
+	"Chain dependent shell commands with &&",
+	"Run independent exec_command calls in parallel when practical",
 ];
 
 const CODE_MODE_GUIDELINES = [
-	"Use tools.exec_command for shell commands; prefer rg and rg --files for search.",
-	"When calling tools.exec_command from JavaScript, String.raw`...` only avoids JavaScript backslash escapes; it does not shell-escape.",
-	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec.",
-	"Wait proportionally to expected runtime; back off repeated polls.",
-	"Use tty=true for interactive commands.",
-	"Use tools.apply_patch(patch) for file edits; split oversized patches.",
-	"Compose independent nested calls with Promise.all.",
-	"With async work, await dependencies; overlap only independent work.",
-	"Use text() only for concise values needed after exec; do not dump complete nested tool results.",
+	"Use tools.exec_command for shell commands; prefer rg and rg --files for search",
+	"When calling tools.exec_command from JavaScript, String.raw`...` only avoids JavaScript backslash escapes; it does not shell-escape",
+	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec",
+	"Wait proportionally to expected runtime; back off repeated polls",
+	"Use tty=true for interactive commands",
+	"Use tools.apply_patch(patch) for file edits; split oversized patches",
+	"Compose independent nested calls with Promise.all",
+	"With async work, await dependencies; overlap only independent work",
+	"Use text() only for concise values needed after exec; do not dump complete nested tool results",
 ];
 
 const PATH_MODE_REMOVED_GUIDELINES = new Set([
-	"Use apply_patch for text-file changes, including creates/deletes/moves; split oversized patches.",
-	"Prefer the apply_patch tool; use shell apply_patch only when chaining edits with other shell steps.",
-	"Run independent tool calls in parallel when practical.",
+	"Use apply_patch for text-file changes, including creates/deletes/moves; split oversized patches",
+	"Prefer the apply_patch tool; use shell apply_patch only when chaining edits with other shell steps",
+	"Run independent tool calls in parallel when practical",
 ]);
 
 export interface CodexPromptToolOptions {
@@ -150,7 +150,7 @@ function injectSkills(prompt: string, skills: PromptSkill[]): string {
 	const lines = [
 		"<skills_instructions>",
 		"## Skills",
-		"Skill: local instructions in `SKILL.md` file.",
+		"Skill: local instructions in `SKILL.md` file",
 		"### Available skills",
 	];
 
@@ -159,11 +159,11 @@ function injectSkills(prompt: string, skills: PromptSkill[]): string {
 	}
 
 	lines.push("### How to use skills");
-	lines.push("- Use skill when user names it (`$SkillName` or plain text) or request clearly matches its description.");
-	lines.push("- Use the minimal required set of skills. If multiple apply, use them together and state the order briefly.");
-	lines.push("- For each selected skill, open its `SKILL.md`, resolve relative paths from the skill directory first, load only the files you need, and prefer existing scripts/assets/templates over recreating them.");
+	lines.push("- Use skill when user names it (`$SkillName` or plain text) or request clearly matches its description");
+	lines.push("- Use the minimal required set of skills. If multiple apply, use them together and state the order briefly");
+	lines.push("- For each selected skill, open its `SKILL.md`, resolve relative paths from the skill directory first, load only the files you need, and prefer existing scripts/assets/templates over recreating them");
 	lines.push("### Fallback");
-	lines.push("- If skill is missing or path cannot be read, say so briefly and continue with best fallback approach.");
+	lines.push("- If skill is missing or path cannot be read, say so briefly and continue with best fallback approach");
 	lines.push("</skills_instructions>");
 
 	return insertBeforeTrailingContext(prompt, lines.join("\n"));

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -48,6 +48,28 @@ const PATH_MODE_REMOVED_GUIDELINES = new Set([
 	"Run independent tool calls in parallel when practical",
 ]);
 
+const ALL_STATIC_CODEX_GUIDELINES = [
+	...NORMAL_CODEX_GUIDELINES,
+	...PATH_CODEX_GUIDELINES,
+	...CODE_MODE_GUIDELINES,
+];
+
+function withoutCosmeticTerminalPeriod(value: string): string {
+	return value.endsWith(".") && !value.endsWith("..") ? value.slice(0, -1) : value;
+}
+
+const STATIC_CODEX_GUIDELINES_BY_KEY = new Map(
+	ALL_STATIC_CODEX_GUIDELINES.map((guideline) => [withoutCosmeticTerminalPeriod(guideline), guideline]),
+);
+
+function canonicalizeGuidelineLine(line: string): string {
+	const match = line.match(/^(\s*-\s+)(.*)$/);
+	if (!match) return line;
+	const key = withoutCosmeticTerminalPeriod(match[2]!.trim());
+	const canonical = STATIC_CODEX_GUIDELINES_BY_KEY.get(key);
+	return canonical ? `${match[1]}${canonical}` : line;
+}
+
 export interface CodexPromptToolOptions {
 	viewImage?: boolean | undefined;
 	webRun?: boolean | undefined;
@@ -178,15 +200,16 @@ function injectGuidelines(prompt: string, mode?: CodexPromptMode, tools?: CodexP
 
 	const [, header, body, suffix] = match as RegExpMatchArray & { 1: string; 2: string; 3: string };
 	const bodyLines = body.split("\n");
+	const canonicalBodyLines = bodyLines.map(canonicalizeGuidelineLine);
 	const keptBodyLines = mode === "path" || mode === "code"
-		? bodyLines.filter((line) => !PATH_MODE_REMOVED_GUIDELINES.has(line.trim().replace(/^-\s*/, "")))
-		: bodyLines;
+		? canonicalBodyLines.filter((line) => !PATH_MODE_REMOVED_GUIDELINES.has(withoutCosmeticTerminalPeriod(line.trim().replace(/^-\s*/, ""))))
+		: canonicalBodyLines;
 	const existingLines = keptBodyLines
 		.map((line) => line.trim())
 		.filter((line) => line.startsWith("- "));
 	const existing = new Set(existingLines.map((line) => line.slice(2)));
 	const additions = buildCodexGuidelines(mode, tools).filter((line) => !existing.has(line)).map((line) => `- ${line}`);
-	if (additions.length === 0) {
+	if (additions.length === 0 && keptBodyLines.join("\n") === body) {
 		return prompt;
 	}
 

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -32,6 +32,7 @@ const PATH_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search.",
+	"Pass tools.exec_command cmd as a raw shell string; do not wrap the entire command in quotes. For embedded shell quotes, use String.raw`...`.",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec.",
 	"Wait proportionally to expected runtime; back off repeated polls.",
 	"Use tty=true for interactive commands.",

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -32,7 +32,7 @@ const PATH_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search.",
-	"Pass tools.exec_command cmd as a raw shell string; do not wrap the entire command in quotes. String.raw`...` only avoids JavaScript backslash escapes; it does not shell-escape, and ${...}/backticks still need JavaScript escaping.",
+	"When calling tools.exec_command from JavaScript, String.raw`...` only avoids JavaScript backslash escapes; it does not shell-escape.",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec.",
 	"Wait proportionally to expected runtime; back off repeated polls.",
 	"Use tty=true for interactive commands.",

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -32,7 +32,7 @@ const PATH_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search.",
-	"Pass tools.exec_command cmd as a raw shell string; do not wrap the entire command in quotes. For embedded shell quotes, use String.raw`...`.",
+	"Pass tools.exec_command cmd as a raw shell string; do not wrap the entire command in quotes. String.raw`...` only avoids JavaScript backslash escapes; it does not shell-escape, and ${...}/backticks still need JavaScript escaping.",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec.",
 	"Wait proportionally to expected runtime; back off repeated polls.",
 	"Use tty=true for interactive commands.",

--- a/packages/pi-codex-conversion/src/tools/apply-patch/executor.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/executor.ts
@@ -31,6 +31,16 @@ function errorMentionsAction(error: string, action: { path: string; movePath?: s
 	return error.includes(action.path) || (action.movePath ? error.includes(action.movePath) : false);
 }
 
+function collapseDuplicatedError(message: string): string {
+	const separator = ": ";
+	const halfLength = (message.length - separator.length) / 2;
+	if (!Number.isInteger(halfLength) || halfLength <= 0) return message;
+	const first = message.slice(0, halfLength);
+	return message.slice(halfLength, halfLength + separator.length) === separator && message.slice(halfLength + separator.length) === first
+		? first
+		: message;
+}
+
 export async function executePatchWithRust({ cwd, patchText, signal }: { cwd: string; patchText: string; signal?: AbortSignal | undefined }): Promise<ExecutePatchResult> {
 	const binary = getBundledApplyPatchBinaryPath();
 	if (!binary) {
@@ -51,7 +61,7 @@ export async function executePatchWithRust({ cwd, patchText, signal }: { cwd: st
 	}
 
 	const result = parsed.result ?? { changedFiles: [], createdFiles: [], deletedFiles: [], movedFiles: [], fuzz: 0 };
-	const errorMessage = parsed.error ?? child.stderr ?? "apply_patch failed";
+	const errorMessage = collapseDuplicatedError(parsed.error ?? child.stderr ?? "apply_patch failed");
 	let parsedActions = [] as ReturnType<typeof parsePatchActions>;
 	try {
 		parsedActions = parsePatchActions({ text: patchText }).map((action) => ({
@@ -64,6 +74,5 @@ export async function executePatchWithRust({ cwd, patchText, signal }: { cwd: st
 	}
 	const failureAction = parsedActions.find((action) => errorMentionsAction(errorMessage, action));
 	const failures = failureAction ? [{ action: failureAction, message: errorMessage }] : [];
-	throw new ExecutePatchError(parsed.error ?? child.stderr ?? "apply_patch failed", result, failures);
+	throw new ExecutePatchError(errorMessage, result, failures);
 }
-

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -17,7 +17,7 @@ import {
 
 const APPLY_PATCH_PARAMETERS = Type.Object({
 	input: Type.String({
-		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections.",
+		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections",
 	}),
 });
 
@@ -74,11 +74,11 @@ function buildPartialFailureMessage(message: string, failedFiles: string[], appl
 	const lines = [message];
 	if (failedFiles.length > 0) {
 		lines.push(`Failed file${failedFiles.length === 1 ? "" : "s"}: ${failedFiles.join(", ")}`);
-		lines.push(`Recovery: MUST read ${failedFiles.join(", ")} before retrying.`);
+		lines.push(`Recovery: MUST read ${failedFiles.join(", ")} before retrying`);
 	}
 	if (appliedFiles.length > 0) {
-		lines.push("Earlier file actions in this patch were already applied.");
-		lines.push("Recovery: MUST NOT reread other files from this patch unless a specific dependency requires it.");
+		lines.push("Earlier file actions in this patch were already applied");
+		lines.push("Recovery: MUST NOT reread other files from this patch unless a specific dependency requires it");
 	}
 	return lines.join("\n");
 }
@@ -101,8 +101,8 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 	return {
 		name: "apply_patch",
 		label: "apply_patch",
-		description: "Patch files.",
-		...(options.promptSnippet === false ? {} : { promptSnippet: "Edit files with patch." }),
+		description: "Patch files",
+		...(options.promptSnippet === false ? {} : { promptSnippet: "Edit files with patch" }),
 		parameters: APPLY_PATCH_PARAMETERS,
 		prepareArguments: prepareApplyPatchArguments,
 		async execute(toolCallId, params, signal, _onUpdate, ctx) {
@@ -145,7 +145,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 				throw error;
 			}
 			const summary = [
-				"Applied patch successfully.",
+				"Applied patch successfully",
 				`Changed files: ${result.changedFiles.length}`,
 				`Created files: ${result.createdFiles.length}`,
 				`Deleted files: ${result.deletedFiles.length}`,

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -83,8 +83,8 @@ function buildPartialFailureMessage(message: string, failedFiles: string[], appl
 	return lines.join("\n");
 }
 
-function addPatchRetryHint(message: string): string {
-	if (!message.includes("Failed to find expected lines")) return message;
+function addPatchRetryHint(message: string, cause: string): string {
+	if (!cause.startsWith("Failed to find expected lines")) return message;
 	return `${message}\nRecovery: order each Update File's hunks top-to-bottom and copy exact indentation before retrying`;
 }
 
@@ -125,7 +125,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 					const failedTargetSummary = failedTargets.join(", ");
 					const prefix = partial ? `apply_patch partially failed after ${summarizePatchCounts(error.result)}` : "apply_patch failed";
 					const rawMessage = failedTargetSummary ? `${prefix} while patching ${failedTargetSummary}: ${error.message}` : `${prefix}: ${error.message}`;
-					const message = addPatchRetryHint(rawMessage);
+					const message = addPatchRetryHint(rawMessage, error.message);
 					if (partial) {
 						const failedFiles = getFailedPaths(error);
 						const appliedFiles = getAppliedPaths(error.result, failedFiles);

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -17,7 +17,7 @@ import {
 
 const APPLY_PATCH_PARAMETERS = Type.Object({
 	input: Type.String({
-		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections",
+		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections. Order each file's hunks top-to-bottom; indentation is literal",
 	}),
 });
 
@@ -83,6 +83,11 @@ function buildPartialFailureMessage(message: string, failedFiles: string[], appl
 	return lines.join("\n");
 }
 
+function addPatchRetryHint(message: string): string {
+	if (!message.includes("Failed to find expected lines")) return message;
+	return `${message}\nRecovery: order each Update File's hunks top-to-bottom and copy exact indentation before retrying`;
+}
+
 function describeFailedActions(error: ExecutePatchError, cwd: string): string[] {
 	return uniqueStrings(error.failures.map(({ action }) => formatPatchTarget(action.path, action.type === "update" ? action.movePath : undefined, cwd)));
 }
@@ -119,7 +124,8 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 					const failedTargets = describeFailedActions(error, ctx.cwd);
 					const failedTargetSummary = failedTargets.join(", ");
 					const prefix = partial ? `apply_patch partially failed after ${summarizePatchCounts(error.result)}` : "apply_patch failed";
-					const message = failedTargetSummary ? `${prefix} while patching ${failedTargetSummary}: ${error.message}` : `${prefix}: ${error.message}`;
+					const rawMessage = failedTargetSummary ? `${prefix} while patching ${failedTargetSummary}: ${error.message}` : `${prefix}: ${error.message}`;
+					const message = addPatchRetryHint(rawMessage);
 					if (partial) {
 						const failedFiles = getFailedPaths(error);
 						const appliedFiles = getAppliedPaths(error.result, failedFiles);
@@ -134,7 +140,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 								failedTargets,
 								appliedFiles,
 								failedFiles,
-								recoveryInstructions: { mustReadFiles: failedFiles, mustNotReadFiles: appliedFiles },
+								recoveryInstructions: { mustReadFiles: [...failedFiles], mustNotReadFiles: [...appliedFiles] },
 							} satisfies ApplyPatchPartialFailureDetails,
 						};
 					}

--- a/packages/pi-codex-conversion/src/tools/code-mode/binary.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/binary.ts
@@ -39,7 +39,7 @@ export function codeModeHostBinaryPath(): string {
 	const cached = codeModeHostCachePath(name);
 	if (existsSync(cached)) return cached;
 	throw new Error(
-		`No code-mode host binary for ${process.platform}-${process.arch}. Reinstall the package or build it with \`bun run build:code-mode-host\`.`,
+		`No code-mode host binary for ${process.platform}-${process.arch}. Reinstall the package or build it with \`bun run build:code-mode-host\``,
 	);
 }
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -1,17 +1,17 @@
 import type { CodeModeToolMetadata } from "./types.js";
 
-export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls.
+export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls
 Optional first line: // @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}
-Emit output with text(value); console is unavailable.
-Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS.`;
+Emit output with text(value); console is unavailable
+Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS`;
 
 export const WAIT_DESCRIPTION =
-	"Resume or terminate an exec cell; use tools.write_stdin for session_id.";
+	"Resume or terminate an exec cell; use tools.write_stdin for session_id";
 
 const PROMOTED_TOOLS_HEADING = "Custom tools available in exec:";
 const DOCUMENTATION_PREFIX = "Custom tools documentation: read ";
 const CUSTOM_TOOLS_GUIDANCE =
-	"Prefer a custom tool over a Pi extension for a command-backed capability.";
+	"Prefer a custom tool over a Pi extension for a command-backed capability";
 
 export function formatCustomToolHelp(tool: CodeModeToolMetadata): string {
 	return [

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -1,6 +1,6 @@
 import type { CodeModeToolMetadata } from "./types.js";
 
-export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls. Pass tools.exec_command cmd as a raw shell string, not a whole shell-quoted command. String.raw\`...\` only avoids JavaScript backslash escapes; it does not shell-escape, and \${...}/backticks still need JavaScript escaping.
+export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls.
 Optional first line: // @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}
 Emit output with text(value); console is unavailable.
 Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS.`;

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -1,6 +1,6 @@
 import type { CodeModeToolMetadata } from "./types.js";
 
-export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls. Pass tools.exec_command cmd as a raw shell string, not a whole shell-quoted command; use String.raw\`...\` when embedded shell quotes would make the JavaScript string noisy.
+export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls. Pass tools.exec_command cmd as a raw shell string, not a whole shell-quoted command. String.raw\`...\` only avoids JavaScript backslash escapes; it does not shell-escape, and \${...}/backticks still need JavaScript escaping.
 Optional first line: // @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}
 Emit output with text(value); console is unavailable.
 Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS.`;

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -1,6 +1,6 @@
 import type { CodeModeToolMetadata } from "./types.js";
 
-export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls.
+export const EXEC_DESCRIPTION = `Run raw JavaScript to compose tool calls. Pass tools.exec_command cmd as a raw shell string, not a whole shell-quoted command; use String.raw\`...\` when embedded shell quotes would make the JavaScript string noisy.
 Optional first line: // @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}
 Emit output with text(value); console is unavailable.
 Globals: tools, text, image, generatedImage, store, load, notify, yield_control, exit, setTimeout, clearTimeout, ALL_TOOLS.`;

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tools.ts
@@ -204,7 +204,7 @@ function loadCustomTool(
 		}
 		return {
 			name,
-			usage: "Disabled: fix this tool's TOML definition before calling it.",
+			usage: "Disabled: fix this tool's TOML definition before calling it",
 			description: message,
 			deferLoading: true,
 			command: "",

--- a/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/public-tools.ts
@@ -65,7 +65,7 @@ function createExecTool(
 		name: "exec",
 		label: "Exec",
 		description: EXEC_DESCRIPTION,
-		promptSnippet: "Compose tools with JavaScript.",
+		promptSnippet: "Compose tools with JavaScript",
 		parameters: EXEC_PARAMETERS,
 		async execute(id, params, signal, onUpdate, ctx) {
 			tracker.start(id);
@@ -112,7 +112,7 @@ function createWaitTool(
 		name: "wait",
 		label: "Wait",
 		description: WAIT_DESCRIPTION,
-		promptSnippet: "Resume or terminate an exec cell.",
+		promptSnippet: "Resume or terminate an exec cell",
 		parameters: WAIT_PARAMETERS,
 		async execute(id, params, signal, onUpdate, ctx) {
 			tracker.start(id);
@@ -236,7 +236,7 @@ async function continueExecSessionFromMistakenWait(
 			content: [
 				{
 					type: "text",
-					text: `Recovered wait cell_id ${cellId} as exec_command session_id ${sessionId} and continued it with write_stdin.`,
+					text: `Recovered wait cell_id ${cellId} as exec_command session_id ${sessionId} and continued it with write_stdin`,
 				},
 				...(output ? [{ type: "text" as const, text: output }] : []),
 				...(exitCode === undefined
@@ -244,14 +244,14 @@ async function continueExecSessionFromMistakenWait(
 					: [
 							{
 								type: "text" as const,
-								text: `Process exited with code ${exitCode}.`,
+								text: `Process exited with code ${exitCode}`,
 							},
 						]),
 				...(running
 					? [
 							{
 								type: "text" as const,
-								text: `exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} }).`,
+								text: `exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} })`,
 							},
 						]
 					: []),

--- a/packages/pi-codex-conversion/src/tools/code-mode/tool-result.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tool-result.ts
@@ -95,7 +95,7 @@ function runningExecSessionGuidance(
 	}
 	return [...sessionIds].map(
 		(sessionId) =>
-			`exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} }); wait is only for a yielded exec cell_id.`,
+			`exec_command session ${sessionId} is still running. Continue with exec and tools.write_stdin({ session_id: ${sessionId} }); wait is only for a yielded exec cell_id`,
 	);
 }
 

--- a/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
@@ -23,7 +23,7 @@ export interface ExecBridgeClient {
 }
 
 const MAX_BRIDGE_STDERR_CHARS = 16_000;
-const LOCAL_BUILD_GUIDANCE = "Bundled exec_bridge is incompatible with this Linux runtime. From a pi-codex-conversion Git checkout, run: bun install && bun run build:path-tool codex-exec-shim exec_bridge, then load that checkout's src/index.ts as the Pi extension.";
+const LOCAL_BUILD_GUIDANCE = "Bundled exec_bridge is incompatible with this Linux runtime. From a pi-codex-conversion Git checkout, run: bun install && bun run build:path-tool codex-exec-shim exec_bridge, then load that checkout's src/index.ts as the Pi extension";
 
 function appendBoundedText(current: string, next: Buffer): string {
 	const combined = `${current}${next.toString("utf8")}`;

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -325,7 +325,7 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 	const tool: Parameters<ExtensionAPI["registerTool"]>[0] = {
 		name: "exec_command",
 		label: "exec_command",
-		description: "Run a raw command string in the current shell; may return session_id. Do not wrap the entire cmd in shell quotes.",
+		description: "Run shell commands; may return session_id.",
 		...(options.promptSnippet === false ? {} : { promptSnippet: "Run command." }),
 		parameters: EXEC_COMMAND_PARAMETERS,
 		prepareArguments: prepareExecCommandArguments as (args: unknown) => { cmd: string; workdir?: string; shell?: string; tty?: boolean; yield_time_ms?: number; max_output_tokens?: number; login?: boolean },

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -18,17 +18,17 @@ import { codexToolProviderEnv, resolveCodexToolProvider } from "../../adapter/co
 export { imageContentFromCodexViewImageOutput, imageContentsFromCodexViewImageOutput } from "../path/outputs.ts";
 
 const EXEC_COMMAND_PARAMETERS = Type.Object({
-	cmd: Type.String({ description: "Raw command string interpreted by the current shell; do not quote the entire command." }),
-	workdir: Type.Optional(Type.String({ description: "Cwd." })),
+	cmd: Type.String({ description: "Raw command string interpreted by the current shell; do not quote the entire command" }),
+	workdir: Type.Optional(Type.String({ description: "Cwd" })),
 	shell: Type.Optional(Type.String()),
 	tty: Type.Optional(
 		Type.Boolean({
-			description: "TTY.",
+			description: "TTY",
 		}),
 	),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms." })),
-	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate." })),
-	login: Type.Optional(Type.Boolean({ description: "Login shell." })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
+	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
+	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });
 
 interface ExecCommandParams {
@@ -325,8 +325,8 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 	const tool: Parameters<ExtensionAPI["registerTool"]>[0] = {
 		name: "exec_command",
 		label: "exec_command",
-		description: "Run shell commands; may return session_id.",
-		...(options.promptSnippet === false ? {} : { promptSnippet: "Run command." }),
+		description: "Run shell commands; may return session_id",
+		...(options.promptSnippet === false ? {} : { promptSnippet: "Run command" }),
 		parameters: EXEC_COMMAND_PARAMETERS,
 		prepareArguments: prepareExecCommandArguments as (args: unknown) => { cmd: string; workdir?: string; shell?: string; tty?: boolean; yield_time_ms?: number; max_output_tokens?: number; login?: boolean },
 		async execute(toolCallId, params, signal, onUpdate, ctx) {

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -18,7 +18,7 @@ import { codexToolProviderEnv, resolveCodexToolProvider } from "../../adapter/co
 export { imageContentFromCodexViewImageOutput, imageContentsFromCodexViewImageOutput } from "../path/outputs.ts";
 
 const EXEC_COMMAND_PARAMETERS = Type.Object({
-	cmd: Type.String(),
+	cmd: Type.String({ description: "Raw command string interpreted by the current shell; do not quote the entire command." }),
 	workdir: Type.Optional(Type.String({ description: "Cwd." })),
 	shell: Type.Optional(Type.String()),
 	tty: Type.Optional(
@@ -325,7 +325,7 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 	const tool: Parameters<ExtensionAPI["registerTool"]>[0] = {
 		name: "exec_command",
 		label: "exec_command",
-		description: "Run shell commands; may return session_id.",
+		description: "Run a raw command string in the current shell; may return session_id. Do not wrap the entire cmd in shell quotes.",
 		...(options.promptSnippet === false ? {} : { promptSnippet: "Run command." }),
 		parameters: EXEC_COMMAND_PARAMETERS,
 		prepareArguments: prepareExecCommandArguments as (args: unknown) => { cmd: string; workdir?: string; shell?: string; tty?: boolean; yield_time_ms?: number; max_output_tokens?: number; login?: boolean },

--- a/packages/pi-codex-conversion/src/tools/exec/write-stdin-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/write-stdin-tool.ts
@@ -8,10 +8,10 @@ import { convertPathToolExecResult, getPathToolPolicy, imageContentsFromPathTool
 import { renderTextWithImages } from "../path/rendering.ts";
 
 const WRITE_STDIN_PARAMETERS = Type.Object({
-	session_id: Type.Number({ description: "Session ID." }),
-	chars: Type.Optional(Type.String({ description: "Input. Empty polls." })),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms." })),
-	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate." })),
+	session_id: Type.Number({ description: "Session ID" }),
+	chars: Type.Optional(Type.String({ description: "Input. Empty polls" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
+	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 });
 
 interface WriteStdinParams {
@@ -111,8 +111,8 @@ export function createWriteStdinTool(sessions: ExecSessionManager, options: { pr
 	const tool: Parameters<ExtensionAPI["registerTool"]>[0] = {
 		name: "write_stdin",
 		label: "write_stdin",
-		description: "Write/poll exec session.",
-		...(options.promptSnippet === false ? {} : { promptSnippet: "Write to exec session." }),
+		description: "Write/poll exec session",
+		...(options.promptSnippet === false ? {} : { promptSnippet: "Write to exec session" }),
 		parameters: WRITE_STDIN_PARAMETERS,
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			const typed = parseWriteStdinParams(params);

--- a/packages/pi-codex-conversion/src/tools/imagegen/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/imagegen/tool.ts
@@ -12,8 +12,8 @@ import { renderCodexToolCell } from "../../ui/tool-rendering/codex-tool-cell.ts"
 export const IMAGE_GENERATION_UNSUPPORTED_MESSAGE = "imagegen requires an image-capable OpenAI Codex-compatible Responses provider";
 const IMAGE_GENERATION_PARAMETERS = Type.Object({
 	prompt: Type.String(),
-	action: Type.Optional(Type.Union([Type.Literal("generate"), Type.Literal("edit")], { description: "Default generate." })),
-	images: Type.Optional(Type.Array(Type.String(), { description: "Edit inputs." })),
+	action: Type.Optional(Type.Union([Type.Literal("generate"), Type.Literal("edit")], { description: "Default generate" })),
+	images: Type.Optional(Type.Array(Type.String(), { description: "Edit inputs" })),
 });
 
 type ImagegenArgs = {
@@ -64,7 +64,7 @@ export interface ImageGenerationToolOptions {
 }
 
 export function createImageGenerationTool(options: ImageGenerationToolOptions = {}): ToolDefinition<typeof IMAGE_GENERATION_PARAMETERS, ImagegenDetails> {
-	const description = "Generate/edit images.";
+	const description = "Generate/edit images";
 	return {
 		name: IMAGE_GENERATION_TOOL_NAME,
 		label: IMAGE_GENERATION_TOOL_NAME,

--- a/packages/pi-codex-conversion/src/tools/view-image/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/view-image/tool.ts
@@ -16,7 +16,7 @@ import { renderCodexToolCell } from "../../ui/tool-rendering/codex-tool-cell.ts"
 
 const VIEW_IMAGE_UNSUPPORTED_MESSAGE = "view_image is not allowed because you do not support image inputs";
 const IMAGE_DESCRIPTION_MODEL = "gpt-5.6-luna";
-const IMAGE_DESCRIPTION_PROMPT = "Describe this image in detail. Output only the image description, no other commentary.";
+const IMAGE_DESCRIPTION_PROMPT = "Describe this image in detail. Output only the image description, no other commentary";
 interface ViewImageParams {
 	path: string;
 }
@@ -84,7 +84,7 @@ async function executeRustViewImageContent(params: ViewImageParams, cwd: string,
 	}
 	const imageContent = imageContentFromCodexViewImageOutput(child.stdout);
 	if (!imageContent) {
-		throw new Error("view_image expected an image file. Use exec_command for text files.");
+		throw new Error("view_image expected an image file. Use exec_command for text files");
 	}
 	return imageContent;
 }
@@ -169,7 +169,7 @@ export async function describeImageContentForTextModel(image: PathViewImageConte
 			input: [{
 				role: "user",
 				content: [
-					{ type: "input_text", text: "Describe the image." },
+					{ type: "input_text", text: "Describe the image" },
 					{ type: "input_image", image_url: `data:${image.mimeType};base64,${image.data}`, detail: image.detail },
 				],
 			}],
@@ -198,8 +198,8 @@ export function createViewImageTool(options: CreateViewImageToolOptions = {}): T
 	return {
 		name: "view_image",
 		label: "view_image",
-		description: "View image.",
-		...(options.promptSnippet === false ? {} : { promptSnippet: "View image." }),
+		description: "View image",
+		...(options.promptSnippet === false ? {} : { promptSnippet: "View image" }),
 		parameters,
 		prepareArguments: prepareViewImageArguments,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {

--- a/packages/pi-codex-conversion/src/tools/web-run/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/web-run/tool.ts
@@ -15,17 +15,17 @@ export const WEB_SEARCH_SESSION_NOTE_TYPE = "codex-web-search-session-note";
 
 const SearchQueryParameters = Type.Object({
 	q: Type.String(),
-	recency: Type.Optional(Type.Number({ description: "Recent days." })),
-	domains: Type.Optional(Type.Array(Type.String(), { description: "Domains." })),
+	recency: Type.Optional(Type.Number({ description: "Recent days" })),
+	domains: Type.Optional(Type.Array(Type.String(), { description: "Domains" })),
 }, { additionalProperties: true });
 
 const WEB_SEARCH_PARAMETERS = Type.Object({
 	search_query: Type.Optional(Type.Array(SearchQueryParameters)),
 	image_query: Type.Optional(Type.Array(SearchQueryParameters)),
-	open: Type.Optional(Type.Array(Type.Object({ ref_id: Type.String(), lineno: Type.Optional(Type.Number()) }, { additionalProperties: true }), { description: "ref_id or URL." })),
+	open: Type.Optional(Type.Array(Type.Object({ ref_id: Type.String(), lineno: Type.Optional(Type.Number()) }, { additionalProperties: true }), { description: "ref_id or URL" })),
 	click: Type.Optional(Type.Array(Type.Object({ ref_id: Type.String(), id: Type.Number() }, { additionalProperties: true }))),
 	find: Type.Optional(Type.Array(Type.Object({ ref_id: Type.String(), pattern: Type.String() }, { additionalProperties: true }))),
-	response_length: Type.Optional(Type.Union([Type.Literal("short"), Type.Literal("medium"), Type.Literal("long")], { description: "Answer length." })),
+	response_length: Type.Optional(Type.Union([Type.Literal("short"), Type.Literal("medium"), Type.Literal("long")], { description: "Answer length" })),
 	settings: Type.Optional(Type.Object({
 		search_context_size: Type.Optional(Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")])),
 	}, { additionalProperties: true })),
@@ -203,8 +203,8 @@ export function createWebSearchTool(name: string = WEB_SEARCH_TOOL_NAME, options
 	return {
 		name,
 		label: name,
-		description: "Search/open web.",
-		...(toolOptions.promptSnippet === false ? {} : { promptSnippet: "Use explicit args." }),
+		description: "Search/open web",
+		...(toolOptions.promptSnippet === false ? {} : { promptSnippet: "Use explicit args" }),
 		parameters: WEB_SEARCH_PARAMETERS,
 		prepareArguments: (args) => args && typeof args === "object" ? args as Record<string, unknown> : {},
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -62,9 +62,9 @@ test("apply_patch reports partial failures with recovery metadata", async () => 
 		};
 		assert.equal(result.content[0]!?.type, "text");
 		assert.match(result.content[0]!?.text ?? "", /partially failed/i);
-		assert.match(result.content[0]!?.text ?? "", /MUST read missing\.txt before retrying\./);
-		assert.match(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied\./);
-		assert.match(result.content[0]!?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it\./);
+		assert.match(result.content[0]!?.text ?? "", /MUST read missing\.txt before retrying/);
+		assert.match(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied/);
+		assert.match(result.content[0]!?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it/);
 		assert.deepEqual(result.details?.failedFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.appliedFiles, ["created.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -73,6 +73,44 @@ test("apply_patch reports partial failures with recovery metadata", async () => 
 		assert.deepEqual(result.details?.appliedFiles, ["created.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustNotReadFiles, ["created.txt"]);
+		assert.notStrictEqual(result.details?.recoveryInstructions?.mustReadFiles, result.details?.failedFiles);
+		assert.notStrictEqual(result.details?.recoveryInstructions?.mustNotReadFiles, result.details?.appliedFiles);
+	} finally {
+		clearApplyPatchRenderState();
+		await rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("apply_patch explains out-of-order hunk recovery without changing the file", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-codex-conversion-"));
+	const filePath = join(cwd, "ordered.txt");
+	const { pi, getTool } = createRegisteredTool();
+	registerApplyPatchTool(pi);
+
+	try {
+		writeFileSync(filePath, "one\ntwo\nthree\nfour\n", "utf8");
+		const patch = `*** Begin Patch
+*** Update File: ordered.txt
+@@
+-four
++FOUR
+@@
+-two
++TWO
+*** End Patch`;
+		const execute = getTool().execute;
+		assert.ok(execute);
+
+		await assert.rejects(
+			execute("call-out-of-order", { input: patch }, undefined, undefined, { cwd }),
+			(error: Error) => {
+				assert.equal(error.message.match(/Failed to find expected lines/g)?.length, 1);
+				assert.match(error.message, /order each Update File's hunks top-to-bottom/);
+				assert.match(error.message, /copy exact indentation/);
+				return true;
+			},
+		);
+		assert.equal(await readFile(filePath, "utf8"), "one\ntwo\nthree\nfour\n");
 	} finally {
 		clearApplyPatchRenderState();
 		await rm(cwd, { recursive: true, force: true });

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -81,7 +81,7 @@ test("apply_patch reports partial failures with recovery metadata", async () => 
 	}
 });
 
-test("apply_patch explains out-of-order hunk recovery without changing the file", async () => {
+test("apply_patch explains out-of-order hunk recovery and preserves other errors", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-codex-conversion-"));
 	const filePath = join(cwd, "ordered.txt");
 	const { pi, getTool } = createRegisteredTool();
@@ -111,6 +111,15 @@ test("apply_patch explains out-of-order hunk recovery without changing the file"
 			},
 		);
 		assert.equal(await readFile(filePath, "utf8"), "one\ntwo\nthree\nfour\n");
+
+		await assert.rejects(
+			execute("call-invalid-patch", { input: "not a patch" }, undefined, undefined, { cwd }),
+			(error: Error) => {
+				assert.match(error.message, /The first line of the patch must be '\*\*\* Begin Patch'/);
+				assert.doesNotMatch(error.message, /hunks top-to-bottom/);
+				return true;
+			},
+		);
 	} finally {
 		clearApplyPatchRenderState();
 		await rm(cwd, { recursive: true, force: true });

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -61,65 +61,14 @@ test("apply_patch reports partial failures with recovery metadata", async () => 
 			};
 		};
 		assert.equal(result.content[0]!?.type, "text");
-		const output = result.content[0]!?.text ?? "";
-		assert.match(output, /partially failed/i);
-		assert.match(output, /MUST read missing\.txt before retrying/);
-		assert.match(output, /Earlier file actions in this patch were already applied/);
-		assert.match(output, /MUST NOT reread other files from this patch unless a specific dependency requires it/);
-		assert.doesNotMatch(output, /before retrying\./);
-		assert.doesNotMatch(output, /applied\./);
-		assert.doesNotMatch(output, /requires it\./);
+		assert.match(result.content[0]!?.text ?? "", /partially failed/i);
+		assert.match(result.content[0]!?.text ?? "", /MUST read missing\.txt before retrying/);
+		assert.match(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied/);
+		assert.match(result.content[0]!?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it/);
 		assert.deepEqual(result.details?.failedFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.appliedFiles, ["created.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustNotReadFiles, ["created.txt"]);
-		assert.notStrictEqual(result.details?.recoveryInstructions?.mustReadFiles, result.details?.failedFiles);
-		assert.notStrictEqual(result.details?.recoveryInstructions?.mustNotReadFiles, result.details?.appliedFiles);
-	} finally {
-		clearApplyPatchRenderState();
-		await rm(cwd, { recursive: true, force: true });
-	}
-});
-
-test("apply_patch explains out-of-order hunk recovery and preserves other errors", async () => {
-	const cwd = mkdtempSync(join(tmpdir(), "pi-codex-conversion-"));
-	const filePath = join(cwd, "ordered.txt");
-	const { pi, getTool } = createRegisteredTool();
-	registerApplyPatchTool(pi);
-
-	try {
-		writeFileSync(filePath, "one\ntwo\nthree\nfour\n", "utf8");
-		const patch = `*** Begin Patch
-*** Update File: ordered.txt
-@@
--four
-+FOUR
-@@
--two
-+TWO
-*** End Patch`;
-		const execute = getTool().execute;
-		assert.ok(execute);
-
-		await assert.rejects(
-			execute("call-out-of-order", { input: patch }, undefined, undefined, { cwd }),
-			(error: Error) => {
-				assert.equal(error.message.match(/Failed to find expected lines/g)?.length, 1);
-				assert.match(error.message, /order each Update File's hunks top-to-bottom/);
-				assert.match(error.message, /copy exact indentation/);
-				return true;
-			},
-		);
-		assert.equal(await readFile(filePath, "utf8"), "one\ntwo\nthree\nfour\n");
-
-		await assert.rejects(
-			execute("call-invalid-patch", { input: "not a patch" }, undefined, undefined, { cwd }),
-			(error: Error) => {
-				assert.match(error.message, /The first line of the patch must be '\*\*\* Begin Patch'/);
-				assert.doesNotMatch(error.message, /hunks top-to-bottom/);
-				return true;
-			},
-		);
 	} finally {
 		clearApplyPatchRenderState();
 		await rm(cwd, { recursive: true, force: true });

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -61,10 +61,14 @@ test("apply_patch reports partial failures with recovery metadata", async () => 
 			};
 		};
 		assert.equal(result.content[0]!?.type, "text");
-		assert.match(result.content[0]!?.text ?? "", /partially failed/i);
-		assert.match(result.content[0]!?.text ?? "", /MUST read missing\.txt before retrying/);
-		assert.match(result.content[0]!?.text ?? "", /Earlier file actions in this patch were already applied/);
-		assert.match(result.content[0]!?.text ?? "", /MUST NOT reread other files from this patch unless a specific dependency requires it/);
+		const output = result.content[0]!?.text ?? "";
+		assert.match(output, /partially failed/i);
+		assert.match(output, /MUST read missing\.txt before retrying/);
+		assert.match(output, /Earlier file actions in this patch were already applied/);
+		assert.match(output, /MUST NOT reread other files from this patch unless a specific dependency requires it/);
+		assert.doesNotMatch(output, /before retrying\./);
+		assert.doesNotMatch(output, /applied\./);
+		assert.doesNotMatch(output, /requires it\./);
 		assert.deepEqual(result.details?.failedFiles, ["missing.txt"]);
 		assert.deepEqual(result.details?.appliedFiles, ["created.txt"]);
 		assert.deepEqual(result.details?.recoveryInstructions?.mustReadFiles, ["missing.txt"]);

--- a/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
@@ -112,36 +112,3 @@ test("Code Mode invokes and renders the conversion shell through V8", async () =
 		await fixture.close();
 	}
 });
-
-test("Code Mode preserves shell quoting when cmd uses String.raw", async () => {
-	const fixture = await createCodeModeHarness();
-	try {
-		const exec = fixture.tools.get("exec");
-		assert.ok(exec);
-		const result = await exec.execute(
-			"exec-quoted",
-			{
-				code: 'text(await tools.exec_command({ cmd: String.raw`printf "%s" "\\${CODE_MODE_LITERAL}"` }));',
-			},
-			undefined,
-			undefined,
-			{
-				cwd: process.cwd(),
-				model: {
-					provider: "openai-codex",
-					api: "openai-codex-responses",
-					id: "gpt-5.6-luna",
-					input: ["text"],
-				},
-			} as never,
-		);
-		assert.match(
-			result.content
-				.map((item: { text?: string }) => item.text ?? "")
-				.join("\n"),
-			/\$\{CODE_MODE_LITERAL\}/,
-		);
-	} finally {
-		await fixture.close();
-	}
-});

--- a/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
@@ -121,7 +121,7 @@ test("Code Mode preserves shell quoting when cmd uses String.raw", async () => {
 		const result = await exec.execute(
 			"exec-quoted",
 			{
-				code: 'text(await tools.exec_command({ cmd: String.raw`printf "%s" "code-mode-quoted"` }));',
+				code: 'text(await tools.exec_command({ cmd: String.raw`printf "%s" "\\${CODE_MODE_LITERAL}"` }));',
 			},
 			undefined,
 			undefined,
@@ -139,7 +139,7 @@ test("Code Mode preserves shell quoting when cmd uses String.raw", async () => {
 			result.content
 				.map((item: { text?: string }) => item.text ?? "")
 				.join("\n"),
-			/code-mode-quoted/,
+			/\$\{CODE_MODE_LITERAL\}/,
 		);
 	} finally {
 		await fixture.close();

--- a/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/shell.ts
@@ -112,3 +112,36 @@ test("Code Mode invokes and renders the conversion shell through V8", async () =
 		await fixture.close();
 	}
 });
+
+test("Code Mode preserves shell quoting when cmd uses String.raw", async () => {
+	const fixture = await createCodeModeHarness();
+	try {
+		const exec = fixture.tools.get("exec");
+		assert.ok(exec);
+		const result = await exec.execute(
+			"exec-quoted",
+			{
+				code: 'text(await tools.exec_command({ cmd: String.raw`printf "%s" "code-mode-quoted"` }));',
+			},
+			undefined,
+			undefined,
+			{
+				cwd: process.cwd(),
+				model: {
+					provider: "openai-codex",
+					api: "openai-codex-responses",
+					id: "gpt-5.6-luna",
+					input: ["text"],
+				},
+			} as never,
+		);
+		assert.match(
+			result.content
+				.map((item: { text?: string }) => item.text ?? "")
+				.join("\n"),
+			/code-mode-quoted/,
+		);
+	} finally {
+		await fixture.close();
+	}
+});

--- a/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
@@ -24,7 +24,7 @@ test("Code Mode advertises only model-compatible nested tools", async () => {
 		);
 		assert.match(
 			promptResult?.systemPrompt ?? "",
-			/await tools\.apply_patch\(patch\) \/\/ each Update File: hunks top-to-bottom; indentation is literal/,
+			/await tools\.apply_patch\(patch\)/,
 		);
 		assert.match(promptResult?.systemPrompt ?? "", /const result = await tools\.view_image/);
 		assert.match(promptResult?.systemPrompt ?? "", /await tools\.web__run/);

--- a/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-cases/tool-catalog.ts
@@ -24,7 +24,7 @@ test("Code Mode advertises only model-compatible nested tools", async () => {
 		);
 		assert.match(
 			promptResult?.systemPrompt ?? "",
-			/await tools\.apply_patch\(patch\)/,
+			/await tools\.apply_patch\(patch\) \/\/ each Update File: hunks top-to-bottom; indentation is literal/,
 		);
 		assert.match(promptResult?.systemPrompt ?? "", /const result = await tools\.view_image/);
 		assert.match(promptResult?.systemPrompt ?? "", /await tools\.web__run/);

--- a/packages/pi-codex-conversion/tests/prompt-building.test.ts
+++ b/packages/pi-codex-conversion/tests/prompt-building.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCodexSystemPrompt } from "../src/prompt/build-system-prompt.ts";
+
+test("existing punctuated Pi guidelines are canonicalized before deduplication and mode removal", () => {
+	const basePrompt = `Base
+
+Guidelines:
+- Use tty=true for dev servers, watchers, REPLs, and prompts.
+- Use apply_patch for text-file changes, including creates/deletes/moves; split oversized patches.
+
+Pi documentation follows`;
+
+	const normalPrompt = buildCodexSystemPrompt(basePrompt, { mode: "normal" });
+	assert.equal(normalPrompt.match(/Use tty=true for dev servers, watchers, REPLs, and prompts/g)?.length, 1);
+	assert.doesNotMatch(normalPrompt, /Use tty=true for dev servers, watchers, REPLs, and prompts\./);
+
+	const pathPrompt = buildCodexSystemPrompt(basePrompt, { mode: "path", tools: {} });
+	assert.doesNotMatch(pathPrompt, /Use apply_patch for text-file changes/);
+	assert.match(pathPrompt, /Use apply_patch for file edits/);
+});

--- a/packages/pi-skill-model-facing-api-design/skills/model-facing-api-design/SKILL.md
+++ b/packages/pi-skill-model-facing-api-design/skills/model-facing-api-design/SKILL.md
@@ -69,6 +69,8 @@ If legacy markers are present, stop the normal wording/token review. If edits ar
    - Remove marketing language, implementation trivia, decorative formatting, and examples that do not prevent real misuse.
    - Do not compress away required evidence, caveats, recovery information, or trigger boundaries merely to improve a token count.
 
+   **Punctuation and token-cost pass:** treat model-facing copy as serialized API payload, not ordinary prose. Omit cosmetic terminal periods from terse labels, one-line fragments, and bullet guidelines when the emitted form saves a token. Preserve structural or meaningful punctuation: quotes, backticks, `${}`, URLs, paths, versions, regexes, decimals, ellipses, code/grammar delimiters, and internal sentence separators. Measure emitted values or serialized schemas rather than TypeScript source lines; compare each mode and conditional tool separately instead of summing mutually exclusive surfaces. Sweep schema descriptions, tool descriptions, `promptSnippet`/guidelines, model-visible results/errors, and secondary-model prompts together, removing duplication before micro-optimizing punctuation
+
 7. **Validate the complete loop.**
    - Check representative selection, valid calls, invalid calls, empty results, failures, and truncated results as relevant to the tool.
    - Confirm the model can distinguish neighboring tools and continue correctly from both success and failure output.


### PR DESCRIPTION
## Summary
- clarify raw shell command and JavaScript escaping guidance while removing duplicated model-facing instructions
- trim cosmetic punctuation from Codex prompt, schema, tool, and result surfaces and document the reusable token-hygiene rule
- improve Pi-owned apply-patch ordering guidance, recovery errors, and trace metadata without changing the vendored Codex patch engine or binaries
- remove low-value tests that only pinned prose, punctuation, unchanged quoting behavior, or unlikely implementation details

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- 80 `@howaboua/pi-codex-conversion` tests passing

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-skill-model-facing-api-design`
- Aggregates: generated by release automation
