### PR TITLE
fix(exec): use bounded raw PTY output

### DIFF
--- a/.changeset/patch-ms1hweio-6b42d5.md
+++ b/.changeset/patch-ms1hweio-6b42d5.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-codex-conversion-lite": patch
 ---
 
-Use bounded raw PTY output instead of terminal emulation, and clarify safe JavaScript quoting for multiline Code Mode commands
+Use bounded raw PTY output instead of terminal emulation while preserving large pipe payloads and reporting omitted PTY output in token counts. Clarify safe JavaScript quoting for multiline Code Mode commands

--- a/.changeset/patch-ms1hweio-6b42d5.md
+++ b/.changeset/patch-ms1hweio-6b42d5.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-codex-conversion-lite": patch
 ---
 
-Use bounded raw PTY output instead of terminal emulation
+Use bounded raw PTY output instead of terminal emulation, and clarify safe JavaScript quoting for multiline Code Mode commands

--- a/.changeset/patch-ms1hweio-6b42d5.md
+++ b/.changeset/patch-ms1hweio-6b42d5.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-codex-conversion-lite": patch
+---
+
+Use bounded raw PTY output instead of terminal emulation

--- a/packages/pi-codex-conversion-lite/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion-lite/src/prompt/build-system-prompt.ts
@@ -21,7 +21,7 @@ const NORMAL_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search",
-	"Use String.raw`...` for multiline or quote-heavy tools.exec_command cmd, or split the call; this prevents JavaScript quoting errors, not shell escaping",
+	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or `${...}`; otherwise use quoted line arrays or split the call",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec",
 	"Give commands time; back off session polls",
 	"Reserve tty=true for input or persistent processes",

--- a/packages/pi-codex-conversion-lite/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion-lite/src/prompt/build-system-prompt.ts
@@ -21,7 +21,7 @@ const NORMAL_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search",
-	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or `${...}`; otherwise use quoted line arrays or split the call",
+	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or ${...}; otherwise use quoted line arrays or split the call",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec",
 	"Give commands time; back off session polls",
 	"Reserve tty=true for input or persistent processes",

--- a/packages/pi-codex-conversion-lite/src/tools/exec/AGENTS.md
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/AGENTS.md
@@ -1,2 +1,2 @@
 - Bridge output chunks are arbitrary bytes; decode incrementally per process stream and flush only after bridge closure.
-- TTY bounds apply to parser source state, not only rendered snapshots; carry incomplete control sequences across chunks.
+- TTY output stays raw and bounded in session state; do not reintroduce terminal-grid emulation.

--- a/packages/pi-codex-conversion-lite/src/tools/exec/output.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/output.ts
@@ -5,32 +5,26 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 
 export interface ExecOutputSessionState {
 	buffer: string;
-	emittedBuffer: string;
-	tty: boolean;
-	terminalCommitted: string;
-	terminalLine: string[];
-	terminalCursor: number;
-	terminalPendingControl: string;
+	bufferStartOffset: number;
+	emittedOffset: number;
 }
 
 function maxCharsForTokens(maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS): number {
 	return Math.max(256, maxOutputTokens * 4);
 }
 
-function stripTerminalControlSequences(text: string, preserveCsi = false): string {
+function stripTerminalControlSequences(text: string): string {
 	const withoutOscAndDcs = text
 		.replace(/\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)/g, "")
 		.replace(/\u001B[P_X^][\s\S]*?\u001B\\/g, "");
-	if (preserveCsi) return withoutOscAndDcs;
 	return withoutOscAndDcs.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "").replace(/\u001B[@-_]/g, "");
 }
 
