### PR TITLE
Refine Codex voice setup UX

### DIFF
--- a/.changeset/tame-voices-route.md
+++ b/.changeset/tame-voices-route.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep dictation context notices to the first use until compaction, refresh device settings from disk before every voice start, and make audio-routing failures actionable for users and their Pi agent.

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -65,6 +65,7 @@ export function registerCodexEvents(
 	sessions.onSessionExit((sessionId) => tracker.recordSessionFinished(sessionId));
 
 	pi.on("session_start", async (event, ctx) => {
+		runtime.voice.resetContextAnnouncements();
 		try {
 			ensureCodexVoiceSystemPrompt();
 		} catch (error) {
@@ -167,6 +168,7 @@ export function registerCodexEvents(
 		return handleCodexSessionBeforeCompact(event, ctx, state, pi);
 	});
 	pi.on("session_compact", async (event) => {
+		runtime.voice.resetContextAnnouncements();
 		state.pendingPiCompactionNativeWindow = undefined;
 		if (!event.fromExtension || !isNativeCompactionDetails(event.compactionEntry.details)) return;
 		pi.sendMessage({

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -4,6 +4,7 @@ import { resolveCodexVoiceAuth } from "./auth.ts";
 import type { CodexRealtimeConversation } from "./conversation/session.ts";
 import type { CodexDictationSession } from "./dictation/session.ts";
 import { CodexVoiceSessionMessages } from "./session-messages.ts";
+import { formatVoiceAudioError } from "./setup.ts";
 import { getProjectCodexVoiceSystemPromptPath, loadCodexVoiceSystemPrompt } from "./system-prompt.ts";
 import type { CodexVoiceMode } from "./ui.ts";
 
@@ -18,6 +19,7 @@ type VoiceState =
 export class CodexVoiceController {
 	private state: VoiceState = { type: "idle" };
 	private context: ExtensionContext | undefined;
+	private config: CodexConversionConfig | undefined;
 	private announcedMode: CodexVoiceMode | undefined;
 	private startGeneration = 0;
 	private readonly messages: CodexVoiceSessionMessages;
@@ -34,6 +36,7 @@ export class CodexVoiceController {
 	get status(): string { return this.state.type; }
 	get active(): boolean { return this.state.type !== "idle" && this.state.type !== "failed"; }
 	get activeMode(): CodexVoiceMode | undefined { return this.announcedMode; }
+	resetContextAnnouncements(): void { this.messages.resetContextAnnouncements(); }
 
 	async start(ctx: ExtensionContext, config: CodexConversionConfig): Promise<void> {
 		const mode: CodexVoiceMode = config.voice.mode === "transcription" ? "dictation" : "realtime";
@@ -50,6 +53,7 @@ export class CodexVoiceController {
 		else await this.stop({ announce: true });
 		const startGeneration = ++this.startGeneration;
 		this.context = ctx;
+		this.config = config;
 		this.messages.setContext(ctx);
 		this.state = { type: "connecting", mode };
 		this.renderStatus("connecting…");
@@ -72,6 +76,7 @@ export class CodexVoiceController {
 		const session = this.currentSession();
 		this.state = { type: "idle" };
 		this.announcedMode = undefined;
+		this.config = undefined;
 		this.context?.ui.setStatus("codex-voice", undefined);
 		await session?.close();
 		this.messages.voiceStopped(endedMode);
@@ -90,6 +95,7 @@ export class CodexVoiceController {
 		const endedMode = options?.announce ? this.announcedMode : undefined;
 		this.state = { type: "idle" };
 		this.announcedMode = undefined;
+		this.config = undefined;
 		this.context?.ui.setStatus("codex-voice", undefined);
 		this.messages.voiceStopped(endedMode);
 	}
@@ -167,13 +173,18 @@ export class CodexVoiceController {
 
 	private fail(error: Error): void {
 		if (this.state.type === "idle" || this.state.type === "failed") return;
+		const mode = this.state.type === "connecting"
+			? this.state.mode
+			: this.state.type === "dictation" ? "dictation" : "realtime";
+		const message = this.config ? formatVoiceAudioError(error, mode, this.config) : error.message;
 		this.startGeneration += 1;
 		const endedMode = this.announcedMode;
 		const session = this.currentSession();
-		this.state = { type: "failed", message: error.message };
+		this.state = { type: "failed", message };
 		this.announcedMode = undefined;
+		this.config = undefined;
 		this.context?.ui.setStatus("codex-voice", undefined);
-		this.context?.ui.notify(error.message, "error");
+		this.context?.ui.notify(message, "error");
 		this.messages.voiceStopped(endedMode);
 		void session?.close();
 	}

--- a/packages/pi-codex-conversion/src/voice/controls.ts
+++ b/packages/pi-codex-conversion/src/voice/controls.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { getCodexConversionConfigPath, type CodexConversionConfig } from "../adapter/activation/config.ts";
+import { getCodexConversionConfigPath, readCodexConversionConfig, type CodexConversionConfig } from "../adapter/activation/config.ts";
 import type { AdapterState } from "../adapter/activation/state.ts";
 import { resolveVoiceHelperBinary } from "./binary.ts";
 import type { CodexVoiceController } from "./controller.ts";
@@ -23,7 +23,9 @@ export function createCodexVoiceControls(options: {
 
 	const start = async (mode: CodexVoiceMode, ctx: ExtensionContext): Promise<void> => {
 		if (voice.activeMode === mode) return;
-		const missingAudioSettings = missingVoiceAudioSettings(state.config, mode);
+		const currentConfig = readCodexConversionConfig();
+		state.config = currentConfig;
+		const missingAudioSettings = missingVoiceAudioSettings(currentConfig, mode);
 		if (missingAudioSettings.length > 0) {
 			if (!ctx.isIdle()) {
 				ctx.ui.notify("Wait for the current turn before setting up Codex voice.", "info");
@@ -40,7 +42,7 @@ export function createCodexVoiceControls(options: {
 			})), { triggerTurn: true });
 			return;
 		}
-		const nextConfig = withVoiceMode(state.config, mode);
+		const nextConfig = withVoiceMode(currentConfig, mode);
 		if (saveAndApply(ctx, nextConfig)) await voice.start(ctx, nextConfig);
 	};
 

--- a/packages/pi-codex-conversion/src/voice/session-messages.ts
+++ b/packages/pi-codex-conversion/src/voice/session-messages.ts
@@ -20,6 +20,7 @@ export class CodexVoiceSessionMessages {
 	private pending: PendingVoiceMessage[] = [];
 	private piTurnActive = false;
 	private backendTurnPending = false;
+	private dictationAnnounced = false;
 
 	constructor(pi: ExtensionAPI, callbacks: CodexVoiceSessionMessageCallbacks) {
 		this.pi = pi;
@@ -32,13 +33,21 @@ export class CodexVoiceSessionMessages {
 	}
 
 	modeStarted(mode: CodexVoiceMode): void {
+		if (mode === "dictation") {
+			if (this.dictationAnnounced) return;
+			this.dictationAnnounced = true;
+		}
 		this.enqueueMode(mode, "started");
+	}
+
+	resetContextAnnouncements(): void {
+		this.dictationAnnounced = false;
 	}
 
 	voiceStopped(mode?: CodexVoiceMode): void {
 		this.backendTurnPending = false;
 		this.piTurnActive = this.context ? !this.context.isIdle() : false;
-		if (mode) this.enqueueMode(mode, "ended");
+		if (mode && mode !== "dictation") this.enqueueMode(mode, "ended");
 		else this.flush();
 	}
 

--- a/packages/pi-codex-conversion/src/voice/setup.ts
+++ b/packages/pi-codex-conversion/src/voice/setup.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_CODEX_CONVERSION_CONFIG, type CodexConversionConfig } from "../adapter/activation/config.ts";
+import { DEFAULT_CODEX_CONVERSION_CONFIG, getCodexConversionConfigPath, type CodexConversionConfig } from "../adapter/activation/config.ts";
+import type { CodexVoiceMode } from "./ui.ts";
 
 export type VoiceAudioSetting = "voice.inputDevice" | "voice.outputDevice";
 
@@ -7,6 +8,29 @@ export function missingVoiceAudioSettings(config: CodexConversionConfig, mode: "
 		...(!config.voice.inputDevice ? ["voice.inputDevice" as const] : []),
 		...(mode === "realtime" && !config.voice.outputDevice ? ["voice.outputDevice" as const] : []),
 	];
+}
+
+export function formatVoiceAudioError(error: Error, mode: CodexVoiceMode, config: CodexConversionConfig): string {
+	const direction = audioErrorDirection(error.message, mode);
+	if (!direction) return error.message;
+	const input = direction === "input";
+	const setting = input ? "voice.inputDevice" : "voice.outputDevice";
+	const device = input ? config.voice.inputDevice : config.voice.outputDevice;
+	return [
+		`Codex voice could not open ${direction} device \`${device ?? "default"}\`.`,
+		"It may be busy, unavailable, or the wrong endpoint in a routed or processed audio setup.",
+		"Ask your Pi agent to resolve the audio setup, or paste this message into the prompt.",
+		`Agent: inspect the available audio devices and routes. If multiple endpoints are plausible, ask the user which they want. Update only \`${setting}\` in \`${getCodexConversionConfigPath()}\`. For shared or processed audio, prefer the final virtual/system source rather than opening physical hardware directly. Then ask the user to try using voice features again.`,
+		`Audio backend: ${error.message}`,
+	].join("\n");
+}
+
+function audioErrorDirection(message: string, mode: CodexVoiceMode): "input" | "output" | undefined {
+	const normalized = message.toLowerCase();
+	if (/microphone|default input|input (?:device|stream|format)/.test(normalized)) return "input";
+	if (/speaker|default output|output (?:device|stream|format)/.test(normalized)) return "output";
+	if (mode === "dictation" && /(?:requested )?device|audio (?:device|stream)|capture stream|sample format/.test(normalized)) return "input";
+	return undefined;
 }
 
 export function buildVoiceSetupInstructions(options: {

--- a/packages/pi-codex-conversion/tests/voice.test.ts
+++ b/packages/pi-codex-conversion/tests/voice.test.ts
@@ -216,6 +216,19 @@ test("voice session messages wait for Pi idle and preserve delegation ordering",
 	idle = true;
 	messages.agentSettled();
 	assert.deepEqual(sent.at(-1)?.message.details, { mode: "realtime", state: "ended" });
+
+	voiceActive = true;
+	messages.setContext(ctx);
+	messages.modeStarted("dictation");
+	messages.voiceStopped("dictation");
+	messages.modeStarted("dictation");
+	messages.voiceStopped("dictation");
+	assert.equal(sent.filter(({ message }) => JSON.stringify(message.details) === JSON.stringify({ mode: "dictation", state: "started" })).length, 1);
+	assert.equal(sent.some(({ message }) => JSON.stringify(message.details) === JSON.stringify({ mode: "dictation", state: "ended" })), false);
+
+	messages.resetContextAnnouncements();
+	messages.modeStarted("dictation");
+	assert.equal(sent.filter(({ message }) => JSON.stringify(message.details) === JSON.stringify({ mode: "dictation", state: "started" })).length, 2);
 });
 
 test("realtime handoff chunks preserve Unicode under the byte limit", () => {

--- a/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
@@ -17,6 +17,7 @@ class FakeWebSocket {
 	readonly options: { headers?: Record<string, string> } | undefined;
 	readyState = 0;
 	private listeners = new Map<string, Set<(event: unknown) => void>>();
+	private pendingResponses: unknown[][] = [];
 
 	constructor(_url: string, options?: { headers?: Record<string, string> }) {
 		this.options = options;
@@ -31,6 +32,7 @@ class FakeWebSocket {
 		const listeners = this.listeners.get(type) ?? new Set();
 		listeners.add(listener);
 		this.listeners.set(type, listeners);
+		if (type === "message") this.deliverResponses();
 	}
 
 	removeEventListener(type: string, listener: (event: unknown) => void): void {
@@ -39,13 +41,12 @@ class FakeWebSocket {
 
 	send(data: string): void {
 		this.sent.push(data);
-		setTimeout(() => {
-			for (const event of FakeWebSocket.responses.shift() ?? [
+		this.pendingResponses.push(FakeWebSocket.responses.shift() ?? [
 				{ type: "codex.response.metadata", headers: { "x-codex-turn-state": "ts-warm" } },
 				{ type: "response.created", response: { id: "resp_warm" } },
 				{ type: "response.completed", response: { id: "resp_warm", status: "completed" } },
-			]) this.emit("message", { data: JSON.stringify(event) });
-		}, 0);
+			]);
+		this.deliverResponses();
 	}
 
 	close(code?: number, reason?: string): void {
@@ -55,6 +56,16 @@ class FakeWebSocket {
 
 	private emit(type: string, event: unknown): void {
 		for (const listener of this.listeners.get(type) ?? []) listener(event);
+	}
+
+	private deliverResponses(): void {
+		if (!this.listeners.get("message")?.size) return;
+		const responses = this.pendingResponses.shift();
+		if (!responses) return;
+		queueMicrotask(() => {
+			for (const event of responses) this.emit("message", { data: JSON.stringify(event) });
+			this.deliverResponses();
+		});
 	}
 }
 
@@ -145,7 +156,7 @@ test("cached WebSocket retries a missing continuation with full context", async 
 		seeded.release({ keep: true });
 		const output = createInitialAssistantMessage(model);
 		let starts = 0;
-		await processWebSocketStream("wss://chatgpt.example/backend-api/codex/responses", body, new Headers(), output, createAssistantMessageEventStream(), model, () => { starts++; }, { sessionId, transport: "websocket-cached" });
+		await processWebSocketStream("wss://chatgpt.example/backend-api/codex/responses", body, new Headers(), output, createAssistantMessageEventStream(), model, () => { starts++; }, { sessionId, timeoutMs: 1_000, transport: "websocket-cached" });
 
 		assert.equal(FakeWebSocket.instances.length, 2);
 		assert.equal(JSON.parse(FakeWebSocket.instances[0]!.sent[0]!).previous_response_id, "resp_warm");


### PR DESCRIPTION
## Summary
- show dictation context once per session context and again after compaction, without per-utterance end cards
- reload the current JSON config before every command or shortcut voice start so stale processes cannot restore old device IDs
- turn audio-device failures into copy-pasteable user and Pi-agent setup guidance

## Validation
- package check: 100 tests passed
- package build passed
- fresh-on-disk device configuration preserved in a built runtime check
- Changeset check passed