### PR TITLE
Enhance agent-native hardening with execution topology

### DIFF
--- a/.changeset/smart-lizards-repeat.md
+++ b/.changeset/smart-lizards-repeat.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-skill-agent-native-hardening": patch
+---
+
+Add execution-topology hardening guidance for agent-navigable call stacks and measured import, initialization, startup, and bundle performance.

--- a/packages/pi-skill-agent-native-hardening/README.md
+++ b/packages/pi-skill-agent-native-hardening/README.md
@@ -1,6 +1,6 @@
 # @howaboua/pi-skill-agent-native-hardening
 
-Audits and improves codebase architecture for safe human and agent changes: ownership, feature boundaries, contracts, state, duplication, traversability, test fit, and parallel-change readiness.
+Audits and improves codebase architecture for safe human and agent changes: ownership, feature boundaries, contracts, state, duplication, execution and import topology, traversability, test fit, and parallel-change readiness.
 
 ## Install
 
@@ -10,4 +10,4 @@ pi install npm:@howaboua/pi-skill-agent-native-hardening
 
 Use it for structural reviews, scorecards, plans, or refactors. It is not intended for ordinary bug fixes with no architecture concern.
 
-The skill loads language-specific guidance and its scoring, work-lane, or dependency-safety references only when the task needs them.
+The skill loads language-specific guidance and its scoring, execution-topology, work-lane, or dependency-safety references only when the task needs them.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/SKILL.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-hardening
-description: "Architecture hardening: ownership, boundaries, contracts, state safety, duplication, traversability, feedback loops, test fit, change decomposition. Use for structural reviews, scorecards, plans, or refactors; not ordinary fixes."
+description: "Architecture hardening: ownership, boundaries, contracts, state safety, duplication, execution/import topology, traversability, feedback loops, test fit, change decomposition. Use for structural reviews, scorecards, plans, refactors, or startup/import-path analysis; not ordinary fixes or unmeasured micro-optimization."
 ---
 
 # Agent-Native Hardening
@@ -12,6 +12,7 @@ Read only the references relevant to the task:
 - `references/scoring-rubric.md` before assigning scores or producing a formal scorecard.
 - `references/work-lanes.md` before splitting broad discovery or implementation across lanes, agents, branches, or worktrees.
 - `references/dependency-safety.md` when dependency changes, installers, lockfiles, toolchains, package scripts, or supply-chain recommendations are in scope.
+- `references/execution-topology.md` when call stacks, dispatch, middleware, callbacks, async continuations, imports, initialization, startup, bundle cost, or runtime-path navigability are in scope.
 - `references/js-ts.md`, `references/python.md`, `references/rust.md`, or `references/go.md` for languages present in the target repo.
 
 If no bundled language reference fits, use the general workflow and verify ecosystem-specific advice against the repo and current official documentation. Repo evidence and host constraints outrank generic guidance.
@@ -24,8 +25,10 @@ If no bundled language reference fits, use the general workflow and verify ecosy
 4. **Explicit contracts at boundaries.** Validate external data once, preserve named domain shapes internally, model state transitions, and derive contracts from a source of truth where practical.
 5. **Stable reuse over premature DRY.** Extract duplication when the behavior is genuinely shared and has a clear owner; tolerate local duplication when semantics are still diverging.
 6. **The shortest correct change path should be obvious.** Entry points, extension points, state owners, and validation commands should be discoverable without rereading the whole system.
-7. **Tests follow risk.** Match the repo's established testing intent and protect consequential behavior; do not manufacture coverage, fixtures, mocks, snapshots, or end-to-end scaffolding by default.
-8. **Failures stay visible.** Fix root causes instead of weakening checks, suppressing diagnostics, swallowing errors, or adding silent fallback behavior.
+7. **Every execution hop earns its place.** Preserve calls that own decisions, contracts, effects, lifecycle, resilience, or observability; collapse pass-through indirection and prefer control transfers an agent can resolve from code.
+8. **Performance claims require runtime evidence.** Distinguish semantic navigability from measured call, import, initialization, startup, or bundle cost. Optimize the relevant hot or cold path for the repo's actual runtime and toolchain.
+9. **Tests follow risk.** Match the repo's established testing intent and protect consequential behavior; do not manufacture coverage, fixtures, mocks, snapshots, or end-to-end scaffolding by default.
+10. **Failures stay visible.** Fix root causes instead of weakening checks, suppressing diagnostics, swallowing errors, or adding silent fallback behavior.
 
 ## Workflow
 
