### PR TITLE
Improve long-running exec and realtime voice updates

### DIFF
--- a/.changeset/patch-ms1r7hyo-2ff29d.md
+++ b/.changeset/patch-ms1r7hyo-2ff29d.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-codex-conversion-lite": patch
 ---
 
-Yield silent shell commands as sessions while active commands continue waiting
+Yield silent shell commands as sessions while active commands continue waiting. Encourage concise intermediary progress updates during longer realtime voice work

--- a/.changeset/patch-ms1r7hyo-2ff29d.md
+++ b/.changeset/patch-ms1r7hyo-2ff29d.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-codex-conversion-lite": patch
+---
+
+Yield silent shell commands as sessions while active commands continue waiting

--- a/packages/pi-codex-conversion-lite/src/tools/exec/AGENTS.md
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/AGENTS.md
@@ -1,2 +1,3 @@
 - Bridge output chunks are arbitrary bytes; decode incrementally per process stream and flush only after bridge closure.
 - TTY output stays raw and bounded in session state; do not reintroduce terminal-grid emulation.
+- Keep wait policy host-side and model wording generic: output extends ordinary non-TTY and empty-poll waits, silence yields a session, and agents only need the continuation handle.

--- a/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
@@ -13,7 +13,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 	workdir: Type.Optional(Type.String({ description: "Cwd" })),
 	shell: Type.Optional(Type.String()),
 	tty: Type.Optional(Type.Boolean({ description: "Keep stdin open for input or interruption" })),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Yield after idle ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });
@@ -175,7 +175,7 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 			});
 			const execInput = input.tty
 				? input
-				: { ...input, yield_time_ms: MAX_EXEC_YIELD_TIME_MS, max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS };
+				: { ...input, max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS };
 			const result = await sessions.exec(execInput, ctx.cwd, signal, onUpdate ? (partial) => onUpdate(toToolResult(partial)) : undefined);
 			if (result.session_id !== undefined) tracker.recordPersistentSession(toolCallId, result.session_id);
 			return toToolResult(result);

--- a/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
@@ -13,7 +13,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 	workdir: Type.Optional(Type.String({ description: "Cwd" })),
 	shell: Type.Optional(Type.String()),
 	tty: Type.Optional(Type.Boolean({ description: "Keep stdin open for input or interruption" })),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Non-TTY idle ms; TTY wait ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });

--- a/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/command-tool.ts
@@ -13,7 +13,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 	workdir: Type.Optional(Type.String({ description: "Cwd" })),
 	shell: Type.Optional(Type.String()),
 	tty: Type.Optional(Type.Boolean({ description: "Keep stdin open for input or interruption" })),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Yield after idle ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Non-TTY idle ms; TTY wait ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });

--- a/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/session-manager.ts
@@ -3,7 +3,7 @@ import { getCodexShellArgs } from "../../adapter/prompt/runtime-shell.ts";
 import { normalizePipeOutput, truncateToTail } from "./output.ts";
 import { chunkToBytes, createExecBridgeClient, type BridgeReadResponse } from "./bridge-client.ts";
 import { DEFAULT_EXEC_YIELD_TIME_MS, DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS, DEFAULT_WRITE_YIELD_TIME_MS, clampExecYieldTime, clampWriteYieldTime, normalizeMinEmptyWriteYieldTime, normalizeMinNonInteractiveExecYieldTime, resolveExecution, resolveShell, resolveWorkdir } from "./shell.ts";
