### PR TITLE
Add GPT model switcher extension

### DIFF
--- a/.changeset/bright-models-switch.md
+++ b/.changeset/bright-models-switch.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-gpt-switcher": minor
+---
+
+Add `/sol`, `/terra`, and `/luna` commands for switching GPT-5.6 Codex models and reasoning levels.

--- a/.github/ISSUE_TEMPLATE/pi-stuff.yml
+++ b/.github/ISSUE_TEMPLATE/pi-stuff.yml
@@ -14,6 +14,7 @@ body:
         - pi-auto-trees
         - pi-cache-hit-predictor
         - pi-explore-subagents
+        - pi-gpt-switcher
         - pi-markdown-workflows
         - pi-memories
         - pi-semantic-grep

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Pi packages run with your local permissions. You can obviously trust me, a stran
 
 | Package | Includes | Deliberate exclusions |
 |---|---|---|
-| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 12 general extensions and 9 shareable skills | Codex conversion and Omarchy support |
-| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 12 general extensions | Codex conversion |
+| [`@howaboua/pi-stuff`](./packages/pi-stuff) | 13 general extensions and 9 shareable skills | Codex conversion and Omarchy support |
+| [`@howaboua/pi-extensions`](./packages/pi-extensions) | 13 general extensions | Codex conversion |
 | [`@howaboua/pi-skills`](./packages/pi-skills) | 9 shareable skills | Omarchy support |
 
 ```bash
@@ -34,6 +34,7 @@ pi install npm:@howaboua/pi-skills
 | [`pi-codex-conversion`](./packages/pi-codex-conversion) | Codex-shaped shell, patch, image, web, and Code Mode tools for GPT/Codex models |
 | [`pi-dynamic-tools`](./packages/pi-dynamic-tools) | TOML-defined command-line tools exposed through JavaScript Code Mode |
 | [`pi-explore-subagents`](./packages/pi-explore-subagents) | Isolated, discovery-only shallow and deep subagents |
+| [`pi-gpt-switcher`](./packages/pi-gpt-switcher) | `/sol`, `/terra`, and `/luna` commands for GPT-5.6 Codex models |
 | [`pi-markdown-workflows`](./packages/pi-markdown-workflows) | Workflow/skill UI, `/learn`, workflow capture, and nested `AGENTS.md` loading |
 | [`pi-memories`](./packages/pi-memories) | Shutdown memory candidates in a plain Markdown inbox |
 | [`pi-semantic-grep`](./packages/pi-semantic-grep) | Meaning-based code and docs search backed by repo-local SQLite indexes |

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,18 @@
         "@earendil-works/pi-coding-agent": "*",
       },
     },
+    "packages/pi-gpt-switcher": {
+      "name": "@howaboua/pi-gpt-switcher",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
+        "@earendil-works/pi-coding-agent": "0.82.0",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.6",
+      },
+    },
     "packages/pi-markdown-workflows": {
       "name": "@howaboua/pi-markdown-workflows",
       "version": "0.2.20",
@@ -564,6 +576,8 @@
     "@howaboua/pi-explore-subagents": ["@howaboua/pi-explore-subagents@workspace:packages/pi-explore-subagents"],
 
     "@howaboua/pi-extensions": ["@howaboua/pi-extensions@workspace:packages/pi-extensions"],
+
+    "@howaboua/pi-gpt-switcher": ["@howaboua/pi-gpt-switcher@workspace:packages/pi-gpt-switcher"],
 
     "@howaboua/pi-howaboua-extensions-primitives-sdk": ["@howaboua/pi-howaboua-extensions-primitives-sdk@0.3.2", "", { "peerDependencies": { "@earendil-works/pi-coding-agent": "*", "@earendil-works/pi-tui": "*" } }, "sha512-HVTZJh6wX4G+C6eFKEEnb7/tj5AY9oIINyHl6cgcRLRnoHZpEU5Mv5aDwGc5rJofjhiWGpB+jZOYYSHgPtCZGA=="],
 

--- a/packages/pi-extensions/README.md
+++ b/packages/pi-extensions/README.md
@@ -16,6 +16,7 @@ pi install npm:@howaboua/pi-extensions
 - `pi-cache-hit-predictor` — inline prompt-cache hit predictions when switching models or reasoning levels
 - `pi-dynamic-tools` — TOML-defined command tools through JavaScript Code Mode
 - `pi-explore-subagents` — isolated, discovery-only subagents
+- `pi-gpt-switcher` — `/sol`, `/terra`, and `/luna` commands for GPT-5.6 Codex models
 - `pi-markdown-workflows` — workflow/skill UI and nested `AGENTS.md` loading
 - `pi-memories` — shutdown memory candidates in a Markdown inbox
 - `pi-semantic-grep` — semantic code and docs search

--- a/packages/pi-gpt-switcher/.gitignore
+++ b/packages/pi-gpt-switcher/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+coverage/

--- a/packages/pi-gpt-switcher/LICENSE
+++ b/packages/pi-gpt-switcher/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Igor Warzocha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-gpt-switcher/README.md
+++ b/packages/pi-gpt-switcher/README.md
@@ -1,0 +1,41 @@
+# @howaboua/pi-gpt-switcher
+
+Pi extension adding quick model commands:
+
+| Command | Model |
+| --- | --- |
+| `/sol [reasoning]` | `openai-codex/gpt-5.6-sol` |
+| `/terra [reasoning]` | `openai-codex/gpt-5.6-terra` |
+| `/luna [reasoning]` | `openai-codex/gpt-5.6-luna` |
+
+Reasoning defaults to `high`. Valid arguments are `off`, `minimal`, `low`,
+`medium`, `high`, `xhigh`, and `max`; for example, `/luna low`.
+
+## Install
+
+```bash
+pi install npm:@howaboua/pi-gpt-switcher
+```
+
+Try it for one session:
+
+```bash
+pi -e npm:@howaboua/pi-gpt-switcher
+```
+
+## How it works
+
+The commands use Pi's model registry and normal provider authentication. If a
+model is unavailable or the OpenAI Codex credentials are missing, the command
+reports that instead of changing the current model.
+
+Reasoning defaults to `high`. Pi clamps the requested level automatically if
+the selected model supports fewer levels.
+
+## Local development
+
+Load the checkout directly:
+
+```sh
+pi -e ./index.ts
+```

--- a/packages/pi-gpt-switcher/biome.json
+++ b/packages/pi-gpt-switcher/biome.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": [
+			"**",
+			"!node_modules",
+			"!dist",
+			"!coverage",
+			"!package-lock.json"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/packages/pi-gpt-switcher/codex-model-shortcuts.ts
+++ b/packages/pi-gpt-switcher/codex-model-shortcuts.ts
@@ -1,0 +1,87 @@
+/**
+ * Adds short slash commands for the three OpenAI Codex model variants.
+ * The commands use Pi's model registry, so normal provider authentication and
+ * model availability checks remain in charge.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const MODELS = {
+	sol: "gpt-5.6-sol",
+	terra: "gpt-5.6-terra",
+	luna: "gpt-5.6-luna",
+} as const;
+
+type Alias = keyof typeof MODELS;
+type ThinkingLevel =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+const DEFAULT_THINKING_LEVEL: ThinkingLevel = "high";
+const THINKING_LEVELS = new Set<ThinkingLevel>([
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+]);
+
+function parseThinkingLevel(args: string): ThinkingLevel | undefined {
+	const requested = args.trim().toLowerCase();
+	if (requested === "") return DEFAULT_THINKING_LEVEL;
+	return THINKING_LEVELS.has(requested as ThinkingLevel)
+		? (requested as ThinkingLevel)
+		: undefined;
+}
+
+export default function (pi: ExtensionAPI) {
+	for (const alias of Object.keys(MODELS) as Alias[]) {
+		pi.registerCommand(alias, {
+			description: `Switch to GPT-5.6 ${alias.charAt(0).toUpperCase()}${alias.slice(1)}`,
+			handler: async (args, ctx) => {
+				const thinkingLevel = parseThinkingLevel(args);
+				if (!thinkingLevel) {
+					ctx.ui.notify(
+						`Usage: /${alias} [off|minimal|low|medium|high|xhigh|max]`,
+						"error",
+					);
+					return;
+				}
+
+				const modelId = MODELS[alias];
+				const model = ctx.modelRegistry.find("openai-codex", modelId);
+
+				if (!model) {
+					ctx.ui.notify(`Model unavailable: openai-codex/${modelId}`, "error");
+					return;
+				}
+
+				const alreadySelected =
+					ctx.model?.provider === "openai-codex" && ctx.model.id === modelId;
+				if (!alreadySelected) {
+					const switched = await pi.setModel(model);
+					if (!switched) {
+						ctx.ui.notify(
+							`Could not switch to ${model.name}: no OpenAI Codex credentials`,
+							"error",
+						);
+						return;
+					}
+				}
+
+				pi.setThinkingLevel(thinkingLevel);
+				ctx.ui.notify(
+					`${alreadySelected ? "Using" : "Switched to"} ${model.name} (${pi.getThinkingLevel()})`,
+					"info",
+				);
+			},
+		});
+	}
+}

--- a/packages/pi-gpt-switcher/codex-model-shortcuts.ts
+++ b/packages/pi-gpt-switcher/codex-model-shortcuts.ts
@@ -66,7 +66,16 @@ export default function (pi: ExtensionAPI) {
 				const alreadySelected =
 					ctx.model?.provider === "openai-codex" && ctx.model.id === modelId;
 				if (!alreadySelected) {
-					const switched = await pi.setModel(model);
+					let switched: boolean;
+					try {
+						switched = await pi.setModel(model);
+					} catch (error) {
+						ctx.ui.notify(
+							`Could not switch to ${model.name}: ${error instanceof Error ? error.message : String(error)}`,
+							"error",
+						);
+						return;
+					}
 					if (!switched) {
 						ctx.ui.notify(
 							`Could not switch to ${model.name}: no OpenAI Codex credentials`,

--- a/packages/pi-gpt-switcher/index.ts
+++ b/packages/pi-gpt-switcher/index.ts
@@ -1,0 +1,3 @@
+/** Pi package entry point for the Codex model shortcut extension. */
+
+export { default } from "./codex-model-shortcuts.js";

--- a/packages/pi-gpt-switcher/package.json
+++ b/packages/pi-gpt-switcher/package.json
@@ -1,0 +1,63 @@
+{
+	"name": "@howaboua/pi-gpt-switcher",
+	"version": "0.0.0",
+	"description": "Quick Pi commands for switching between GPT-5.6 Codex models and reasoning levels.",
+	"type": "module",
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-gpt-switcher"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-gpt-switcher#readme",
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-coding-agent",
+		"gpt-5.6",
+		"model-switching",
+		"reasoning-level"
+	],
+	"engines": {
+		"node": ">=20.6.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"index.ts",
+		"codex-model-shortcuts.ts",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.80.6"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "0.82.0",
+		"typescript": "^6.0.3"
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck && bun run test",
+		"prepack": "bun run check",
+		"test": "bun test",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run"
+	},
+	"main": "index.ts",
+	"exports": "./index.ts"
+}

--- a/packages/pi-gpt-switcher/tests/extension.test.ts
+++ b/packages/pi-gpt-switcher/tests/extension.test.ts
@@ -53,3 +53,37 @@ test("registers model commands and switches model plus reasoning level", async (
 	expect(selectedThinkingLevel).toBe("low");
 	expect(notifications).toEqual(["Switched to GPT-5.6 Luna (low)"]);
 });
+
+test("reports model authentication failures without changing reasoning", async () => {
+	const notifications: string[] = [];
+	const pi = {
+		registerCommand(_name: string, options: { handler: CommandHandler }) {
+			void options;
+		},
+		setModel: async () => {
+			throw new Error("No API key for openai-codex/gpt-5.6-sol");
+		},
+		setThinkingLevel() {
+			throw new Error("reasoning level should not change");
+		},
+		getThinkingLevel: () => "high",
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		modelRegistry: { find: () => ({ id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }) },
+		ui: { notify: (message: string) => notifications.push(message) },
+	} as unknown as ExtensionContext;
+	const commands = new Map<string, { handler: CommandHandler }>();
+	pi.registerCommand = ((
+		name: string,
+		options: { handler: CommandHandler },
+	) => {
+		commands.set(name, options);
+	}) as typeof pi.registerCommand;
+
+	gptSwitcher(pi);
+	await commands.get("sol")?.handler("", ctx);
+
+	expect(notifications).toEqual([
+		"Could not switch to GPT-5.6 Sol: No API key for openai-codex/gpt-5.6-sol",
+	]);
+});

--- a/packages/pi-gpt-switcher/tests/extension.test.ts
+++ b/packages/pi-gpt-switcher/tests/extension.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import gptSwitcher from "../index.js";
+
+type CommandHandler = (args: string, ctx: ExtensionContext) => unknown;
+
+test("registers model commands and switches model plus reasoning level", async () => {
+	const commands = new Map<string, { handler: CommandHandler }>();
+	const notifications: string[] = [];
+	const model = { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" };
+	let selectedModel: unknown;
+	let selectedThinkingLevel: unknown;
+	let currentThinkingLevel = "high";
+
+	gptSwitcher({
+		registerCommand(name, options) {
+			commands.set(name, options as { handler: CommandHandler });
+		},
+		setModel: async (next) => {
+			selectedModel = next;
+			return true;
+		},
+		setThinkingLevel: (level) => {
+			selectedThinkingLevel = level;
+			currentThinkingLevel = level;
+		},
+		getThinkingLevel: () => currentThinkingLevel,
+	} as unknown as ExtensionAPI);
+
+	const ctx = {
+		model: undefined,
+		modelRegistry: {
+			find(provider: string, id: string) {
+				expect(provider).toBe("openai-codex");
+				expect(id).toBe("gpt-5.6-luna");
+				return model;
+			},
+		},
+		ui: {
+			notify(message: string) {
+				notifications.push(message);
+			},
+		},
+	} as unknown as ExtensionContext;
+
+	expect([...commands.keys()]).toEqual(["sol", "terra", "luna"]);
+	await commands.get("luna")?.handler("low", ctx);
+
+	expect(selectedModel).toBe(model);
+	expect(selectedThinkingLevel).toBe("low");
+	expect(notifications).toEqual(["Switched to GPT-5.6 Luna (low)"]);
+});

--- a/packages/pi-gpt-switcher/tsconfig.json
+++ b/packages/pi-gpt-switcher/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts", "codex-model-shortcuts.ts"]
+}

--- a/packages/pi-stuff/README.md
+++ b/packages/pi-stuff/README.md
@@ -1,6 +1,6 @@
 # @howaboua/pi-stuff
 
-The full general-purpose bundle: all 12 extensions from `@howaboua/pi-extensions`, pi-ask's prompt workflows, and all 9 skills from `@howaboua/pi-skills`.
+The full general-purpose bundle: all 13 extensions from `@howaboua/pi-extensions`, pi-ask's prompt workflows, and all 9 skills from `@howaboua/pi-skills`.
 
 ## Install
 
@@ -10,7 +10,7 @@ pi install npm:@howaboua/pi-stuff
 
 This installs:
 
-- extensions: `pi-ask`, `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-cache-hit-predictor`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
+- extensions: `pi-ask`, `pi-auto-reasoning-tool`, `pi-auto-trees`, `pi-cache-hit-predictor`, `pi-dynamic-tools`, `pi-explore-subagents`, `pi-gpt-switcher`, `pi-markdown-workflows`, `pi-memories`, `pi-semantic-grep`, `pi-smart-btw`, `pi-subagent-review`, and `pi-vent`
 - skills: `adversarial-qa`, `agent-native-hardening`, `agents-md`, `anti-ai-copy`, `chrome-cdp`, `gh-issue-pr-flow`, `model-facing-api-design`, `project-reference-research`, and `skill-creator`
 
 `pi-codex-conversion` and `omarchy-help` are intentionally separate because they depend on model and workstation choices.


### PR DESCRIPTION
## Summary
- Move the GPT switcher into the monorepo as `@howaboua/pi-gpt-switcher`
- Package `/sol`, `/terra`, and `/luna` model/reasoning commands for npm and aggregate release automation
- Report model authentication failures without leaving an unhandled command error

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `npm pack --dry-run`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-gpt-switcher`
- Aggregates: generated by release automation