@@ -38,8 +41,9 @@ If no bundled language reference fits, use the general workflow and verify ecosy
 
 ### 2. Map the relevant system
 
-- Trace entry points, feature owners, state mutation, IO boundaries, contracts, and affected checks.
-- Inspect hotspots for mixed concerns, central-handler growth, hidden side effects, positional data, duplicated contracts, manual lifecycle resets, and broad cross-feature coupling.
+- Trace entry points, the real synchronous call stack, dynamic dispatch, async continuations, feature owners, state mutation, IO boundaries, contracts, and affected checks. Do not infer runtime flow from folders alone.
+- When startup, imports, or runtime efficiency matter, map the relevant import/initialization path and collect representative measurements before attributing cost.
+- Inspect hotspots for mixed concerns, central-handler growth, no-value frames, generic dispatch, callback or middleware tunnels, hidden side effects, positional data, duplicated contracts, manual lifecycle resets, and broad cross-feature coupling.
 - Distinguish generated/framework-required structure from code humans are expected to maintain.
 - For broad or unfamiliar repos, use focused read-only discovery lanes when they reduce rereading. Direct inspection is sufficient when the scope fits one coherent context.
 
@@ -55,7 +59,8 @@ If no bundled language reference fits, use the general workflow and verify ecosy
 
 - Prefer one owned extraction or contract boundary over a speculative architecture rewrite.
 - Split by feature ownership first, then by concern where the feature needs it.
-- Keep central paths as small routers, registries, or composition roots; move feature behavior behind explicit boundaries.
+- Keep central paths as small, statically enumerable routers, registries, or composition roots; move feature behavior behind explicit boundaries without hiding the selected implementation.
+- Collapse pass-through wrappers and single-use microfunctions only when they own no decision, translation, contract, effect, lifecycle, resilience, or observability boundary.
 - Model impossible or ambiguous states with variants, enums, validators, domain values, or named objects appropriate to the language.
 - For broad multi-area work, read `references/work-lanes.md` and create only as many lanes as have independent objectives and validation.
 
@@ -80,6 +85,9 @@ Evaluate these where relevant:
 
 - root objects route and compose rather than own feature-local state
 - feature additions primarily touch feature-owned modules, with small registration changes in central paths
+- important execution paths use recognisable feature terminology and each hop has an explainable role
+- dynamic dispatch, decorators, middleware, callbacks, generated bindings, and async hand-offs remain inspectable in both directions
+- imports and module initialization avoid hidden IO, surprising global mutation, cycles, or eager cold-path work where the runtime makes those costs material
 - orchestration, domain rules, IO, rendering, and mutation are separated where mixing them raises change risk
 - async/background work has a clear owner, result/message shape, cancellation or shutdown path, and state mutation boundary
 - render/view functions avoid hidden IO or mutation where the framework permits
@@ -92,7 +100,7 @@ Evaluate these where relevant:
 
 - Add documentation only when it reduces future discovery cost. Prefer accurate entry-point maps and local invariant comments over broad prose.
 - Do not rewrite user-facing README material unless it is part of the requested hardening scope.