-import { registerAbortHandler, waitForExitOrTimeout } from "./wait.ts";
+import { registerAbortHandler, waitForExitOrInactivity } from "./wait.ts";
 import { makeExecResult, makeSnapshotResult, makeSnapshotSince, snapshotSession } from "./results.ts";
 
 export interface UnifiedExecResult {
@@ -53,6 +53,7 @@ interface BaseExecSession {
 	buffer: string;
 	bufferStartOffset: number;
 	emittedOffset: number;
+	outputVersion: number;
 	exitCode: number | null | undefined;
 	startedAt: number;
 	updatedAt: number;
@@ -187,6 +188,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		if (text.length === 0) return;
 		const output = session.tty ? text : normalizePipeOutput(text);
 		session.buffer += output;
+		session.outputVersion += 1;
 		const maxSessionBufferChars = configuredMaxSessionBufferChars ?? (session.tty ? DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS : DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS);
 		if (session.buffer.length > maxSessionBufferChars) {
 			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
@@ -237,6 +239,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			buffer: "",
 			bufferStartOffset: 0,
 			emittedOffset: 0,
+			outputVersion: 0,
 			exitCode: undefined,
 			listeners: new Set(),
 			interactive: Boolean(input.tty),
@@ -330,9 +333,11 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			try {
 				onUpdate?.(makeSnapshotResult(session, 0, input.max_output_tokens, true));
 				const execYieldMs = clampExecYieldTime(input.yield_time_ms, defaultExecYieldTimeMs, session.interactive, minNonInteractiveExecYieldTimeMs, input.max_yield_time_ms);
-				const waitedMs = await waitForExitOrTimeout(
+				const maxExecWaitMs = Math.max(execYieldMs, input.max_yield_time_ms ?? execYieldMs);
+				const waitedMs = await waitForExitOrInactivity(
 					session,
 					execYieldMs,
+					maxExecWaitMs,
 					signal,
 					onUpdate ? (elapsedMs) => onUpdate(makeSnapshotResult(session, elapsedMs, input.max_output_tokens)) : undefined,
 				);
@@ -357,6 +362,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 				throw new Error(`Unknown process id ${input.session_id}`);
 			}
 			const updateBaseline = session.bufferStartOffset + session.buffer.length;
+			const outputVersionBaseline = session.outputVersion;
 			const chars = input.chars ?? "";
 			const isEmptyPoll = chars.length === 0;
 			if (!isEmptyPoll) {
@@ -379,9 +385,10 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 				: requestedYieldMs;
 			const waitedMs =
 				session.exitCode === undefined
-					? await waitForExitOrTimeout(
+					? await waitForExitOrInactivity(
 							session,
 							effectiveYieldMs,
+							isEmptyPoll ? maxEmptyWriteYieldTimeMs : effectiveYieldMs,
 							signal,
 							onUpdate ? (elapsedMs) => onUpdate(makeSnapshotSince(session, elapsedMs, updateBaseline, input.max_output_tokens)) : undefined,
 					)
@@ -389,7 +396,9 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			await waitForStartup(session, signal);
 			if (session.started) await pollSession(session, 0);
 			if (isEmptyPoll && (session.exitCode === undefined || session.exitCode === null))
-				session.nextEmptyPollYieldMs = growEmptyPollYield(effectiveYieldMs, maxEmptyWriteYieldTimeMs);
+				session.nextEmptyPollYieldMs = session.outputVersion === outputVersionBaseline
+					? growEmptyPollYield(effectiveYieldMs, maxEmptyWriteYieldTimeMs)
+					: minEmptyWriteYieldTimeMs;
 			return makeExecResult(session, waitedMs, input.max_output_tokens, exposeSession, (sessionId) => sessions.delete(sessionId));
 		},
 		hasSession: (sessionId) => sessions.has(sessionId),

--- a/packages/pi-codex-conversion-lite/src/tools/exec/wait.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/exec/wait.ts
@@ -1,5 +1,6 @@
 export interface WaitableSession {
 	exitCode: number | null | undefined;
+	outputVersion: number;
 	listeners: Set<() => void>;
 }
 
@@ -14,18 +15,23 @@ export function registerAbortHandler(signal: AbortSignal | undefined, onAbort: (
 	return () => signal.removeEventListener("abort", abortListener);
 }
 
-export function waitForExitOrTimeout(session: WaitableSession, yieldTimeMs: number, signal?: AbortSignal, onUpdate?: (elapsedMs: number) => void): Promise<number> {
+export function waitForExitOrInactivity(session: WaitableSession, idleTimeMs: number, maxWaitMs = idleTimeMs, signal?: AbortSignal, onUpdate?: (elapsedMs: number) => void): Promise<number> {
 	if (session.exitCode !== undefined && session.exitCode !== null) return Promise.resolve(0);
 	if (signal?.aborted) return Promise.resolve(0);
 
 	const startedAt = Date.now();
+	const hardLimitMs = Math.max(idleTimeMs, maxWaitMs);
 	let updateTimer: ReturnType<typeof setInterval> | undefined;
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	let hardTimer: ReturnType<typeof setTimeout> | undefined;
 	let lastUpdateAt = 0;
+	let outputVersion = session.outputVersion;
 	return new Promise((resolvePromise) => {
 		let abortCleanup: (() => void) | undefined;
 		let done = false;
 		const cleanup = () => {
-			clearTimeout(timeout);
+			if (idleTimer) clearTimeout(idleTimer);
+			if (hardTimer) clearTimeout(hardTimer);
 			if (updateTimer) clearInterval(updateTimer);
 			abortCleanup?.();
 			session.listeners.delete(onWake);
@@ -44,13 +50,19 @@ export function waitForExitOrTimeout(session: WaitableSession, yieldTimeMs: numb
 		};
 		const onWake = () => {
 			if (session.exitCode === undefined || session.exitCode === null) {
+				if (session.outputVersion !== outputVersion) {
+					outputVersion = session.outputVersion;
+					if (idleTimer) clearTimeout(idleTimer);
+					idleTimer = setTimeout(finish, idleTimeMs);
+				}
 				emitUpdate();
 				return;
 			}
 			emitUpdate(true);
 			finish();
 		};
-		const timeout = setTimeout(finish, yieldTimeMs);
+		idleTimer = setTimeout(finish, idleTimeMs);
+		hardTimer = setTimeout(finish, hardLimitMs);
 		abortCleanup = registerAbortHandler(signal, finish);
 		if (onUpdate) updateTimer = setInterval(emitUpdate, 250);
 		session.listeners.add(onWake);

--- a/packages/pi-codex-conversion-lite/src/voice/ui.ts
+++ b/packages/pi-codex-conversion-lite/src/voice/ui.ts
@@ -84,7 +84,7 @@ function modeStateContent(mode: CodexVoiceMode, state: CodexVoiceModeState): str
 	}
 	return mode === "dictation"
 		? "<codex_voice_mode mode=\"dictation\" state=\"active\">Dictation is active. User messages may contain speech-recognition errors or missing punctuation. Resolve obvious errors from context and clarify only material ambiguity.</codex_voice_mode>"
-		: "<codex_voice_mode mode=\"realtime\" state=\"active\">Realtime voice is active. Routed requests may contain speech-recognition errors or missing punctuation. Responses are consumed by a voice intermediary, so keep updates concise and action-oriented.</codex_voice_mode>";
+		: "<codex_voice_mode mode=\"realtime\" state=\"active\">Realtime voice is active. Routed requests may contain speech-recognition errors or missing punctuation. Responses are consumed by a voice intermediary, so keep updates concise and action-oriented. During longer work, use brief assistant messages between tool calls to report meaningful progress instead of waiting until the final result.</codex_voice_mode>";
 }
 
 function modeStateDisplay(mode: CodexVoiceMode, state: CodexVoiceModeState): string {

--- a/packages/pi-codex-conversion-lite/tests/exec-wait.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/exec-wait.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { waitForExitOrInactivity, type WaitableSession } from "../src/tools/exec/wait.ts";
+
+function emitOutput(session: WaitableSession): void {
+	session.outputVersion += 1;
+	for (const listener of session.listeners) listener();
+}
+
+function runningSession(): WaitableSession {
+	return { exitCode: undefined, outputVersion: 0, listeners: new Set() };
+}
+
+test("exec waits through output activity but yields on silence or the hard limit", async (t) => {
+	t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+
+	const silent = runningSession();
+	const silentWait = waitForExitOrInactivity(silent, 10, 30);
+	t.mock.timers.tick(10);
+	assert.equal(await silentWait, 10);
+
+	const active = runningSession();
+	const activeWait = waitForExitOrInactivity(active, 10, 30);
+	for (let elapsed = 9; elapsed <= 27; elapsed += 9) {
+		t.mock.timers.tick(9);
+		emitOutput(active);
+	}
+	t.mock.timers.tick(3);
+	assert.equal(await activeWait, 30);
+});

--- a/packages/pi-codex-conversion/src/tools/exec/AGENTS.md
+++ b/packages/pi-codex-conversion/src/tools/exec/AGENTS.md
@@ -1,2 +1,3 @@
 - Bridge output chunks are arbitrary bytes; decode incrementally per process stream and flush only after bridge closure.
 - TTY output stays raw and bounded in session state; do not reintroduce terminal-grid emulation.
+- Keep wait policy host-side and model wording generic: output extends ordinary non-TTY and empty-poll waits, silence yields a session, and agents only need the continuation handle.

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -27,7 +27,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 			description: "Keep stdin open for input or interruption",
 		}),
 	),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Yield after idle ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });
@@ -381,7 +381,7 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 				...(pathToolEnv ? { env: pathToolEnv } : {}),
 				...(pathToolPolicy?.disableTruncation ? { max_output_tokens: Number.MAX_SAFE_INTEGER } : {}),
 				...(!typedParams.tty && pathToolPolicy?.yieldTimeMs === undefined
-					? { yield_time_ms: MAX_EXEC_YIELD_TIME_MS, max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS }
+					? { max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS }
 					: {}),
 				...(pathToolPolicy?.yieldTimeMs !== undefined ? { yield_time_ms: pathToolPolicy.yieldTimeMs, max_yield_time_ms: pathToolPolicy.yieldTimeMs } : {}),
 			};

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -27,7 +27,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 			description: "Keep stdin open for input or interruption",
 		}),
 	),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Non-TTY idle ms; TTY wait ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Wait ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -27,7 +27,7 @@ const EXEC_COMMAND_PARAMETERS = Type.Object({
 			description: "Keep stdin open for input or interruption",
 		}),
 	),
