### PR TITLE
Preserve Codex cache through delayed compaction

### DIFF
--- a/.changeset/patch-ms3thmo2-8dc5ee.md
+++ b/.changeset/patch-ms3thmo2-8dc5ee.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-codex-conversion-lite": patch
+---
+
+Keep Codex WebSocket continuations alive through the backend cache window so delayed compaction can reuse the hot context.

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/constants.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/constants.ts
@@ -7,5 +7,4 @@ export const DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS = 15_000;
 export const CODEX_RESPONSE_STATUSES = new Set(["completed", "incomplete", "failed", "cancelled", "queued", "in_progress"]);
 export const OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06";
 export const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
-export const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
 export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-session-cache.ts
@@ -1,4 +1,3 @@
-import { SESSION_WEBSOCKET_CACHE_TTL_MS } from "./constants.ts";
 import type { AcquiredWebSocket, ProviderEnv, SessionWebSocketCacheEntry } from "./types.ts";
 import { closeWebSocketSilently, connectWebSocket, isWebSocketReusable } from "./websocket-connection.ts";
 
@@ -13,11 +12,12 @@ function scheduleSessionWebSocketExpiry(cacheKey: string, entry: SessionWebSocke
 	if (entry.idleTimer) {
 		clearTimeout(entry.idleTimer);
 	}
+	const remainingLifetimeMs = Math.max(0, SESSION_WEBSOCKET_MAX_AGE_MS - (Date.now() - entry.createdAt));
 	entry.idleTimer = setTimeout(() => {
 		if (entry.busy) return;
-		closeWebSocketSilently(entry.socket, 1000, "idle_timeout");
+		closeWebSocketSilently(entry.socket, 1000, "connection_age_limit");
 		websocketSessionCache.delete(cacheKey);
-	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
+	}, remainingLifetimeMs);
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/constants.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/constants.ts
@@ -7,5 +7,4 @@ export const DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS = 15_000;
 export const CODEX_RESPONSE_STATUSES = new Set(["completed", "incomplete", "failed", "cancelled", "queued", "in_progress"]);
 export const OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06";
 export const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
-export const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
 export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
@@ -1,4 +1,3 @@
-import { SESSION_WEBSOCKET_CACHE_TTL_MS } from "./constants.ts";
 import type { AcquiredWebSocket, ProviderEnv, SessionWebSocketCacheEntry } from "./types.ts";
 import { closeWebSocketSilently, connectWebSocket, isWebSocketReusable } from "./websocket-connection.ts";
 
@@ -13,11 +12,12 @@ function scheduleSessionWebSocketExpiry(cacheKey: string, entry: SessionWebSocke
 	if (entry.idleTimer) {
 		clearTimeout(entry.idleTimer);
 	}
+	const remainingLifetimeMs = Math.max(0, SESSION_WEBSOCKET_MAX_AGE_MS - (Date.now() - entry.createdAt));
 	entry.idleTimer = setTimeout(() => {
 		if (entry.busy) return;
-		closeWebSocketSilently(entry.socket, 1000, "idle_timeout");
+		closeWebSocketSilently(entry.socket, 1000, "connection_age_limit");
 		websocketSessionCache.delete(cacheKey);
-	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
+	}, remainingLifetimeMs);
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {


### PR DESCRIPTION
## Summary
- keep reusable Codex WebSockets alive for their existing 55-minute maximum lifetime instead of evicting them after five idle minutes
- preserve hot continuation context for delayed native compaction and align both Codex adapters with stock Codex session reuse

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- live Responses V2 control probe: immediate 16,048-token compaction reused 15,104 cached tokens

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-codex-conversion-lite`
- Aggregates: generated by release automation