-- Treat toolchain, dependency, lint-policy, and runtime changes as opt-in modernization. Explain evidence, benefit, migration cost, and risk before implementation.
+- Treat toolchain, dependency, lint-policy, lazy-loading, bundling, and runtime changes as opt-in modernization. Explain evidence, benefit, migration cost, and risk before implementation.
 - Do not use “agent-friendly” to justify product scope expansion, framework churn, new infrastructure, or unfamiliar dependencies.
 - Read `references/dependency-safety.md` before dependency or installer changes.
 

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/agents/openai.yaml
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Agent Native Hardening
-short_description: Audit and improve codebase architecture for safe human and agent changes.
-default_prompt: Review this codebase for agent-native maintainability and recommend the highest-leverage improvements.
+short_description: Harden code ownership, execution paths, imports, and contracts for safe changes.
+default_prompt: Review this codebase for agent-native maintainability, including execution and import topology, and recommend the highest-leverage improvements.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/execution-topology.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/execution-topology.md
@@ -1,0 +1,89 @@
+# Execution Topology
+
+Use this lens when the hardening task involves runtime navigation or cost. It is heuristic, not a prescribed layer model or maximum stack depth.
+
+## Separate the two claims
+
+Assess these independently:
+
+- **Semantic efficiency:** how easily an agent can discover, follow, modify, and debug the execution path.
+- **Runtime efficiency:** measured call, dispatch, import, initialization, startup, bundle, allocation, or latency cost.
+
+A path can be easy to navigate but expensive, or fast but opaque. Do not use an architectural preference as performance evidence.
+
+## Trace the relevant topology
+
+Start from one concrete behavior or startup path. Follow:
+
+- the synchronous call stack from entry to result or effect
+- strategy selection, registries, dependency injection, decorators, middleware, callbacks, generated bindings, reflection, or string-keyed dispatch
+- explicit continuations after task, event, queue, process, or network boundaries; do not pretend they share one literal stack
+- error propagation, wrapping, retry, fallback, and cancellation
+- imports and module initialization that the path triggers
+- representative tests, traces, profiles, bundle reports, or startup measurements
+
+Read forward and backward. A clear callee can still have surprising callers or bypasses.
+
+## Make frames earn their place
+
+A frame or layer usually earns its place when it owns at least one of:
+
+- a domain decision or state transition
+- validation or contract translation
+- an external effect or transaction boundary
+- implementation selection at a visible composition point
+- lifecycle, cancellation, concurrency, retry, timeout, or fallback policy
+- stable reuse with a real owner
+- security, authorization, or isolation
+- observability that materially improves diagnosis
+
+Suspect frames that only rename an operation, forward unchanged arguments, unpack and repack the same shape, retrieve ambient dependencies, or split a readable operation into one-use fragments. Several named calls can remain clearer than one dense function; optimize semantic hops, not frame count alone.
+
+Before collapsing a frame, check callers, overrides, generated use, public compatibility, test seams, observability, and failure behavior. Before adding one, state what it owns.
+
+## Navigation heuristics
+
+Prefer paths where:
+
+- the next meaningful call is predictable from the current symbol and imports
+- feature terminology survives through handlers, operations, errors, logs, and tests
+- orchestration exposes consequential ordering and branching
+- registries and plugin tables have one typed or statically enumerable manifest
+- configuration selects implementations at a visible composition boundary
+- important callbacks and middleware stages are named and ordered explicitly
+- stack traces preserve feature owners instead of collapsing into `handle`, `process`, `run`, or framework internals
+- async producers, messages, registrations, consumers, and failure policies are discoverable
+
+Friction signals include callback tunnels, wrapper factories, broad service locators, import-time self-registration, decorators that hide business behavior, reflection without a manifest, middleware-order policy, event chains used as local function calls, and parallel old/new paths to the same outcome.
+
+Choose the smallest intervention: name a callback, expose a manifest, move selection to the composition root, inline a pass-through wrapper, restore error provenance, or remove a bypass. Do not impose `route -> use case -> domain -> repository` when the codebase has a simpler honest shape.
+
+## Import and initialization heuristics
+
+Import cost is runtime- and toolchain-specific. First establish whether imports are interpreted, compiled, bundled, tree-shaken, cached, or executed for side effects.
+
+Inspect for:
+
+- top-level IO, client construction, large data parsing, filesystem scans, registration, or mutable global setup
+- cycles that force partial initialization, awkward late imports, or broad ownership coupling
+- barrel, prelude, wildcard, or package-root imports that pull substantially more code into startup or a bundle
+- repeated boundary conversions caused by package layout
+- eager loading of optional, platform-specific, or cold functionality
+- scattered dynamic imports that hide dependencies or move latency into an interactive path
+
+Useful interventions can include explicit initialization owners, narrower entrypoints, cycle removal, type-only imports where the toolchain supports them, and lazy loading of measured cold or optional work. Lazy loading is a trade: it can improve startup while worsening first-use latency, failure timing, static navigation, and packaging. Keep it deliberate and visible.
+
+Measure the metric that matters: cold and warm startup, request latency, module-load timing, bundle/chunk size, memory, compiler output, or profile samples. Compare the same representative command or workload before and after; one noisy run is not evidence.
+
+## Report and validate
+
+For findings, state:
+
+- the behavior or startup path inspected
+- the observed stack/import topology and evidence
+- whether the problem is semantic, runtime, or both
+- which hops earn their place and which do not
+- the smallest coherent change and its tradeoffs
+- the measurement or behavioral checks that would prove improvement
+
+After edits, trace the resulting path again. Verify behavior, error provenance, active callers and continuations, and the relevant performance baseline; compilation alone does not prove a better topology.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/go.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/go.md
@@ -80,6 +80,13 @@ Prefer these when hardening Go code:
 - Avoid package-level mutable state for configuration, clients, caches, or test toggles. Prefer explicit constructors and dependency injection at composition boundaries.
 - Avoid circular dependency workarounds that create abstract `common` packages. Break cycles by clarifying ownership and moving contracts to the smallest stable boundary.
 