-	yield_time_ms: Type.Optional(Type.Number({ description: "Yield after idle ms" })),
+	yield_time_ms: Type.Optional(Type.Number({ description: "Non-TTY idle ms; TTY wait ms" })),
 	max_output_tokens: Type.Optional(Type.Number({ description: "Truncate" })),
 	login: Type.Optional(Type.Boolean({ description: "Login shell" })),
 });
@@ -381,7 +381,9 @@ export function createExecCommandTool(tracker: ExecCommandTracker, sessions: Exe
 				...(pathToolEnv ? { env: pathToolEnv } : {}),
 				...(pathToolPolicy?.disableTruncation ? { max_output_tokens: Number.MAX_SAFE_INTEGER } : {}),
 				...(!typedParams.tty && pathToolPolicy?.yieldTimeMs === undefined
-					? { max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS }
+					? pathToolPolicy
+						? { yield_time_ms: MAX_EXEC_YIELD_TIME_MS, max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS }
+						: { max_yield_time_ms: MAX_EXEC_YIELD_TIME_MS }
 					: {}),
 				...(pathToolPolicy?.yieldTimeMs !== undefined ? { yield_time_ms: pathToolPolicy.yieldTimeMs, max_yield_time_ms: pathToolPolicy.yieldTimeMs } : {}),
 			};

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -3,7 +3,7 @@ import { getCodexShellArgs } from "../../adapter/prompt/runtime-shell.ts";
 import { normalizePipeOutput, truncateToTail } from "./output.ts";
 import { chunkToBytes, createExecBridgeClient, type BridgeReadResponse } from "./bridge-client.ts";
 import { DEFAULT_EXEC_YIELD_TIME_MS, DEFAULT_MAX_EMPTY_WRITE_YIELD_TIME_MS, DEFAULT_WRITE_YIELD_TIME_MS, clampExecYieldTime, clampWriteYieldTime, normalizeMinEmptyWriteYieldTime, normalizeMinNonInteractiveExecYieldTime, resolveExecution, resolveShell, resolveWorkdir } from "./shell.ts";
