### PR TITLE
Fix installed Codex voice helper resolution

### DIFF
--- a/.changeset/fix-voice-binary-resolution.md
+++ b/.changeset/fix-voice-binary-resolution.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Resolve bundled voice helpers from the installed npm package layout.

--- a/packages/pi-codex-conversion/scripts/verify-codex-tool-binaries.mjs
+++ b/packages/pi-codex-conversion/scripts/verify-codex-tool-binaries.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const platforms = ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"];
 const tools = [
@@ -36,6 +37,17 @@ if (missing.length > 0 || notExecutable.length > 0) {
 		for (const path of notExecutable) console.error(`  - ${path}`);
 	}
 	console.error("Run the GitHub Actions binary workflow and commit the downloaded artifacts.");
+	process.exit(1);
+}
+
+const builtResolver = resolve("dist", "voice", "binary.js");
+if (!existsSync(builtResolver)) {
+	console.error("Refusing to publish: built voice helper resolver is missing. Run `bun run build` first.");
+	process.exit(1);
+}
+const { resolveVoiceHelperBinary } = await import(pathToFileURL(builtResolver).href);
+if (!resolveVoiceHelperBinary()) {
+	console.error(`Refusing to publish: built package cannot resolve the bundled voice helper for ${process.platform}-${process.arch}.`);
 	process.exit(1);
 }
 

--- a/packages/pi-codex-conversion/src/voice/binary.ts
+++ b/packages/pi-codex-conversion/src/voice/binary.ts
@@ -7,10 +7,11 @@ const EXECUTABLE = process.platform === "win32" ? "pi-codex-voice.exe" : "pi-cod
 
 export function resolveVoiceHelperBinary(): string | undefined {
 	const sourceRoot = dirname(fileURLToPath(import.meta.url));
+	const packageRoot = dirname(dirname(sourceRoot));
 	const candidates = [
-		join(sourceRoot, "bin", PLATFORM_DIR, EXECUTABLE),
-		join(sourceRoot, "rust", "target", "release", EXECUTABLE),
-		join(sourceRoot, "rust", "target", "debug", EXECUTABLE),
+		join(packageRoot, "src", "voice", "bin", PLATFORM_DIR, EXECUTABLE),
+		join(packageRoot, "src", "voice", "rust", "target", "release", EXECUTABLE),
+		join(packageRoot, "src", "voice", "rust", "target", "debug", EXECUTABLE),
 	];
 	for (const candidate of candidates) {
 		try {


### PR DESCRIPTION
## Summary
- resolve bundled voice helpers from the npm package root rather than beside compiled code
- cover Linux, macOS, and Windows x64/arm64 package layouts
- block publishing when compiled code cannot resolve the local platform helper

## Validation
- package check: 100 tests passed
- package build passed
- built resolver found `src/voice/bin/linux-x64/pi-codex-voice`
- Changeset check passed