+## Execution and initialization topology
+
+- Go imports are compile-time package dependencies, not per-request dynamic loading. Runtime startup concerns usually come from package `init` functions, package-level variable initialization, registration, and dependency construction; inspect those before proposing import-path performance work.
+- Prefer explicit startup wiring over import-for-side-effect registration. When framework/plugin constraints require blank imports or `init`, keep the active set in one searchable manifest.
+- Measure representative startup, binary size, profiles, allocations, or request latency before changing package boundaries for performance. Do not infer runtime savings from fewer imports alone.
+- Keep middleware and interface call chains semantically dense. Collapse pure forwarding adapters; retain frames that own cancellation, contracts, effects, retries, security, or useful error context.
+
 ## Error handling guidance
 
 - Do not ignore returned errors unless the ignored case is intentional and documented locally.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/js-ts.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/js-ts.md
@@ -54,6 +54,15 @@ Record the installed TypeScript version and whether build/lint/framework tooling
 - Avoid refactors that move generated files, framework conventions, or build outputs unless the framework requires it.
 - When splitting React/UI code, keep render components mostly pure and move effects, IO, state transitions, and data shaping into owned hooks/modules where that improves clarity.
 
+## Execution and import topology
+
+- Inspect the emitted runtime or bundle rather than treating source import syntax as cost. Bundler, module target, package `sideEffects`, tree-shaking, and server/client boundaries change what loads and executes.
+- Use `import type` for type-only edges where supported and consistent with the repo; it clarifies the runtime graph and prevents accidental emitted imports.
+- Treat barrel/package-root imports as suspects only when they obscure ownership, create cycles, defeat tree-shaking, or eagerly evaluate broad module graphs. Verify with the active bundler or startup measurement.
+- Keep top-level modules cheap and deterministic. Move client construction, filesystem/network work, registration, and mutable setup into visible composition or lifecycle owners.
+- Use dynamic `import()` for measured cold or optional boundaries, not as a generic cycle workaround. Account for chunking, first-use latency, error timing, SSR/runtime support, and reduced static navigability.
+- For deep middleware, hook, decorator, or callback stacks, identify which frames own policy or effects and collapse forwarding layers that add no contract, lifecycle, resilience, or observability value.
+
 ## TypeScript 7 guidance
 
 TypeScript 7.0 is the stable native Go-based compiler, distributed through the standard `typescript` package and invoked with `tsc`. Do not recommend the old `@typescript/native-preview` / `tsgo` path for stable adoption.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/python.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/python.md