-import { registerAbortHandler, waitForExitOrTimeout } from "./wait.ts";
+import { registerAbortHandler, waitForExitOrInactivity } from "./wait.ts";
 import { makeExecResult, makeSnapshotResult, makeSnapshotSince, snapshotSession } from "./results.ts";
 
 export interface UnifiedExecResult {
@@ -53,6 +53,7 @@ interface BaseExecSession {
 	buffer: string;
 	bufferStartOffset: number;
 	emittedOffset: number;
+	outputVersion: number;
 	exitCode: number | null | undefined;
 	startedAt: number;
 	updatedAt: number;
@@ -187,6 +188,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		if (text.length === 0) return;
 		const output = session.tty ? text : normalizePipeOutput(text);
 		session.buffer += output;
+		session.outputVersion += 1;
 		const maxSessionBufferChars = configuredMaxSessionBufferChars ?? (session.tty ? DEFAULT_MAX_TTY_SESSION_BUFFER_CHARS : DEFAULT_MAX_PIPE_SESSION_BUFFER_CHARS);
 		if (session.buffer.length > maxSessionBufferChars) {
 			const bounded = truncateToTail(session.buffer, maxSessionBufferChars);
@@ -237,6 +239,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			buffer: "",
 			bufferStartOffset: 0,
 			emittedOffset: 0,
+			outputVersion: 0,
 			exitCode: undefined,
 			listeners: new Set(),
 			interactive: Boolean(input.tty),
@@ -330,9 +333,11 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			try {
 				onUpdate?.(makeSnapshotResult(session, 0, input.max_output_tokens, true));
 				const execYieldMs = clampExecYieldTime(input.yield_time_ms, defaultExecYieldTimeMs, session.interactive, minNonInteractiveExecYieldTimeMs, input.max_yield_time_ms);
-				const waitedMs = await waitForExitOrTimeout(
+				const maxExecWaitMs = Math.max(execYieldMs, input.max_yield_time_ms ?? execYieldMs);
+				const waitedMs = await waitForExitOrInactivity(
 					session,
 					execYieldMs,
+					maxExecWaitMs,
 					signal,
 					onUpdate ? (elapsedMs) => onUpdate(makeSnapshotResult(session, elapsedMs, input.max_output_tokens)) : undefined,
 				);
@@ -357,6 +362,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 				throw new Error(`Unknown process id ${input.session_id}`);
 			}
 			const updateBaseline = session.bufferStartOffset + session.buffer.length;
+			const outputVersionBaseline = session.outputVersion;
 			const chars = input.chars ?? "";
 			const isEmptyPoll = chars.length === 0;
 			if (!isEmptyPoll) {
@@ -379,9 +385,10 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 				: requestedYieldMs;
 			const waitedMs =
 				session.exitCode === undefined
-					? await waitForExitOrTimeout(
+					? await waitForExitOrInactivity(
 							session,
 							effectiveYieldMs,
+							isEmptyPoll ? maxEmptyWriteYieldTimeMs : effectiveYieldMs,
 							signal,
 							onUpdate ? (elapsedMs) => onUpdate(makeSnapshotSince(session, elapsedMs, updateBaseline, input.max_output_tokens)) : undefined,
 					)
@@ -389,7 +396,9 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			await waitForStartup(session, signal);
 			if (session.started) await pollSession(session, 0);
 			if (isEmptyPoll && (session.exitCode === undefined || session.exitCode === null))
-				session.nextEmptyPollYieldMs = growEmptyPollYield(effectiveYieldMs, maxEmptyWriteYieldTimeMs);
+				session.nextEmptyPollYieldMs = session.outputVersion === outputVersionBaseline
+					? growEmptyPollYield(effectiveYieldMs, maxEmptyWriteYieldTimeMs)
+					: minEmptyWriteYieldTimeMs;
 			return makeExecResult(session, waitedMs, input.max_output_tokens, exposeSession, (sessionId) => sessions.delete(sessionId));
 		},
 		hasSession: (sessionId) => sessions.has(sessionId),

--- a/packages/pi-codex-conversion/src/tools/exec/wait.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/wait.ts
@@ -1,5 +1,6 @@
 export interface WaitableSession {
 	exitCode: number | null | undefined;
+	outputVersion: number;
 	listeners: Set<() => void>;
 }
 
@@ -14,18 +15,23 @@ export function registerAbortHandler(signal: AbortSignal | undefined, onAbort: (
 	return () => signal.removeEventListener("abort", abortListener);
 }
 
-export function waitForExitOrTimeout(session: WaitableSession, yieldTimeMs: number, signal?: AbortSignal, onUpdate?: (elapsedMs: number) => void): Promise<number> {
+export function waitForExitOrInactivity(session: WaitableSession, idleTimeMs: number, maxWaitMs = idleTimeMs, signal?: AbortSignal, onUpdate?: (elapsedMs: number) => void): Promise<number> {
 	if (session.exitCode !== undefined && session.exitCode !== null) return Promise.resolve(0);
 	if (signal?.aborted) return Promise.resolve(0);
 
 	const startedAt = Date.now();
+	const hardLimitMs = Math.max(idleTimeMs, maxWaitMs);
 	let updateTimer: ReturnType<typeof setInterval> | undefined;
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	let hardTimer: ReturnType<typeof setTimeout> | undefined;
 	let lastUpdateAt = 0;
+	let outputVersion = session.outputVersion;
 	return new Promise((resolvePromise) => {
 		let abortCleanup: (() => void) | undefined;
 		let done = false;
 		const cleanup = () => {
-			clearTimeout(timeout);
+			if (idleTimer) clearTimeout(idleTimer);
+			if (hardTimer) clearTimeout(hardTimer);
 			if (updateTimer) clearInterval(updateTimer);
 			abortCleanup?.();
 			session.listeners.delete(onWake);
@@ -44,13 +50,19 @@ export function waitForExitOrTimeout(session: WaitableSession, yieldTimeMs: numb
 		};
 		const onWake = () => {
 			if (session.exitCode === undefined || session.exitCode === null) {
+				if (session.outputVersion !== outputVersion) {
+					outputVersion = session.outputVersion;
+					if (idleTimer) clearTimeout(idleTimer);
+					idleTimer = setTimeout(finish, idleTimeMs);
+				}
 				emitUpdate();
 				return;
 			}
 			emitUpdate(true);
 			finish();
 		};
-		const timeout = setTimeout(finish, yieldTimeMs);
+		idleTimer = setTimeout(finish, idleTimeMs);
+		hardTimer = setTimeout(finish, hardLimitMs);
 		abortCleanup = registerAbortHandler(signal, finish);
 		if (onUpdate) updateTimer = setInterval(emitUpdate, 250);
 		session.listeners.add(onWake);

--- a/packages/pi-codex-conversion/src/voice/ui.ts
+++ b/packages/pi-codex-conversion/src/voice/ui.ts
@@ -84,7 +84,7 @@ function modeStateContent(mode: CodexVoiceMode, state: CodexVoiceModeState): str
 	}
 	return mode === "dictation"
 		? "<codex_voice_mode mode=\"dictation\" state=\"active\">Dictation is active. User messages may contain speech-recognition errors or missing punctuation. Resolve obvious errors from context and clarify only material ambiguity.</codex_voice_mode>"
-		: "<codex_voice_mode mode=\"realtime\" state=\"active\">Realtime voice is active. Routed requests may contain speech-recognition errors or missing punctuation. Responses are consumed by a voice intermediary, so keep updates concise and action-oriented.</codex_voice_mode>";
+		: "<codex_voice_mode mode=\"realtime\" state=\"active\">Realtime voice is active. Routed requests may contain speech-recognition errors or missing punctuation. Responses are consumed by a voice intermediary, so keep updates concise and action-oriented. During longer work, use brief assistant messages between tool calls to report meaningful progress instead of waiting until the final result.</codex_voice_mode>";
 }
 
 function modeStateDisplay(mode: CodexVoiceMode, state: CodexVoiceModeState): string {

--- a/packages/pi-codex-conversion/tests/exec-wait.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-wait.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { waitForExitOrInactivity, type WaitableSession } from "../src/tools/exec/wait.ts";
+
+function emitOutput(session: WaitableSession): void {
+	session.outputVersion += 1;
+	for (const listener of session.listeners) listener();
+}
+
+function runningSession(): WaitableSession {
+	return { exitCode: undefined, outputVersion: 0, listeners: new Set() };
+}
+
+test("exec waits through output activity but yields on silence or the hard limit", async (t) => {
+	t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+
+	const silent = runningSession();
+	const silentWait = waitForExitOrInactivity(silent, 10, 30);
+	t.mock.timers.tick(10);
+	assert.equal(await silentWait, 10);
+
+	const active = runningSession();
+	const activeWait = waitForExitOrInactivity(active, 10, 30);
+	for (let elapsed = 9; elapsed <= 27; elapsed += 9) {
+		t.mock.timers.tick(9);
+		emitOutput(active);
+	}
+	t.mock.timers.tick(3);
+	assert.equal(await activeWait, 30);
+});


### PR DESCRIPTION
## Summary
- yield silent non-TTY commands as resumable sessions after the normal idle window
- reset the idle window whenever process output arrives, while retaining the 30-minute hard ceiling
- apply the same activity-aware behavior to empty `write_stdin` polls in normal and lite conversion
- prompt Pi to send brief meaningful progress messages during longer realtime voice work

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- direct native-bridge check: silent commands yielded while incrementally emitting commands completed in both packages

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-codex-conversion-lite`
- Aggregates: generated by release automation
