### PR TITLE
Fix legacy Code Mode exec replay

### DIFF
--- a/.changeset/patch-ms3qg8rh-1518a3.md
+++ b/.changeset/patch-ms3qg8rh-1518a3.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-codex-conversion-lite": patch
+---
+
+Migrate legacy function-shaped exec history to native custom-tool IDs so existing Code Mode sessions resume across the tool-contract upgrade

--- a/packages/pi-codex-conversion-lite/src/providers/openai-responses/shared.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-responses/shared.ts
@@ -270,7 +270,6 @@ export function convertResponsesMessages<TApi extends Api>(
 			}
 		} else if (msg.role === "assistant") {
 			const output: ResponseInput = [];
-			const isForeignProvider = msg.provider !== model.provider || msg.api !== model.api;
 			const isDifferentModel = msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
 			let textBlockIndex = 0;
 			for (const block of msg.content as InternalAssistantContent[]) {
@@ -301,7 +300,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					const [callId, itemIdRaw] = block.id.split("|");
 					const customInputProperty = options?.grammarToolInputProperties?.get(block.name);
 					let itemId: string | undefined = itemIdRaw;
-					if (isForeignProvider && customInputProperty !== undefined && itemId?.startsWith("fc_")) {
+					if (customInputProperty !== undefined && itemId?.startsWith("fc_")) {
 						itemId = `ctc_${itemId.slice(3)}`;
 					}
 					if (

--- a/packages/pi-codex-conversion-lite/tests/native-freeform-contract.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/native-freeform-contract.test.ts
@@ -93,6 +93,36 @@ test("native grammar metadata controls custom replay and function fallback", () 
 			{ type: "custom_tool_call_output", call_id: "call_1", output: "42" },
 		],
 	);
+	const legacyFunctionContext = {
+		messages: [
+			{
+				content: [{ type: "toolCall", id: "call_1|fc_1", name: "exec", arguments: { code: "text(42);" } }],
+				role: "assistant",
+				provider: "openai-codex",
+				api: "openai-codex-responses",
+				model: "gpt-5.6",
+				stopReason: "toolUse",
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_1|fc_1",
+				toolName: "exec",
+				content: [{ type: "text", text: "42" }],
+				isError: false,
+				timestamp: 2,
+			},
+		],
+	} as never;
+	assert.deepEqual(
+		convertResponsesMessages(model, legacyFunctionContext, new Set(["openai-codex"]), {
+			grammarToolInputProperties: new Map([["exec", "code"]]),
+		}),
+		[
+			{ type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", input: "text(42);" },
+			{ type: "custom_tool_call_output", call_id: "call_1", output: "42" },
+		],
+	);
 	assert.deepEqual(
 		convertResponsesMessages(model, context, new Set(["openai-codex"])),
 		[

--- a/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode-contract.ts
@@ -33,9 +33,12 @@ export function applyCodeModeFreeformContract<T extends ResponsesLikeBody>(
 			typeof item["call_id"] === "string" ? item["call_id"] : undefined;
 		if (callId) execCallIds.add(callId);
 		const { arguments: _arguments, id, ...rest } = item;
+		const customId = typeof id === "string" && id.startsWith("fc_")
+			? `ctc_${id.slice(3)}`
+			: id;
 		return {
 			...rest,
-			...(typeof id === "string" && id.startsWith("ctc_") ? { id } : {}),
+			...(typeof customId === "string" && customId.startsWith("ctc_") ? { id: customId } : {}),
 			type: "custom_tool_call",
 			input: execSourceFromArguments(item["arguments"]),
 		};

--- a/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-contract.test.ts
@@ -15,7 +15,7 @@ test("Code Mode rewrites exec history to custom tool items", () => {
 		input: [
 			{
 				type: "function_call",
-				id: "ctc_1",
+				id: "fc_1",
 				call_id: "call_1",
 				name: "exec",
 				arguments: JSON.stringify({ code: "text(42);" }),


### PR DESCRIPTION
## Summary
- migrate legacy function-shaped `exec` calls from `fc_*` to native Code Mode `ctc_*` IDs during replay
- cover same-model session upgrades in Lite and the full adapter contract
- allow existing Code Mode sessions to resume after the native freeform tool-contract change

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `git diff --check`
- verification cull: 0 complete tests deleted; existing protocol tests were expanded for persisted tool-call migration

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-codex-conversion-lite`
- Aggregates: generated by release automation