@@ -50,6 +50,14 @@ Common active checks:
 - Use explicit result/error shapes for operations with expected failure modes instead of returning `None`, `{}`, `False`, or magic strings.
 - Keep imports boring: avoid path mutation, import-time connection setup, and side effects that make tests or agents depend on execution order.
 
+## Execution and import topology
+
+- Use `python -X importtime ...` or `PYTHONPROFILEIMPORTTIME=1` on the representative CLI, worker, test, or service startup before attributing latency to imports. Compare like-for-like cold runs and inspect cumulative rather than only self time.
+- Treat package `__init__.py` re-exports, plugin discovery, module-level registries, and import-time decorators as runtime edges. Keep active registrations enumerable and initialization ownership explicit.
+- Break cycles by clarifying ownership rather than scattering local imports. A local import is reasonable for a measured cold optional path or unavoidable framework boundary, but document the reason when it hides a dependency.
+- Avoid module-level construction of clients, model loads, filesystem scans, large data parsing, and environment-dependent state. Own them in application lifespan, factories, commands, or explicit caches.
+- Collapse forwarding wrappers and decorator layers that add no decision, contract, lifecycle, resilience, effect, or diagnostic value; preserve frames that give exceptions useful domain context.
+
 ## Async Python guidance
 
 Watch async code for hidden lifecycle and ownership problems:

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/rust.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/rust.md
@@ -57,6 +57,15 @@ Prefer these when hardening Rust code:
 - narrow trait boundaries introduced for real polymorphism, test seams, or external adapters, not preemptive genericity
 - documented `unsafe` invariants and safe APIs that prevent callers from violating them
 
+## Execution and dependency topology
+
+- Rust modules and crate imports are not runtime module loading. Dependency and feature topology primarily affects compile/link time, binary size, code generation, and ownership; measure those separately from runtime call cost.
+- Inspect proc macros, generated dispatch, blanket trait implementations, feature-selected implementations, and `dyn Trait` boundaries when source navigation cannot reveal the selected call path directly.
+- Treat broad preludes and re-exports as navigation or cycle concerns unless compiler output, build timing, or binary analysis shows a performance cost.
+- Keep application construction explicit. Avoid distributed registration mechanisms whose active implementations can be known only after macro expansion or runtime inventory without a source-level manifest.
+- Compare monomorphization/code-size and dynamic-dispatch tradeoffs with representative builds or benchmarks; do not prescribe generics or trait objects from theory alone.
+- Collapse adapter or combinator chains that merely forward values, but preserve frames that own pinning/lifetime boundaries, cancellation, effects, error context, resilience, or stable public contracts.
+
 ## Error handling guidance
 
 Rust's standard docs distinguish anticipated runtime failures from bugs: use `Result` and error types for expected failures; reserve panic paths for bugs or impossible states.

--- a/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/scoring-rubric.md
+++ b/packages/pi-skill-agent-native-hardening/skills/agent-native-hardening/references/scoring-rubric.md
@@ -17,10 +17,10 @@ Apply explicit godfile/godfunction penalties when the hotspot is material to the
 9-10: contracts are strict across boundaries, invalid states are modeled out, and end-to-end data flow is preserved where tooling supports it
 
 ## 3) traversable
-0-2: hard to locate ownership and flows, godfiles/godfunctions dominate navigation
-3-5: partial structure, large hotspots remain, feature boundaries blurry
-6-8: clear feature folders, reduced hotspots, entrypoints mostly obvious
-9-10: small focused modules with stable entrypoints and crisp separation of concerns
+0-2: ownership and execution paths disappear into godfiles, generic dispatch, hidden registration, callback tunnels, or import side effects
+3-5: partial structure and traceable happy paths exist, but hotspots, no-value frames, dynamic edges, or initialization surprises require broad exploration
+6-8: feature ownership and entrypoints are clear; important call stacks, async continuations, and imports are mostly inspectable with limited no-value indirection
+9-10: important runtime paths are statically discoverable where practical, every semantic hop has a clear role, initialization is deliberate, and changes require little rereading
 
 ## 4) test_coverage
 0-2: no tests