-function sanitizeBinaryOutput(text: string, preserveBackspace = false): string {
+function sanitizeBinaryOutput(text: string): string {
 	return Array.from(text).filter((char) => {
 		const code = char.codePointAt(0);
 		if (code === undefined) return false;
 		if (code === 0x09 || code === 0x0a || code === 0x0d) return true;
-		if (preserveBackspace && code === 0x08) return true;
 		if (code <= 0x1f) return false;
 		if (code >= 0xfff9 && code <= 0xfffb) return false;
 		return true;
@@ -41,102 +35,10 @@ export function normalizePipeOutput(text: string): string {
 	return sanitizeBinaryOutput(stripTerminalControlSequences(text)).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-function writeTerminalChar(session: ExecOutputSessionState, char: string): void {
-	if (session.terminalCursor > session.terminalLine.length) {
-		session.terminalLine.push(...Array.from({ length: session.terminalCursor - session.terminalLine.length }, () => " "));
-	}
-	session.terminalLine[session.terminalCursor] = char;
-	session.terminalCursor += 1;
-}
-
-export function applyTerminalOutput(session: ExecOutputSessionState, text: string): string {
-	const sanitized = stripTerminalControlSequences(`${session.terminalPendingControl}${text}`, true);
-	session.terminalPendingControl = "";
-	if (sanitized.length === 0) return session.terminalCommitted + session.terminalLine.join("");
-
-	for (let index = 0; index < sanitized.length; index += 1) {
-		const char = sanitized[index]!;
-		if (char === "\u001b") {
-			if (sanitized[index + 1] === "[") {
-				let sequenceEnd = index + 2;
-				while (sequenceEnd < sanitized.length) {
-					const code = sanitized.charCodeAt(sequenceEnd);
-					if (code >= 0x40 && code <= 0x7e) break;
-					sequenceEnd += 1;
-				}
-				if (sequenceEnd >= sanitized.length) {
-					session.terminalPendingControl = sanitized.slice(index);
-					break;
-				}
-				const params = sanitized.slice(index + 2, sequenceEnd);
-				const finalByte = sanitized[sequenceEnd]!;
-				if (finalByte === "K") {
-					const mode = Number(params || "0");
-					if (mode === 0) session.terminalLine = session.terminalLine.slice(0, session.terminalCursor);
-					else if (mode === 1) {
-						session.terminalLine = [
-							...Array.from({ length: Math.min(session.terminalCursor, session.terminalLine.length) }, () => " "),
-							...session.terminalLine.slice(session.terminalCursor),
-						];
-					} else if (mode === 2) session.terminalLine = [];
-				}
-				index = sequenceEnd;
-				continue;
-			}
-
-			const next = sanitized[index + 1]!;
-			if (next && /[()*+,\-./]/.test(next) && index + 2 < sanitized.length) {
-				index += 2;
-				continue;
-			}
-			if (next) index += 1;
-			continue;
-		}
-
-		const code = char.codePointAt(0);
-		if (code !== undefined && code <= 0x1f && char !== "\t" && char !== "\n" && char !== "\r" && char !== "\b") continue;
-
-		switch (char) {
-			case "\r": session.terminalCursor = 0; break;
-			case "\n":
-				session.terminalCommitted += `${session.terminalLine.join("")}\n`;
-				session.terminalLine = [];
-				session.terminalCursor = 0;
-				break;
-			case "\b": session.terminalCursor = Math.max(0, session.terminalCursor - 1); break;
-			default: writeTerminalChar(session, char); break;
-		}
-	}
-
-	return session.terminalCommitted + session.terminalLine.join("");
-}
-
-export function boundTerminalOutput(session: ExecOutputSessionState, maxChars: number): { output: string; rebased: boolean } {
-	const lineLength = session.terminalLine.length;
-	let rebased = false;
-	if (lineLength >= maxChars) {
-		const removed = lineLength - maxChars;
-		session.terminalLine = session.terminalLine.slice(removed);
-		session.terminalCursor = Math.max(0, Math.min(session.terminalLine.length, session.terminalCursor - removed));
-		if (session.terminalCommitted.length > 0) rebased = true;
-		session.terminalCommitted = "";
-		rebased ||= removed > 0;
-	} else {
-		const committedLimit = maxChars - lineLength;
-		if (session.terminalCommitted.length > committedLimit) {
-			session.terminalCommitted = session.terminalCommitted.slice(-committedLimit);
-			rebased = true;
-		}
-	}
-	return { output: session.terminalCommitted + session.terminalLine.join(""), rebased };
-}
-
-function computePtyDelta(previous: string, current: string): string {
-	if (current.startsWith(previous)) return current.slice(previous.length);
-	const lineStart = previous.lastIndexOf("\n") + 1;
-	const stablePrefix = previous.slice(0, lineStart);
-	if (current.startsWith(stablePrefix)) return `\r${current.slice(lineStart)}`;
-	return current;
+export function truncateToTail(text: string, maxChars: number): { output: string; removed: number } {
+	let start = Math.max(0, text.length - maxChars);
+	if (start > 0 && start < text.length && /[\uDC00-\uDFFF]/.test(text[start]!)) start += 1;
+	return { output: text.slice(start), removed: start };
 }
 
 export function generateChunkId(): string {
@@ -148,22 +50,26 @@ export function truncateOutput(text: string, maxOutputTokens?: number): { output
 	const maxChars = maxCharsForTokens(maxOutputTokens);
 	const originalTokenCount = Math.ceil(text.length / 4);
 	if (text.length <= maxChars) return { output: text, original_token_count: originalTokenCount };
-	return { output: text.slice(-maxChars), original_token_count: originalTokenCount };
+	return { output: truncateToTail(text, maxChars).output, original_token_count: originalTokenCount };
 }
 
 export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
-	session.emittedBuffer = session.buffer;
+	const endOffset = session.bufferStartOffset + session.buffer.length;
+	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
+	session.emittedOffset = endOffset;
 	return truncateOutput(text, maxOutputTokens);
 }
 
 export function peekUnconsumedOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
+	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
 	return truncateOutput(text, maxOutputTokens);
 }
 
-export function peekOutputSince(session: ExecOutputSessionState, baseline: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(baseline, session.buffer) : session.buffer.slice(baseline.length);
+export function peekOutputSince(session: ExecOutputSessionState, baselineOffset: number, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+	const startOffset = Math.max(baselineOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
 	return truncateOutput(text, maxOutputTokens);
 }
 

--- a/packages/pi-codex-conversion-lite/src/tools/exec/output.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/output.ts
@@ -45,32 +45,38 @@ export function generateChunkId(): string {
 	return randomBytes(3).toString("hex");
 }
 
-export function truncateOutput(text: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	if (text.length === 0) return { output: "" };
+export function truncateOutput(text: string, maxOutputTokens?: number, originalCharCount = text.length): { output: string; original_token_count?: number | undefined } {
+	if (text.length === 0 && originalCharCount === 0) return { output: "" };
 	const maxChars = maxCharsForTokens(maxOutputTokens);
-	const originalTokenCount = Math.ceil(text.length / 4);
+	const originalTokenCount = Math.ceil(Math.max(text.length, originalCharCount) / 4);
 	if (text.length <= maxChars) return { output: text, original_token_count: originalTokenCount };
 	return { output: truncateToTail(text, maxChars).output, original_token_count: originalTokenCount };
 }
 
-export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+function outputSince(session: ExecOutputSessionState, offset: number): { text: string; originalCharCount: number; endOffset: number } {
 	const endOffset = session.bufferStartOffset + session.buffer.length;
-	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	session.emittedOffset = endOffset;
-	return truncateOutput(text, maxOutputTokens);
+	const startOffset = Math.max(offset, session.bufferStartOffset);
+	return {
+		text: session.buffer.slice(startOffset - session.bufferStartOffset),
+		originalCharCount: Math.max(0, endOffset - offset),
+		endOffset,
+	};
+}
+
+export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+	const output = outputSince(session, session.emittedOffset);
+	session.emittedOffset = output.endOffset;
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function peekUnconsumedOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	return truncateOutput(text, maxOutputTokens);
+	const output = outputSince(session, session.emittedOffset);
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function peekOutputSince(session: ExecOutputSessionState, baselineOffset: number, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const startOffset = Math.max(baselineOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	return truncateOutput(text, maxOutputTokens);
+	const output = outputSince(session, baselineOffset);
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function resultFromSnapshot(args: {

--- a/packages/pi-codex-conversion-lite/src/tools/exec/results.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/results.ts
@@ -23,7 +23,7 @@ export function makeExecResult<TSession extends ExecResultSessionState>(session:
 	const result = fromSnapshot(session, waitMs, consumed);
 	if (session.exitCode === undefined || session.exitCode === null) {
 		exposeSession(session);
-	} else if (session.emittedBuffer === session.buffer) {
+	} else if (session.emittedOffset === session.bufferStartOffset + session.buffer.length) {
 		deleteSessionIfDrained(session.id);
 	}
 	return result;
@@ -47,6 +47,6 @@ export function makeSnapshotResult(session: ExecResultSessionState, waitMs: numb
 	return fromSnapshot(session, waitMs, snapshot);
 }
 
-export function makeSnapshotSince(session: ExecResultSessionState, waitMs: number, baseline: string, maxOutputTokens?: number): UnifiedExecResult {
-	return fromSnapshot(session, waitMs, peekOutputSince(session, baseline, maxOutputTokens));
+export function makeSnapshotSince(session: ExecResultSessionState, waitMs: number, baselineOffset: number, maxOutputTokens?: number): UnifiedExecResult {
+	return fromSnapshot(session, waitMs, peekOutputSince(session, baselineOffset, maxOutputTokens));
 }

--- a/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
@@ -1,6 +1,6 @@
 import { StringDecoder } from "node:string_decoder";
 import { getCodexShellArgs } from "../../adapter/prompt/runtime-shell.ts";
-import { applyTerminalOutput, boundTerminalOutput, normalizePipeOutput } from "./output.ts";
+import { normalizePipeOutput, truncateToTail } from "./output.ts";
 import { chunkToBytes, createExecBridgeClient, type BridgeReadResponse } from "./bridge-client.ts";
 import { DEFAULT_EXEC_YIELD_TIME_MS, DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS, DEFAULT_WRITE_YIELD_TIME_MS, clampExecYieldTime, clampWriteYieldTime, normalizeMinEmptyWriteYieldTime, normalizeMinNonInteractiveExecYieldTime, resolveExecution, resolveShell, resolveWorkdir } from "./shell.ts";
 import { registerAbortHandler, waitForExitOrTimeout } from "./wait.ts";
@@ -51,7 +51,8 @@ interface BaseExecSession {
 	id: number;
 	command: string;
 	buffer: string;
-	emittedBuffer: string;
+	bufferStartOffset: number;
+	emittedOffset: number;
 	exitCode: number | null | undefined;
 	startedAt: number;
 	updatedAt: number;
@@ -70,10 +71,6 @@ interface RustExecSession extends BaseExecSession {
 	started: boolean;
 	tty: boolean;
 	lastSeq: number;
-	terminalCommitted: string;
-	terminalLine: string[];
-	terminalCursor: number;
-	terminalPendingControl: string;
 	outputDecoders: Record<"stdout" | "stderr" | "pty", StringDecoder>;
 	outputDecodersFlushed: boolean;
 }
@@ -106,7 +103,7 @@ export interface ExecSessionManagerOptions {
 }
 
 const MAX_COMMAND_HISTORY = 256;
-const DEFAULT_MAX_SESSION_BUFFER_CHARS = 256 * 1024 * 1024;
+const DEFAULT_MAX_SESSION_BUFFER_CHARS = 1024 * 1024;
 const TERMINATE_ESCALATE_MS = 2_000;
 
 export function createExecSessionManager(options: ExecSessionManagerOptions = {}): ExecSessionManager {
@@ -187,17 +184,12 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 
 	function appendOutput(session: ExecSession, text: string): void {
 		if (text.length === 0) return;
-		if (session.tty) {
-			applyTerminalOutput(session, text);
-			const bounded = boundTerminalOutput(session, maxSessionBufferChars);
+		const output = session.tty ? text : normalizePipeOutput(text);
+		session.buffer += output;
+		if (session.buffer.length > maxSessionBufferChars) {
+			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
 			session.buffer = bounded.output;
-			if (bounded.rebased) session.emittedBuffer = "";
-		} else {
-			session.buffer += normalizePipeOutput(text);
-		}
-		if (!session.tty && session.buffer.length > maxSessionBufferChars) {
-			session.buffer = session.buffer.slice(-maxSessionBufferChars);
-			session.emittedBuffer = "";
+			session.bufferStartOffset += bounded.removed;
 		}
 		notify(session);
 	}
@@ -238,23 +230,20 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			processId: "",
 			startup: Promise.resolve(),
 			started: false,
+			tty: Boolean(input.tty),
 			command: input.cmd,
 			buffer: "",
-			emittedBuffer: "",
+			bufferStartOffset: 0,
+			emittedOffset: 0,
 			exitCode: undefined,
 			listeners: new Set(),
 			interactive: Boolean(input.tty),
-			tty: Boolean(input.tty),
 			lastSeq: 0,
 			startedAt: Date.now(),
 			updatedAt: Date.now(),
 			finalized: false,
 			exposed: false,
 			terminating: false,
-			terminalCommitted: "",
-			terminalLine: [],
-			terminalCursor: 0,
-			terminalPendingControl: "",
 			outputDecoders: {
 				stdout: new StringDecoder("utf8"),
 				stderr: new StringDecoder("utf8"),
@@ -365,7 +354,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			if (!session) {
 				throw new Error(`Unknown process id ${input.session_id}`);
 			}
-			const updateBaseline = session.buffer;
+			const updateBaseline = session.bufferStartOffset + session.buffer.length;
 			const chars = input.chars ?? "";
 			const isEmptyPoll = chars.length === 0;
 			if (!isEmptyPoll) {

--- a/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
@@ -103,7 +103,8 @@ export interface ExecSessionManagerOptions {
 }
 
 const MAX_COMMAND_HISTORY = 256;
-const DEFAULT_MAX_SESSION_BUFFER_CHARS = 1024 * 1024;
+const DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS = 1024 * 1024;
+const DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS = 256 * 1024 * 1024;
 const TERMINATE_ESCALATE_MS = 2_000;
 
 export function createExecSessionManager(options: ExecSessionManagerOptions = {}): ExecSessionManager {
@@ -122,7 +123,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		minEmptyWriteYieldTimeMs,
 		options.maxEmptyWriteYieldTimeMs ?? DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS,
 	);
-	const maxSessionBufferChars = Math.max(1024, options.maxSessionBufferChars ?? DEFAULT_MAX_SESSION_BUFFER_CHARS);
+	const configuredMaxSessionBufferChars = options.maxSessionBufferChars === undefined ? undefined : Math.max(1024, options.maxSessionBufferChars);
 
 	function rememberCommand(sessionId: number, command: string): void {
 		commandHistory.set(sessionId, command);
@@ -186,6 +187,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		if (text.length === 0) return;
 		const output = session.tty ? text : normalizePipeOutput(text);
 		session.buffer += output;
+		const maxSessionBufferChars = configuredMaxSessionBufferChars ?? (session.tty ? DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS : DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS);
 		if (session.buffer.length > maxSessionBufferChars) {
 			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
 			session.buffer = bounded.output;

--- a/packages/pi-codex-conversion-lite/tests/exec-output.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/exec-output.test.ts
@@ -13,10 +13,10 @@ test("bounded raw output resumes deltas after rollover", () => {
 	assert.equal(peekOutputSince(session, baselineOffset).output, "klm");
 	assert.equal(consumeOutput(session).output, "klm");
 
-	const secondRollover = truncateToTail(`${session.buffer}nopqrstuv`, 10);
+	const secondRollover = truncateToTail(`${session.buffer}nopqrstuvwxyzABCDEFG`, 10);
 	session.buffer = secondRollover.output;
 	session.bufferStartOffset += secondRollover.removed;
-	assert.equal(consumeOutput(session).output, "nopqrstuv");
+	assert.deepEqual(consumeOutput(session), { output: "xyzABCDEFG", original_token_count: 5 });
 	assert.equal(truncateToTail(`${"x".repeat(4)}😀z`, 2).output, "z");
 	assert.equal(truncateOutput(`x😀${"y".repeat(255)}`, 1).output, "y".repeat(255));
 });

--- a/packages/pi-codex-conversion-lite/tests/exec-output.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/exec-output.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { consumeOutput, peekOutputSince, truncateOutput, truncateToTail } from "../src/tools/exec/output.ts";
+
+test("bounded raw output resumes deltas after rollover", () => {
+	const session = { buffer: "abcdefghij", bufferStartOffset: 0, emittedOffset: 0 };
+
+	assert.equal(consumeOutput(session).output, "abcdefghij");
+	const baselineOffset = session.bufferStartOffset + session.buffer.length;
+	const firstRollover = truncateToTail(`${session.buffer}klm`, 10);
+	session.buffer = firstRollover.output;
+	session.bufferStartOffset += firstRollover.removed;
+	assert.equal(peekOutputSince(session, baselineOffset).output, "klm");
+	assert.equal(consumeOutput(session).output, "klm");
+
+	const secondRollover = truncateToTail(`${session.buffer}nopqrstuv`, 10);
+	session.buffer = secondRollover.output;
+	session.bufferStartOffset += secondRollover.removed;
+	assert.equal(consumeOutput(session).output, "nopqrstuv");
+	assert.equal(truncateToTail(`${"x".repeat(4)}😀z`, 2).output, "z");
+	assert.equal(truncateOutput(`x😀${"y".repeat(255)}`, 1).output, "y".repeat(255));
+});

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -33,7 +33,7 @@ const PATH_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search",
-	"Use String.raw`...` for multiline or quote-heavy tools.exec_command cmd, or split the call; this prevents JavaScript quoting errors, not shell escaping",
+	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or `${...}`; otherwise use quoted line arrays or split the call",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec",
 	"Give commands time; back off session polls",
 	"Reserve tty=true for input or persistent processes",

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -33,7 +33,7 @@ const PATH_CODEX_GUIDELINES = [
 
 const CODE_MODE_GUIDELINES = [
 	"Use tools.exec_command for shell commands; prefer rg and rg --files for search",
-	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or `${...}`; otherwise use quoted line arrays or split the call",
+	"Keep tools.exec_command cmd valid JavaScript: use String.raw templates only when shell text has no backticks or ${...}; otherwise use quoted line arrays or split the call",
 	"Continue exec cell_id with wait; continue exec_command session_id by calling tools.write_stdin inside exec",
 	"Give commands time; back off session polls",
 	"Reserve tty=true for input or persistent processes",

--- a/packages/pi-codex-conversion/src/tools/exec/AGENTS.md
+++ b/packages/pi-codex-conversion/src/tools/exec/AGENTS.md
@@ -1,2 +1,2 @@
 - Bridge output chunks are arbitrary bytes; decode incrementally per process stream and flush only after bridge closure.
-- TTY bounds apply to parser source state, not only rendered snapshots; carry incomplete control sequences across chunks.
+- TTY output stays raw and bounded in session state; do not reintroduce terminal-grid emulation.

--- a/packages/pi-codex-conversion/src/tools/exec/output.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/output.ts
@@ -46,32 +46,38 @@ export function generateChunkId(): string {
 	return randomBytes(3).toString("hex");
 }
 
-export function truncateOutput(text: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	if (text.length === 0) return { output: "" };
+export function truncateOutput(text: string, maxOutputTokens?: number, originalCharCount = text.length): { output: string; original_token_count?: number | undefined } {
+	if (text.length === 0 && originalCharCount === 0) return { output: "" };
 	const maxChars = maxCharsForTokens(maxOutputTokens);
-	const originalTokenCount = Math.ceil(text.length / 4);
+	const originalTokenCount = Math.ceil(Math.max(text.length, originalCharCount) / 4);
 	if (text.length <= maxChars) return { output: text, original_token_count: originalTokenCount };
 	return { output: truncateToTail(text, maxChars).output, original_token_count: originalTokenCount };
 }
 
-export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+function outputSince(session: ExecOutputSessionState, offset: number): { text: string; originalCharCount: number; endOffset: number } {
 	const endOffset = session.bufferStartOffset + session.buffer.length;
-	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	session.emittedOffset = endOffset;
-	return truncateOutput(text, maxOutputTokens);
+	const startOffset = Math.max(offset, session.bufferStartOffset);
+	return {
+		text: session.buffer.slice(startOffset - session.bufferStartOffset),
+		originalCharCount: Math.max(0, endOffset - offset),
+		endOffset,
+	};
+}
+
+export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+	const output = outputSince(session, session.emittedOffset);
+	session.emittedOffset = output.endOffset;
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function peekUnconsumedOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	return truncateOutput(text, maxOutputTokens);
+	const output = outputSince(session, session.emittedOffset);
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function peekOutputSince(session: ExecOutputSessionState, baselineOffset: number, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const startOffset = Math.max(baselineOffset, session.bufferStartOffset);
-	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
-	return truncateOutput(text, maxOutputTokens);
+	const output = outputSince(session, baselineOffset);
+	return truncateOutput(output.text, maxOutputTokens, output.originalCharCount);
 }
 
 export function resultFromSnapshot(args: {

--- a/packages/pi-codex-conversion/src/tools/exec/output.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/output.ts
@@ -5,23 +5,18 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 
 export interface ExecOutputSessionState {
 	buffer: string;
-	emittedBuffer: string;
-	tty: boolean;
-	terminalCommitted: string;
-	terminalLine: string[];
-	terminalCursor: number;
-	terminalPendingControl: string;
+	bufferStartOffset: number;
+	emittedOffset: number;
 }
 
 function maxCharsForTokens(maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS): number {
 	return Math.max(256, maxOutputTokens * 4);
 }
 
-function stripTerminalControlSequences(text: string, preserveCsi = false): string {
+function stripTerminalControlSequences(text: string): string {
 	const withoutOscAndDcs = text
 		.replace(/\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)/g, "")
 		.replace(/\u001B[P_X^][\s\S]*?\u001B\\/g, "");
-	if (preserveCsi) return withoutOscAndDcs;
 	return withoutOscAndDcs.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "").replace(/\u001B[@-_]/g, "");
 }
 
@@ -41,102 +36,10 @@ export function normalizePipeOutput(text: string): string {
 	return sanitizeBinaryOutput(stripTerminalControlSequences(text)).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-function writeTerminalChar(session: ExecOutputSessionState, char: string): void {
-	if (session.terminalCursor > session.terminalLine.length) {
-		session.terminalLine.push(...Array.from({ length: session.terminalCursor - session.terminalLine.length }, () => " "));
-	}
-	session.terminalLine[session.terminalCursor] = char;
-	session.terminalCursor += 1;
-}
-
-export function applyTerminalOutput(session: ExecOutputSessionState, text: string): string {
-	const sanitized = stripTerminalControlSequences(`${session.terminalPendingControl}${text}`, true);
-	session.terminalPendingControl = "";
-	if (sanitized.length === 0) return session.terminalCommitted + session.terminalLine.join("");
-
-	for (let index = 0; index < sanitized.length; index += 1) {
-		const char = sanitized[index]!;
-		if (char === "\u001b") {
-			if (sanitized[index + 1] === "[") {
-				let sequenceEnd = index + 2;
-				while (sequenceEnd < sanitized.length) {
-					const code = sanitized.charCodeAt(sequenceEnd);
-					if (code >= 0x40 && code <= 0x7e) break;
-					sequenceEnd += 1;
-				}
-				if (sequenceEnd >= sanitized.length) {
-					session.terminalPendingControl = sanitized.slice(index);
-					break;
-				}
-				const params = sanitized.slice(index + 2, sequenceEnd);
-				const finalByte = sanitized[sequenceEnd]!;
-				if (finalByte === "K") {
-					const mode = Number(params || "0");
-					if (mode === 0) session.terminalLine = session.terminalLine.slice(0, session.terminalCursor);
-					else if (mode === 1) {
-						session.terminalLine = [
-							...Array.from({ length: Math.min(session.terminalCursor, session.terminalLine.length) }, () => " "),
-							...session.terminalLine.slice(session.terminalCursor),
-						];
-					} else if (mode === 2) session.terminalLine = [];
-				}
-				index = sequenceEnd;
-				continue;
-			}
-
-			const next = sanitized[index + 1]!;
-			if (next && /[()*+,\-./]/.test(next) && index + 2 < sanitized.length) {
-				index += 2;
-				continue;
-			}
-			if (next) index += 1;
-			continue;
-		}
-
-		const code = char.codePointAt(0);
-		if (code !== undefined && code <= 0x1f && char !== "\t" && char !== "\n" && char !== "\r" && char !== "\b") continue;
-
-		switch (char) {
-			case "\r": session.terminalCursor = 0; break;
-			case "\n":
-				session.terminalCommitted += `${session.terminalLine.join("")}\n`;
-				session.terminalLine = [];
-				session.terminalCursor = 0;
-				break;
-			case "\b": session.terminalCursor = Math.max(0, session.terminalCursor - 1); break;
-			default: writeTerminalChar(session, char); break;
-		}
-	}
-
-	return session.terminalCommitted + session.terminalLine.join("");
-}
-
-export function boundTerminalOutput(session: ExecOutputSessionState, maxChars: number): { output: string; rebased: boolean } {
-	const lineLength = session.terminalLine.length;
-	let rebased = false;
-	if (lineLength >= maxChars) {
-		const removed = lineLength - maxChars;
-		session.terminalLine = session.terminalLine.slice(removed);
-		session.terminalCursor = Math.max(0, Math.min(session.terminalLine.length, session.terminalCursor - removed));
-		if (session.terminalCommitted.length > 0) rebased = true;
-		session.terminalCommitted = "";
-		rebased ||= removed > 0;
-	} else {
-		const committedLimit = maxChars - lineLength;
-		if (session.terminalCommitted.length > committedLimit) {
-			session.terminalCommitted = session.terminalCommitted.slice(-committedLimit);
-			rebased = true;
-		}
-	}
-	return { output: session.terminalCommitted + session.terminalLine.join(""), rebased };
-}
-
-function computePtyDelta(previous: string, current: string): string {
-	if (current.startsWith(previous)) return current.slice(previous.length);
-	const lineStart = previous.lastIndexOf("\n") + 1;
-	const stablePrefix = previous.slice(0, lineStart);
-	if (current.startsWith(stablePrefix)) return `\r${current.slice(lineStart)}`;
-	return current;
+export function truncateToTail(text: string, maxChars: number): { output: string; removed: number } {
+	let start = Math.max(0, text.length - maxChars);
+	if (start > 0 && start < text.length && /[\uDC00-\uDFFF]/.test(text[start]!)) start += 1;
+	return { output: text.slice(start), removed: start };
 }
 
 export function generateChunkId(): string {
@@ -148,22 +51,26 @@ export function truncateOutput(text: string, maxOutputTokens?: number): { output
 	const maxChars = maxCharsForTokens(maxOutputTokens);
 	const originalTokenCount = Math.ceil(text.length / 4);
 	if (text.length <= maxChars) return { output: text, original_token_count: originalTokenCount };
-	return { output: text.slice(-maxChars), original_token_count: originalTokenCount };
+	return { output: truncateToTail(text, maxChars).output, original_token_count: originalTokenCount };
 }
 
 export function consumeOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
-	session.emittedBuffer = session.buffer;
+	const endOffset = session.bufferStartOffset + session.buffer.length;
+	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
+	session.emittedOffset = endOffset;
 	return truncateOutput(text, maxOutputTokens);
 }
 
 export function peekUnconsumedOutput(session: ExecOutputSessionState, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(session.emittedBuffer, session.buffer) : session.buffer.slice(session.emittedBuffer.length);
+	const startOffset = Math.max(session.emittedOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
 	return truncateOutput(text, maxOutputTokens);
 }
 
-export function peekOutputSince(session: ExecOutputSessionState, baseline: string, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
-	const text = session.tty ? computePtyDelta(baseline, session.buffer) : session.buffer.slice(baseline.length);
+export function peekOutputSince(session: ExecOutputSessionState, baselineOffset: number, maxOutputTokens?: number): { output: string; original_token_count?: number | undefined } {
+	const startOffset = Math.max(baselineOffset, session.bufferStartOffset);
+	const text = session.buffer.slice(startOffset - session.bufferStartOffset);
 	return truncateOutput(text, maxOutputTokens);
 }
 

--- a/packages/pi-codex-conversion/src/tools/exec/results.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/results.ts
@@ -23,7 +23,7 @@ export function makeExecResult<TSession extends ExecResultSessionState>(session:
 	const result = fromSnapshot(session, waitMs, consumed);
 	if (session.exitCode === undefined || session.exitCode === null) {
 		exposeSession(session);
-	} else if (session.emittedBuffer === session.buffer) {
+	} else if (session.emittedOffset === session.bufferStartOffset + session.buffer.length) {
 		deleteSessionIfDrained(session.id);
 	}
 	return result;
@@ -47,6 +47,6 @@ export function makeSnapshotResult(session: ExecResultSessionState, waitMs: numb
 	return fromSnapshot(session, waitMs, snapshot);
 }
 
-export function makeSnapshotSince(session: ExecResultSessionState, waitMs: number, baseline: string, maxOutputTokens?: number): UnifiedExecResult {
-	return fromSnapshot(session, waitMs, peekOutputSince(session, baseline, maxOutputTokens));
+export function makeSnapshotSince(session: ExecResultSessionState, waitMs: number, baselineOffset: number, maxOutputTokens?: number): UnifiedExecResult {
+	return fromSnapshot(session, waitMs, peekOutputSince(session, baselineOffset, maxOutputTokens));
 }

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -1,6 +1,6 @@
 import { StringDecoder } from "node:string_decoder";
 import { getCodexShellArgs } from "../../adapter/prompt/runtime-shell.ts";
-import { applyTerminalOutput, boundTerminalOutput, normalizePipeOutput } from "./output.ts";
+import { normalizePipeOutput, truncateToTail } from "./output.ts";
 import { chunkToBytes, createExecBridgeClient, type BridgeReadResponse } from "./bridge-client.ts";
 import { DEFAULT_EXEC_YIELD_TIME_MS, DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS, DEFAULT_WRITE_YIELD_TIME_MS, clampExecYieldTime, clampWriteYieldTime, normalizeMinEmptyWriteYieldTime, normalizeMinNonInteractiveExecYieldTime, resolveExecution, resolveShell, resolveWorkdir } from "./shell.ts";
 import { registerAbortHandler, waitForExitOrTimeout } from "./wait.ts";
@@ -51,7 +51,8 @@ interface BaseExecSession {
 	id: number;
 	command: string;
 	buffer: string;
-	emittedBuffer: string;
+	bufferStartOffset: number;
+	emittedOffset: number;
 	exitCode: number | null | undefined;
 	startedAt: number;
 	updatedAt: number;
@@ -70,10 +71,6 @@ interface RustExecSession extends BaseExecSession {
 	started: boolean;
 	tty: boolean;
 	lastSeq: number;
-	terminalCommitted: string;
-	terminalLine: string[];
-	terminalCursor: number;
-	terminalPendingControl: string;
 	outputDecoders: Record<"stdout" | "stderr" | "pty", StringDecoder>;
 	outputDecodersFlushed: boolean;
 }
@@ -106,7 +103,7 @@ export interface ExecSessionManagerOptions {
 }
 
 const MAX_COMMAND_HISTORY = 256;
-const DEFAULT_MAX_SESSION_BUFFER_CHARS = 256 * 1024 * 1024;
+const DEFAULT_MAX_SESSION_BUFFER_CHARS = 1024 * 1024;
 const TERMINATE_ESCALATE_MS = 2_000;
 
 export function createExecSessionManager(options: ExecSessionManagerOptions = {}): ExecSessionManager {
@@ -187,17 +184,12 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 
 	function appendOutput(session: ExecSession, text: string): void {
 		if (text.length === 0) return;
-		if (session.tty) {
-			applyTerminalOutput(session, text);
-			const bounded = boundTerminalOutput(session, maxSessionBufferChars);
+		const output = session.tty ? text : normalizePipeOutput(text);
+		session.buffer += output;
+		if (session.buffer.length > maxSessionBufferChars) {
+			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
 			session.buffer = bounded.output;
-			if (bounded.rebased) session.emittedBuffer = "";
-		} else {
-			session.buffer += normalizePipeOutput(text);
-		}
-		if (!session.tty && session.buffer.length > maxSessionBufferChars) {
-			session.buffer = session.buffer.slice(-maxSessionBufferChars);
-			session.emittedBuffer = "";
+			session.bufferStartOffset += bounded.removed;
 		}
 		notify(session);
 	}
@@ -238,23 +230,20 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			processId: "",
 			startup: Promise.resolve(),
 			started: false,
+			tty: Boolean(input.tty),
 			command: input.cmd,
 			buffer: "",
-			emittedBuffer: "",
+			bufferStartOffset: 0,
+			emittedOffset: 0,
 			exitCode: undefined,
 			listeners: new Set(),
 			interactive: Boolean(input.tty),
-			tty: Boolean(input.tty),
 			lastSeq: 0,
 			startedAt: Date.now(),
 			updatedAt: Date.now(),
 			finalized: false,
 			exposed: false,
 			terminating: false,
-			terminalCommitted: "",
-			terminalLine: [],
-			terminalCursor: 0,
-			terminalPendingControl: "",
 			outputDecoders: {
 				stdout: new StringDecoder("utf8"),
 				stderr: new StringDecoder("utf8"),
@@ -365,7 +354,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			if (!session) {
 				throw new Error(`Unknown process id ${input.session_id}`);
 			}
-			const updateBaseline = session.buffer;
+			const updateBaseline = session.bufferStartOffset + session.buffer.length;
 			const chars = input.chars ?? "";
 			const isEmptyPoll = chars.length === 0;
 			if (!isEmptyPoll) {

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -103,7 +103,8 @@ export interface ExecSessionManagerOptions {
 }
 
 const MAX_COMMAND_HISTORY = 256;
-const DEFAULT_MAX_SESSION_BUFFER_CHARS = 1024 * 1024;
+const DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS = 1024 * 1024;
+const DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS = 256 * 1024 * 1024;
 const TERMINATE_ESCALATE_MS = 2_000;
 
 export function createExecSessionManager(options: ExecSessionManagerOptions = {}): ExecSessionManager {
@@ -122,7 +123,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		minEmptyWriteYieldTimeMs,
 		options.maxEmptyWriteYieldTimeMs ?? DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS,
 	);
-	const maxSessionBufferChars = Math.max(1024, options.maxSessionBufferChars ?? DEFAULT_MAX_SESSION_BUFFER_CHARS);
+	const configuredMaxSessionBufferChars = options.maxSessionBufferChars === undefined ? undefined : Math.max(1024, options.maxSessionBufferChars);
 
 	function rememberCommand(sessionId: number, command: string): void {
 		commandHistory.set(sessionId, command);
@@ -186,6 +187,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		if (text.length === 0) return;
 		const output = session.tty ? text : normalizePipeOutput(text);
 		session.buffer += output;
+		const maxSessionBufferChars = configuredMaxSessionBufferChars ?? (session.tty ? DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS : DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS);
 		if (session.buffer.length > maxSessionBufferChars) {
 			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
 			session.buffer = bounded.output;

--- a/packages/pi-codex-conversion/tests/exec-output.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-output.test.ts
@@ -13,10 +13,10 @@ test("bounded raw output resumes deltas after rollover", () => {
 	assert.equal(peekOutputSince(session, baselineOffset).output, "klm");
 	assert.equal(consumeOutput(session).output, "klm");
 
-	const secondRollover = truncateToTail(`${session.buffer}nopqrstuv`, 10);
+	const secondRollover = truncateToTail(`${session.buffer}nopqrstuvwxyzABCDEFG`, 10);
 	session.buffer = secondRollover.output;
 	session.bufferStartOffset += secondRollover.removed;
-	assert.equal(consumeOutput(session).output, "nopqrstuv");
+	assert.deepEqual(consumeOutput(session), { output: "xyzABCDEFG", original_token_count: 5 });
 	assert.equal(truncateToTail(`${"x".repeat(4)}😀z`, 2).output, "z");
 	assert.equal(truncateOutput(`x😀${"y".repeat(255)}`, 1).output, "y".repeat(255));
 });

--- a/packages/pi-codex-conversion/tests/exec-output.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-output.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { consumeOutput, peekOutputSince, truncateOutput, truncateToTail } from "../src/tools/exec/output.ts";
+
+test("bounded raw output resumes deltas after rollover", () => {
+	const session = { buffer: "abcdefghij", bufferStartOffset: 0, emittedOffset: 0 };
+
+	assert.equal(consumeOutput(session).output, "abcdefghij");
+	const baselineOffset = session.bufferStartOffset + session.buffer.length;
+	const firstRollover = truncateToTail(`${session.buffer}klm`, 10);
+	session.buffer = firstRollover.output;
+	session.bufferStartOffset += firstRollover.removed;
+	assert.equal(peekOutputSince(session, baselineOffset).output, "klm");
+	assert.equal(consumeOutput(session).output, "klm");
+
+	const secondRollover = truncateToTail(`${session.buffer}nopqrstuv`, 10);
+	session.buffer = secondRollover.output;
+	session.bufferStartOffset += secondRollover.removed;
+	assert.equal(consumeOutput(session).output, "nopqrstuv");
+	assert.equal(truncateToTail(`${"x".repeat(4)}😀z`, 2).output, "z");
+	assert.equal(truncateOutput(`x😀${"y".repeat(255)}`, 1).output, "y".repeat(255));
+});


### PR DESCRIPTION
## Summary
- remove the partial PTY terminal-grid emulator and retain raw PTY output instead
- cap raw TTY retention at 1 MiB while preserving the existing large pipe budget required by PATH tool payloads
- track rollover with absolute offsets, including omitted output in token counts
- apply surrogate-safe tail truncation and clarify multiline Code Mode command quoting

Closes #174

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `bun run knip`
- direct 1.2M-character pipe and TTY retention checks

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-codex-conversion-lite`
- Aggregates: generated by release automation
