### PR TITLE
Skip redundant main binary rebuilds

### DIFF
--- a/.github/workflows/codex-lite-tool-binaries.yml
+++ b/.github/workflows/codex-lite-tool-binaries.yml
@@ -3,6 +3,7 @@ name: Build Codex lite tool binaries
 on:
   workflow_dispatch:
   push:
+    branches-ignore: [main]
     paths:
       - '.github/workflows/codex-lite-tool-binaries.yml'
       - 'packages/pi-codex-conversion-lite/src/tools/**/rust/**'

--- a/.github/workflows/codex-tool-binaries.yml
+++ b/.github/workflows/codex-tool-binaries.yml
@@ -3,6 +3,7 @@ name: Build Codex tool binaries
 on:
   workflow_dispatch:
   push:
+    branches-ignore: [main]
     paths:
       - '.github/workflows/codex-tool-binaries.yml'
       - 'packages/pi-codex-conversion/src/tools/**/rust/**'


### PR DESCRIPTION
## Summary
- skip automatic native binary rebuilds on `main`
- retain feature-branch builds and manual dispatch for both Codex adapters

## Validation
- `git diff --check`
- inspected GitHub Actions trigger syntax

## Release
- Changeset: no
- Packages: none
- Aggregates: none