@@ -50,6 +50,9 @@ Treat these as strong negative signals:
 - broad `utils`/`helpers`/`misc` dumping grounds with weak ownership
 - copy-paste logic across features where a stable shared abstraction should exist
 - hidden side effects or mixed layers that make extraction risky
+- pass-through wrapper piles, one-use microfunction confetti, callback tunnels, or generic dispatch that add semantic hops without ownership
+- runtime selection, decorators, middleware order, generated bindings, or import-time registration with no inspectable manifest
+- import cycles, hidden initialization work, or eager cold-path loading that materially harms startup, bundles, tests, or navigation
 - godfunctions that mix unrelated responsibilities, such as validation, orchestration, IO, mutation, rendering, and error handling in one long flow
 - central handlers or lifecycle methods that keep absorbing feature-specific branches instead of delegating to feature-owned code
 - root app/controller objects owning feature-local state, input handling, async task coordination, and rendering decisions
@@ -59,12 +62,13 @@ Treat these as strong negative signals:
 
 Treat these as strong positive signals:
 - godfiles decomposed into feature folders with clear ownership
-- godfunctions decomposed into small named steps with clear ownership and explicit inputs/outputs
+- godfunctions decomposed into coherent named steps whose frames own decisions, contracts, effects, lifecycle, resilience, or observability
 - feature-local modules separated by concern where needed (`index`/entrypoint, domain logic, IO, types/schema, tests)
 - shared abstractions extracted only when genuinely cross-feature and stable
 - explicit state variants, domain-specific value types, validators, and derived contracts replace ambiguous primitives or manually duplicated shapes
 - lower fan-in/fan-out per module and fewer unrelated edits per lane
-- central paths are small routers/registries; feature behavior lives behind explicit, contracted extension points
+- central paths are small, statically enumerable routers/registries; feature behavior and selected implementations remain discoverable behind explicit, contracted extension points
+- runtime and import topology claims are supported by traces, profiles, bundle reports, or representative startup measurements where performance is material
 - async/background work communicates through explicit messages/events/results, with one clear state mutation owner
 - domain data keeps named fields until render/serialization boundaries
 
@@ -72,6 +76,7 @@ Calibration guardrails for material central-path problems:
 
 - a godfile that owns several unrelated core responsibilities usually keeps `agent_native` and `traversable` at 5 or below
 - a central godfunction that mixes orchestration, domain rules, IO, and mutation usually keeps `agent_native` and `traversable` at 6 or below
+- a central execution path dominated by opaque dispatch, no-value frames, or hidden initialization usually keeps `traversable` at 5 or below
 - multiple central godfiles/godfolders usually keep `agent_native`, `traversable`, and `self_documenting` at 4 or below
 - persistent duplication combined with mixed ownership usually keeps `agent_native` at 6 or below until an owner boundary is clear
 


### PR DESCRIPTION
## Summary
- add a heuristic execution-topology lens for call stacks, dispatch, async continuations, imports, and initialization
- distinguish agent navigability from measured runtime performance and make each execution hop justify its boundary
- add JS/TS, Python, Go, and Rust guidance for ecosystem-specific import and execution costs
- extend traversability scoring to cover opaque dispatch, no-value frames, and hidden initialization

## Validation
- `python /home/igorw/.pi/agent/skills/skill-creator/scripts/skill-efficiency-check.py packages/pi-skill-agent-native-hardening/skills/agent-native-hardening`
- `bun pm pack --dry-run`
- `bun run check:changed`
- `bun run changeset:check`

## Release
- Changeset: yes
- Packages: `@howaboua/pi-skill-agent-native-hardening`
- Aggregates: generated by release automation
