### PR TITLE
fix(codex): recover transports and harden file tools

### DIFF
--- a/.changeset/patch-ms4gi6sr-8c5926.md
+++ b/.changeset/patch-ms4gi6sr-8c5926.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-codex-conversion-lite": patch
 ---
 
-Recover failed Codex WebSocket sessions through SSE until successful compaction restores cached WebSockets
+Recover failed Codex WebSocket sessions through SSE until successful compaction restores cached WebSockets. Serialize patch mutations, retain partial patch errors, and accept model-style image paths

--- a/.changeset/patch-ms4gi6sr-8c5926.md
+++ b/.changeset/patch-ms4gi6sr-8c5926.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-codex-conversion-lite": patch
+---
+
+Recover failed Codex WebSocket sessions through SSE until successful compaction restores cached WebSockets

--- a/packages/pi-codex-conversion-lite/src/adapter/compaction/remote-v2-client.ts
+++ b/packages/pi-codex-conversion-lite/src/adapter/compaction/remote-v2-client.ts
@@ -7,6 +7,7 @@ import { canonicalCompactionOutput, normalizeRemoteCompactionV2PromptInput } fro
 import { withRemoteCompactionV2Feature } from "../../providers/openai-responses/compaction-v2-feature.ts";
 import type { OpenAICodexStreamOptions, ResponsesBody } from "../../providers/openai-codex/types.ts";
 import { sleep } from "../../providers/openai-codex/sse.ts";
+import { isWebSocketSseFallbackActive } from "../../providers/openai-codex/websocket.ts";
 
 const MAX_STREAM_RETRIES = 2;
 type V2Stream = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AsyncIterable<unknown>;
@@ -132,7 +133,9 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 export async function executeRemoteCompactionV2(options: ExecuteRemoteCompactionV2Options): Promise<RemoteCompactionV2Result> {
 	const streamSimple = resolveStream(options);
 	if (!streamSimple) return { ok: false, reason: "unavailable", errorMessage: "No compatible Responses stream is registered for this provider" };
-	const initialTransport = options.transport ?? (options.runtime.provider === "openai-codex" ? "websocket-cached" : "sse");
+	const initialTransport = options.runtime.provider === "openai-codex" && isWebSocketSseFallbackActive(options.sessionId)
+		? "sse"
+		: options.transport ?? (options.runtime.provider === "openai-codex" ? "websocket-cached" : "sse");
 	const transports: Transport[] = options.runtime.provider === "openai-codex" && initialTransport !== "sse"
 		? [initialTransport, "sse"]
 		: [initialTransport];

--- a/packages/pi-codex-conversion-lite/src/extension/events.ts
+++ b/packages/pi-codex-conversion-lite/src/extension/events.ts
@@ -168,25 +168,28 @@ export function registerCodexEvents(
 		if (!resolveCodexRuntimePlan(ctx, state.config).nativeCompaction) return undefined;
 		return handleCodexSessionBeforeCompact(event, ctx, state, pi);
 	});
-	pi.on("session_compact", async (event) => {
+	pi.on("session_compact", async (event, ctx) => {
 		runtime.voice.resetContextAnnouncements();
 		state.pendingPiCompactionNativeWindow = undefined;
-		if (!event.fromExtension || !isNativeCompactionDetails(event.compactionEntry.details)) return;
-		const details = event.compactionEntry.details;
-		pi.sendMessage({
-			customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
-			content: NATIVE_COMPACTION_DISPLAY_TEXT,
-			display: true,
-			details: { compactionEntryId: event.compactionEntry.id },
-		}, { triggerTurn: false });
-		if (details.strategy === NATIVE_COMPACTION_STRATEGY && details.usage) {
+		if (event.fromExtension && isNativeCompactionDetails(event.compactionEntry.details)) {
+			const details = event.compactionEntry.details;
 			pi.sendMessage({
 				customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
-				content: formatCompactionUsage(details.usage),
+				content: NATIVE_COMPACTION_DISPLAY_TEXT,
 				display: true,
-				details: { compactionEntryId: event.compactionEntry.id, kind: "usage" },
+				details: { compactionEntryId: event.compactionEntry.id },
 			}, { triggerTurn: false });
+			if (details.strategy === NATIVE_COMPACTION_STRATEGY && details.usage) {
+				pi.sendMessage({
+					customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
+					content: formatCompactionUsage(details.usage),
+					display: true,
+					details: { compactionEntryId: event.compactionEntry.id, kind: "usage" },
+				}, { triggerTurn: false });
+			}
 		}
+		runtime.resetTransport(ctx.sessionManager.getSessionId());
+		await runtime.startPrewarm(ctx);
 	});
 	pi.on("context", async (event) => {
 		if (state.config.voiceFeaturesOnly) return undefined;

--- a/packages/pi-codex-conversion-lite/src/extension/tools.ts
+++ b/packages/pi-codex-conversion-lite/src/extension/tools.ts
@@ -4,7 +4,7 @@ import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import { usesCodexProviderFallback } from "../adapter/activation/runtime-plan.ts";
 import { WEB_SEARCH_TOOL_NAME } from "../adapter/activation/tool-set.ts";
 import { isResponsesModel } from "../adapter/prompt/codex-model.ts";
-import { registerApplyPatchTool } from "../tools/apply-patch/tool.ts";
+import { registerApplyPatchResultEvent, registerApplyPatchTool } from "../tools/apply-patch/tool.ts";
 import { registerExecCommandTool } from "../tools/exec/command-tool.ts";
 import { registerWriteStdinTool } from "../tools/exec/write-stdin-tool.ts";
 import { registerImageGenerationTool } from "../tools/imagegen/tool.ts";
@@ -23,6 +23,7 @@ export function isExplicitlyConfiguredToolProvider(model: Model<Api> | undefined
 }
 
 export function registerCodexTools(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexToolRegistration {
+	registerApplyPatchResultEvent(pi);
 	const renderOptions = (config: CodexConversionConfig) => ({ customRendering: config.ui.toolRenaming });
 	const registerApplyPatch = (config: CodexConversionConfig) =>
 		registerApplyPatchTool(pi, { customRustBinariesDir: config.tools.customRustBinariesDir, showDiffWhenCollapsed: !config.ui.compactTools });

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex-custom-provider.ts
@@ -21,8 +21,8 @@ import { combineAbortSignals, compressRequestBodyZstd, createSSEHeaderTimeout, p
 import type { CodexProviderStreamOptions, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { createInitialAssistantMessage } from "./openai-codex/types.ts";
 import { finalizeUsage } from "./openai-codex/usage.ts";
-import { validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
-import { processCodexResponsesStream } from "./openai-codex/stream-events.ts";
+import { isWebSocketSseFallbackActive, recordWebSocketSseFallback, validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
+import { isCodexNonTransportError, isWebSocketConnectionLimitReachedError, processCodexResponsesStream } from "./openai-codex/stream-events.ts";
 import { prewarmWebSocket, processWebSocketStream } from "./openai-codex/websocket-stream.ts";
 import { openaiCodexNativeOAuthProvider } from "./openai-codex/oauth.ts";
 import { CODEX_TURN_STATE_HEADER, type CodexTurnState } from "./openai-codex/turn-state.ts";
@@ -37,11 +37,13 @@ export type { CachedWebSocketContinuationState, CachedWebSocketRequestBodyResult
 export function getEffectiveCodexTransport(
 	transport: Transport | undefined,
 	config: Pick<CodexConversionConfig["openai"], "forceCachedWebSockets"> | undefined,
+	sessionId?: string | undefined,
 ): Transport {
 	const configuredTransport = transport ?? "auto";
-	if (config?.forceCachedWebSockets === false) return configuredTransport;
-	if (configuredTransport === "websocket") return "websocket-cached";
-	return configuredTransport;
+	const preferredTransport = config?.forceCachedWebSockets !== false && configuredTransport === "websocket"
+		? "websocket-cached"
+		: configuredTransport;
+	return preferredTransport !== "sse" && isWebSocketSseFallbackActive(sessionId) ? "sse" : preferredTransport;
 }
 
 async function prepareCodexRequestBody<TApi extends Api>(
@@ -73,7 +75,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	},
 ): Promise<void> {
 	const runtimeConfig = deps.getConfig?.();
-	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai) === "sse") return;
+	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai, options.sessionId) === "sse") return;
 	if (!options.apiKey || !options.sessionId) return;
 	const responsesLite = deps.useResponsesLite?.(model) ?? (runtimeConfig?.beta.codeMode === true && supportsResponsesLiteModel(model.id));
 	const grammarToolInputProperties = createGrammarToolInputProperties(context.tools, responsesLite);
@@ -90,7 +92,14 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 			client_metadata: { ...(websocketBody.client_metadata ?? {}), [CODEX_TURN_STATE_HEADER]: currentTurnState },
 		};
 	}
-	await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, effectiveOptions, deps.turnState);
+	try {
+		await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, effectiveOptions, deps.turnState);
+	} catch (error) {
+		if (!options.signal?.aborted && (!isCodexNonTransportError(error) || isWebSocketConnectionLimitReachedError(error))) {
+			recordWebSocketSseFallback(options.sessionId);
+		}
+		throw error;
+	}
 }
 
 function createCodexStream<TApi extends Api>(
@@ -107,7 +116,8 @@ function createCodexStream<TApi extends Api>(
 	const runtimeConfig = deps.getConfig?.();
 	const responsesLite = deps.useResponsesLite?.(model) ?? (runtimeConfig?.beta.codeMode === true && supportsResponsesLiteModel(model.id));
 	const grammarToolInputProperties = createGrammarToolInputProperties(context.tools, responsesLite);
-	const effectiveTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai);
+	const preferredTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai);
+	const effectiveTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai, options?.sessionId);
 	const effectiveOptions: OpenAICodexStreamOptions | undefined = options
 		? { ...options, transport: effectiveTransport, grammarToolInputProperties }
 		: { transport: effectiveTransport, grammarToolInputProperties };
@@ -167,19 +177,21 @@ function createCodexStream<TApi extends Api>(
 					stream.end();
 					return;
 				} catch (error) {
+					const aborted = effectiveOptions?.signal?.aborted === true;
+					const connectionLimitBeforeStart = !websocketStarted && isWebSocketConnectionLimitReachedError(error);
+					if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) throw error;
 					appendAssistantMessageDiagnostic(
 						output,
 						createAssistantMessageDiagnostic("provider_transport_failure", error, {
-							configuredTransport: transport,
+							configuredTransport: preferredTransport,
 							fallbackTransport: websocketStarted ? undefined : "sse",
 							eventsEmitted: websocketStarted,
 							phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
 							requestBytes: new TextEncoder().encode(bodyJson).byteLength,
 						}),
 					);
-					if (transport === "websocket" || transport === "websocket-cached" || websocketStarted) {
-						throw error;
-					}
+					recordWebSocketSseFallback(effectiveOptions?.sessionId);
+					if (websocketStarted) throw error;
 				}
 			}
 

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/stream-events.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/stream-events.ts
@@ -19,6 +19,17 @@ export class CodexApiError extends Error {
 	}
 }
 
+export class CodexProtocolError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "CodexProtocolError";
+	}
+}
+
+export function isCodexNonTransportError(error: unknown): boolean {
+	return error instanceof CodexApiError || error instanceof CodexProtocolError;
+}
+
 export function isWebSocketConnectionLimitReachedError(error: unknown): boolean {
 	return error instanceof CodexApiError && error.code === WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE;
 }

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-connection.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-connection.ts
@@ -106,16 +106,40 @@ export function closeWebSocketSilently(socket: WebSocketLike, code = 1000, reaso
 	}
 }
 
-
+function nestedWebSocketError(error: Error): Error {
+	const wrapped = new Error(`WebSocket error: ${error.message}`, { cause: error }) as Error & { code?: string | number | undefined };
+	wrapped.name = "WebSocketError";
+	const code = (error as Error & { code?: unknown }).code;
+	if (typeof code === "string" || typeof code === "number") wrapped.code = code;
+	return wrapped;
+}
 
 export function extractWebSocketError(event: unknown): Error {
-	if (event && typeof event === "object" && "message" in event) {
-		const message = (event as { message?: unknown | undefined }).message;
+	if (event && typeof event === "object") {
+		const message = "message" in event ? (event as { message?: unknown | undefined }).message : undefined;
 		if (typeof message === "string" && message.length > 0) {
 			return new Error(message);
 		}
+		const nestedError = "error" in event ? (event as { error?: unknown | undefined }).error : undefined;
+		if (nestedError instanceof Error && nestedError.message.length > 0) return nestedWebSocketError(nestedError);
+		if (nestedError && typeof nestedError === "object" && "message" in nestedError) {
+			const nestedMessage = (nestedError as { message?: unknown | undefined }).message;
+			if (typeof nestedMessage === "string" && nestedMessage.length > 0) return nestedWebSocketError(new Error(nestedMessage));
+		}
 	}
 	return new Error("WebSocket error");
+}
+
+export class WebSocketCloseError extends Error {
+	readonly code?: number | undefined;
+	readonly reason?: string | undefined;
+
+	constructor(message: string, options?: { code?: number | undefined; reason?: string | undefined }) {
+		super(message);
+		this.name = "WebSocketCloseError";
+		this.code = options?.code;
+		this.reason = options?.reason;
+	}
 }
 
 export function extractWebSocketCloseError(event: unknown): Error {
@@ -127,7 +151,10 @@ export function extractWebSocketCloseError(event: unknown): Error {
 		if (!reasonText && code === WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE) {
 			reasonText = " message too big";
 		}
-		return new Error(`WebSocket closed${codeText}${reasonText}`.trim());
+		return new WebSocketCloseError(`WebSocket closed${codeText}${reasonText}`.trim(), {
+			code: typeof code === "number" ? code : undefined,
+			reason: typeof reason === "string" && reason.length > 0 ? reason : undefined,
+		});
 	}
 	return new Error("WebSocket closed");
 }

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-parser.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-parser.ts
@@ -1,6 +1,7 @@
 import type { StreamEventShape, WebSocketLike } from "./types.ts";
 import { extractWebSocketCloseError, extractWebSocketError } from "./websocket-connection.ts";
 import { extractCodexTurnStateFromWebSocketEvent } from "./turn-state.ts";
+import { CodexProtocolError } from "./stream-events.ts";
 
 async function decodeWebSocketData(data: unknown): Promise<string | null> {
 	if (typeof data === "string") return data;
@@ -54,7 +55,7 @@ export async function* parseWebSocket(socket: WebSocketLike, signal: AbortSignal
 					}
 					queue.push(parsed);
 				} catch (error) {
-					failed = new Error(`Invalid Codex WebSocket JSON: ${error instanceof Error ? error.message : String(error)}`);
+					failed = new CodexProtocolError(`Invalid Codex WebSocket JSON: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
 					done = true;
 				}
 			})
@@ -163,5 +164,5 @@ export async function* startWebSocketOutputOnFirstEvent(
 export function isRetryableEarlyWebSocketError(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : String(error);
 	if (/message too big/i.test(message)) return false;
-	return /^(?:WebSocket (?:error|closed|connect timeout)(?:\s|$)|Invalid Codex WebSocket JSON)/.test(message);
+	return /^WebSocket (?:error|closed|connect timeout)(?:\s|$)/.test(message);
 }

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket-session-cache.ts
@@ -2,7 +2,16 @@ import type { AcquiredWebSocket, ProviderEnv, SessionWebSocketCacheEntry } from 
 import { closeWebSocketSilently, connectWebSocket, isWebSocketReusable } from "./websocket-connection.ts";
 
 const websocketSessionCache = new Map<string, SessionWebSocketCacheEntry>();
+const websocketSseFallbackSessions = new Set<string>();
 const SESSION_WEBSOCKET_MAX_AGE_MS = 55 * 60 * 1000;
+
+export function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
+	return sessionId ? websocketSseFallbackSessions.has(sessionId) : false;
+}
+
+export function recordWebSocketSseFallback(sessionId: string | undefined): void {
+	if (sessionId) websocketSseFallbackSessions.add(sessionId);
+}
 
 function isWebSocketSessionExpired(entry: SessionWebSocketCacheEntry): boolean {
 	return Date.now() - entry.createdAt >= SESSION_WEBSOCKET_MAX_AGE_MS;
@@ -33,6 +42,7 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		const entry = websocketSessionCache.get(sessionId);
 		if (entry) closeEntry(entry);
 		websocketSessionCache.delete(sessionId);
+		websocketSseFallbackSessions.delete(sessionId);
 		return;
 	}
 
@@ -40,6 +50,7 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		closeEntry(entry);
 	}
 	websocketSessionCache.clear();
+	websocketSseFallbackSessions.clear();
 }
 
 export async function acquireWebSocket(

--- a/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket.ts
+++ b/packages/pi-codex-conversion-lite/src/providers/openai-codex/websocket.ts
@@ -1,7 +1,7 @@
 import type { OpenAICodexStreamOptions } from "./types.ts";
 import { normalizeTimeoutMs } from "./sse.ts";
 
-export { closeOpenAICodexWebSocketSessions, acquireWebSocket } from "./websocket-session-cache.ts";
+export { closeOpenAICodexWebSocketSessions, acquireWebSocket, isWebSocketSseFallbackActive, recordWebSocketSseFallback } from "./websocket-session-cache.ts";
 export { countWebSocketEvents, isRetryableEarlyWebSocketError, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket-parser.ts";
 
 export function validateWebSocketTimeoutOptions(options: OpenAICodexStreamOptions | undefined): void {

--- a/packages/pi-codex-conversion-lite/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/apply-patch/tool.ts
@@ -1,6 +1,8 @@
 import { Type } from "typebox";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Container, Text } from "@earendil-works/pi-tui";
+import { parsePatchActions } from "../../patch/parser.ts";
+import { resolvePatchPath } from "../../patch/paths.ts";
 import { ExecutePatchError, type ExecutePatchResult } from "../../patch/types.ts";
 import { formatPatchTarget } from "./rendering.ts";
 import { executePatchWithRust } from "./executor.ts";
@@ -71,6 +73,24 @@ function getAppliedPaths(result: ExecutePatchResult, failedFiles: string[]): str
 	return result.changedFiles.filter((path) => !failedFiles.includes(path));
 }
 
+function touchedPatchPaths(cwd: string, patchText: string): string[] {
+	try {
+		const paths = parsePatchActions({ text: patchText }).flatMap((action) => [action.path, action.movePath]);
+		return [...new Set(paths.filter((path): path is string => !!path).map((patchPath) => resolvePatchPath({ cwd, patchPath })))].sort();
+	} catch {
+		// The Rust helper remains authoritative for malformed patch errors.
+		return [];
+	}
+}
+
+async function withTouchedFileMutationQueues<T>(cwd: string, patchText: string, fn: () => Promise<T>): Promise<T> {
+	const paths = touchedPatchPaths(cwd, patchText);
+	const run = (index: number): Promise<T> => index >= paths.length
+		? fn()
+		: withFileMutationQueue(paths[index]!, () => run(index + 1));
+	return run(0);
+}
+
 function buildPartialFailureMessage(message: string, failedFiles: string[], appliedFiles: string[]): string {
 	const lines = [message];
 	if (failedFiles.length > 0) {
@@ -110,6 +130,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 		description: "Patch files",
 		...(options.promptSnippet === false ? {} : { promptSnippet: "Edit files with patch" }),
 		parameters: APPLY_PATCH_PARAMETERS,
+		executionMode: "sequential",
 		prepareArguments: prepareApplyPatchArguments,
 		async execute(toolCallId, params, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("apply_patch aborted");
@@ -118,7 +139,9 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 			setApplyPatchRenderState(toolCallId, typedParams.patchText, ctx.cwd);
 			let result: ExecutePatchResult;
 			try {
-				result = await executePatchWithRust({ cwd: ctx.cwd, patchText: typedParams.patchText, signal, customRustBinariesDir: options.customRustBinariesDir });
+				result = await withTouchedFileMutationQueues(ctx.cwd, typedParams.patchText, () =>
+					executePatchWithRust({ cwd: ctx.cwd, patchText: typedParams.patchText, signal, customRustBinariesDir: options.customRustBinariesDir }),
+				);
 			} catch (error) {
 				if (error instanceof ExecutePatchError) {
 					const partial = error.hasPartialSuccess();
@@ -174,4 +197,13 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 
 export function registerApplyPatchTool(pi: ExtensionAPI, options: ApplyPatchToolOptions = {}): void {
 	pi.registerTool(createApplyPatchTool(options));
+}
+
+export function registerApplyPatchResultEvent(pi: ExtensionAPI): void {
+	pi.on("tool_result", (event) => {
+		if (event.toolName === "apply_patch" && isApplyPatchToolDetails(event.details) && event.details.status === "partial_failure") {
+			return { isError: true };
+		}
+		return undefined;
+	});
 }

--- a/packages/pi-codex-conversion-lite/src/tools/view-image/tool.ts
+++ b/packages/pi-codex-conversion-lite/src/tools/view-image/tool.ts
@@ -49,7 +49,7 @@ export function parseViewImageParams(params: unknown): ViewImageParams {
 			throw new Error(`view_image.detail only supports \`original\`, got \`${rawDetail}\``);
 		}
 	}
-	return { path: params.path };
+	return { path: params.path.startsWith("@") ? params.path.slice(1) : params.path };
 }
 
 function prepareViewImageArguments(args: unknown): Record<string, unknown> {

--- a/packages/pi-codex-conversion-lite/tests/adapter-tool-activation.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/adapter-tool-activation.test.ts
@@ -14,6 +14,7 @@ function createToolHarness(activeTools: string[]) {
 		setActiveTools: (nextTools: string[]) => {
 			activeTools = nextTools;
 		},
+		on: () => undefined,
 		registerTool: (tool: { name: string }) => registeredTools.add(tool.name),
 		activeTools: () => activeTools,
 		registeredTools: () => registeredTools,

--- a/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
@@ -163,7 +163,7 @@ class ScriptedWebSocket {
 	}
 }
 
-const websocketSuccess: WebSocketScript = (socket) => setTimeout(() => {
+const websocketSuccess: WebSocketScript = (socket) => setImmediate(() => {
 	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
 	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
 });
@@ -428,7 +428,7 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 
 test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setTimeout(() => {
+		(socket) => setImmediate(() => {
 			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
 			socket.emit("error", { error: new Error("socket reset by peer") });
 		}),
@@ -467,9 +467,9 @@ test("a post-start WebSocket failure makes SSE sticky only for that session unti
 
 test("Codex API and protocol errors do not arm SSE fallback", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setTimeout(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }), 0),
+		(socket) => setImmediate(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" })),
 		websocketSuccess,
-		(socket) => setTimeout(() => socket.emit("message", { data: "not-json" }), 0),
+		(socket) => setImmediate(() => socket.emit("message", { data: "not-json" })),
 		websocketSuccess,
 	]);
 	const originalFetch = globalThis.fetch;

--- a/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { zstdDecompressSync } from "node:zlib";
 import {
 	buildRequestBody,
+	closeOpenAICodexWebSocketSessions,
 	parseSSE,
 	registerOpenAICodexCustomProvider,
 } from "../src/providers/openai-codex-custom-provider.ts";
@@ -113,6 +114,82 @@ async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]>
 	const events: unknown[] = [];
 	for await (const event of stream) events.push(event);
 	return events;
+}
+
+type WebSocketScript = (socket: ScriptedWebSocket) => void;
+
+class ScriptedWebSocket {
+	static scripts: WebSocketScript[] = [];
+	static opened = 0;
+	readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+	readonly script: WebSocketScript;
+	readyState = 0;
+
+	constructor() {
+		const script = ScriptedWebSocket.scripts.shift();
+		if (!script) throw new Error("No scripted WebSocket behavior");
+		this.script = script;
+		ScriptedWebSocket.opened++;
+		queueMicrotask(() => {
+			this.readyState = 1;
+			this.emit("open", {});
+		});
+	}
+
+	addEventListener(type: string, listener: (event: unknown) => void): void {
+		const listeners = this.listeners.get(type) ?? new Set();
+		listeners.add(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: string, listener: (event: unknown) => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	send(): void {
+		this.script(this);
+	}
+
+	close(): void {
+		this.readyState = 3;
+	}
+
+	emit(type: string, event: unknown): void {
+		for (const listener of this.listeners.get(type) ?? []) listener(event);
+	}
+
+	emitJson(event: unknown): void {
+		this.emit("message", { data: JSON.stringify(event) });
+	}
+}
+
+const websocketSuccess: WebSocketScript = (socket) => setTimeout(() => {
+	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
+	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
+});
+
+function installScriptedWebSocket(scripts: WebSocketScript[]): () => void {
+	const original = globalThis.WebSocket;
+	ScriptedWebSocket.scripts = [...scripts];
+	ScriptedWebSocket.opened = 0;
+	globalThis.WebSocket = ScriptedWebSocket as never;
+	return () => {
+		globalThis.WebSocket = original;
+		ScriptedWebSocket.scripts = [];
+		closeOpenAICodexWebSocketSessions();
+	};
+}
+
+function codexStreamRequest(sessionId: string) {
+	return {
+		model: { ...(codexModel as object), baseUrl: "https://chatgpt.example/backend-api" } as never,
+		context: { systemPrompt: "Instructions", messages: [] } as never,
+		options: {
+			apiKey: fakeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_1" } }),
+			transport: "auto",
+			sessionId,
+		} as never,
+	};
 }
 
 function createRegisteredCodexProvider(options?: { codeMode?: boolean | undefined; harnessIdentifierHeader?: boolean | undefined }) {
@@ -347,4 +424,75 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 	for await (const event of parseSSE(response)) events.push(event);
 
 	assert.deepEqual(events, [{ type: "response.created", response: { id: "resp_1" } }]);
+});
+
+test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		(socket) => setTimeout(() => {
+			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
+			socket.emit("error", { error: new Error("socket reset by peer") });
+		}),
+		websocketSuccess,
+		websocketSuccess,
+	]);
+	const originalFetch = globalThis.fetch;
+	let fetchCalls = 0;
+	globalThis.fetch = (async () => {
+		fetchCalls++;
+		return sseResponse([{ type: "response.completed", response: { id: "resp_sse", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } }]);
+	}) as typeof fetch;
+	try {
+		const registered = createRegisteredCodexProvider();
+		const sessionA = codexStreamRequest("session-a");
+		const failed = await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.match((failed.at(-1) as { error: { errorMessage: string } }).error.errorMessage, /Connection error: WebSocket error: socket reset by peer/);
+		assert.equal(fetchCalls, 0);
+
+		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.equal(fetchCalls, 1);
+		assert.equal(ScriptedWebSocket.opened, 1);
+
+		const sessionB = codexStreamRequest("session-b");
+		await collectStream(registered.provider.streamSimple(sessionB.model, sessionB.context, sessionB.options));
+		assert.equal(ScriptedWebSocket.opened, 2);
+
+		closeOpenAICodexWebSocketSessions("session-a");
+		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.equal(ScriptedWebSocket.opened, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+		restoreWebSocket();
+	}
+});
+
+test("Codex API and protocol errors do not arm SSE fallback", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		(socket) => setTimeout(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }), 0),
+		websocketSuccess,
+		(socket) => setTimeout(() => socket.emit("message", { data: "not-json" }), 0),
+		websocketSuccess,
+	]);
+	const originalFetch = globalThis.fetch;
+	let fetchCalls = 0;
+	globalThis.fetch = (async () => {
+		fetchCalls++;
+		return sseResponse([]);
+	}) as typeof fetch;
+	try {
+		const registered = createRegisteredCodexProvider();
+		const request = codexStreamRequest("api-error-session");
+		const failed = await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+		assert.match(JSON.stringify(failed), /bad request/);
+		await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+
+		const protocolRequest = codexStreamRequest("protocol-error-session");
+		const malformed = await collectStream(registered.provider.streamSimple(protocolRequest.model, protocolRequest.context, protocolRequest.options));
+		assert.match(JSON.stringify(malformed), /Invalid Codex WebSocket JSON/);
+		await collectStream(registered.provider.streamSimple(protocolRequest.model, protocolRequest.context, protocolRequest.options));
+		assert.equal(ScriptedWebSocket.opened, 4);
+		assert.equal(fetchCalls, 0);
+	} finally {
+		globalThis.fetch = originalFetch;
+		restoreWebSocket();
+	}
 });

--- a/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/openai-codex-custom-provider.test.ts
@@ -124,6 +124,8 @@ class ScriptedWebSocket {
 	readonly listeners = new Map<string, Set<(event: unknown) => void>>();
 	readonly script: WebSocketScript;
 	readyState = 0;
+	private sent = false;
+	private scriptStarted = false;
 
 	constructor() {
 		const script = ScriptedWebSocket.scripts.shift();
@@ -140,6 +142,7 @@ class ScriptedWebSocket {
 		const listeners = this.listeners.get(type) ?? new Set();
 		listeners.add(listener);
 		this.listeners.set(type, listeners);
+		this.startScriptWhenReady();
 	}
 
 	removeEventListener(type: string, listener: (event: unknown) => void): void {
@@ -147,6 +150,13 @@ class ScriptedWebSocket {
 	}
 
 	send(): void {
+		this.sent = true;
+		this.startScriptWhenReady();
+	}
+
+	private startScriptWhenReady(): void {
+		if (!this.sent || this.scriptStarted || !["message", "error", "close"].every((type) => (this.listeners.get(type)?.size ?? 0) > 0)) return;
+		this.scriptStarted = true;
 		this.script(this);
 	}
 
@@ -163,10 +173,10 @@ class ScriptedWebSocket {
 	}
 }
 
-const websocketSuccess: WebSocketScript = (socket) => setImmediate(() => {
+const websocketSuccess: WebSocketScript = (socket) => {
 	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
 	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
-});
+};
 
 function installScriptedWebSocket(scripts: WebSocketScript[]): () => void {
 	const original = globalThis.WebSocket;
@@ -428,10 +438,10 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 
 test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setImmediate(() => {
+		(socket) => {
 			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
 			socket.emit("error", { error: new Error("socket reset by peer") });
-		}),
+		},
 		websocketSuccess,
 		websocketSuccess,
 	]);
@@ -467,9 +477,9 @@ test("a post-start WebSocket failure makes SSE sticky only for that session unti
 
 test("Codex API and protocol errors do not arm SSE fallback", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setImmediate(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" })),
+		(socket) => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }),
 		websocketSuccess,
-		(socket) => setImmediate(() => socket.emit("message", { data: "not-json" })),
+		(socket) => socket.emit("message", { data: "not-json" }),
 		websocketSuccess,
 	]);
 	const originalFetch = globalThis.fetch;

--- a/packages/pi-codex-conversion-lite/tests/remote-v2-compaction.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/remote-v2-compaction.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Model } from "@earendil-works/pi-ai";
 import { executeRemoteCompactionV2 } from "../src/adapter/compaction/remote-v2-client.ts";
 import { buildRemoteCompactionV2Window, normalizeRemoteCompactionV2PromptInput } from "../src/adapter/compaction/remote-v2-history.ts";
+import { closeOpenAICodexWebSocketSessions, recordWebSocketSseFallback } from "../src/providers/openai-codex/websocket.ts";
 
 const model = {
 	id: "gpt-5.6-luna",
@@ -18,8 +19,10 @@ const model = {
 test("Responses compaction v2 uses the registered stream and installs one canonical checkpoint", async () => {
 	let request: Record<string, unknown> | undefined;
 	let headers: Record<string, string | null> | undefined;
+	let transport: string | undefined;
 	const streamSimple = (_model: unknown, _context: unknown, options: any) => (async function* () {
 		headers = options.headers;
+		transport = options.transport;
 		request = await options.onPayload({
 			model: model.id,
 			store: false,
@@ -41,6 +44,7 @@ test("Responses compaction v2 uses the registered stream and installs one canoni
 			},
 		};
 	})();
+	recordWebSocketSseFallback("session");
 	const result = await executeRemoteCompactionV2({
 		runtime: {
 			provider: model.provider,
@@ -59,12 +63,13 @@ test("Responses compaction v2 uses the registered stream and installs one canoni
 		promptInput: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
 		requestOptions: { reasoning: { effort: "high", summary: "auto" } },
 		sessionId: "session",
-		transport: "sse",
 		retryDelayMs: 0,
 	});
+	closeOpenAICodexWebSocketSessions("session");
 
 	assert.equal(result.ok, true);
 	assert.equal(headers?.["x-codex-beta-features"], "other,remote_compaction_v2");
+	assert.equal(transport, "sse");
 	assert.equal((request?.["input"] as Array<{ type?: string }>).at(-1)?.type, "compaction_trigger");
 	assert.deepEqual(result.ok && result.compaction, { type: "compaction", id: "cmp", encrypted_content: "sealed" });
 	assert.deepEqual(result.ok && result.usage, { inputTokens: 1_020, cachedInputTokens: 900, cacheWriteInputTokens: 20, outputTokens: 30 });

--- a/packages/pi-codex-conversion-lite/tests/tool-result-contracts.test.ts
+++ b/packages/pi-codex-conversion-lite/tests/tool-result-contracts.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerApplyPatchResultEvent } from "../src/tools/apply-patch/tool.ts";
+import { parseViewImageParams } from "../src/tools/view-image/tool.ts";
+
+test("apply_patch partial mutations remain error results", () => {
+	let handler: ((event: { toolName: string; details: unknown }) => unknown) | undefined;
+	registerApplyPatchResultEvent({
+		on(event: string, registered: (...args: never[]) => unknown) {
+			if (event === "tool_result") handler = registered as typeof handler;
+		},
+	} as never);
+
+	assert.deepEqual(handler?.({
+		toolName: "apply_patch",
+		details: { status: "partial_failure", result: {} },
+	}), { isError: true });
+	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result: {} } }), undefined);
+});
+
+test("view_image accepts model-style path references", () => {
+	assert.deepEqual(parseViewImageParams({ path: "@assets/example.png" }), { path: "assets/example.png" });
+	assert.deepEqual(parseViewImageParams({ path: "assets/example.png" }), { path: "assets/example.png" });
+});

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
@@ -7,6 +7,7 @@ import { canonicalCompactionOutput, normalizeRemoteCompactionV2PromptInput } fro
 import { withRemoteCompactionV2Feature } from "../../providers/openai-responses/compaction-v2-feature.ts";
 import type { OpenAICodexStreamOptions, ResponsesBody } from "../../providers/openai-codex/types.ts";
 import { sleep } from "../../providers/openai-codex/sse.ts";
+import { isWebSocketSseFallbackActive } from "../../providers/openai-codex/websocket.ts";
 
 const MAX_STREAM_RETRIES = 2;
 type V2Stream = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AsyncIterable<unknown>;
@@ -132,7 +133,9 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 export async function executeRemoteCompactionV2(options: ExecuteRemoteCompactionV2Options): Promise<RemoteCompactionV2Result> {
 	const streamSimple = resolveStream(options);
 	if (!streamSimple) return { ok: false, reason: "unavailable", errorMessage: "No compatible Responses stream is registered for this provider" };
-	const initialTransport = options.transport ?? (options.runtime.provider === "openai-codex" ? "websocket-cached" : "sse");
+	const initialTransport = options.runtime.provider === "openai-codex" && isWebSocketSseFallbackActive(options.sessionId)
+		? "sse"
+		: options.transport ?? (options.runtime.provider === "openai-codex" ? "websocket-cached" : "sse");
 	const transports: Transport[] = options.runtime.provider === "openai-codex" && initialTransport !== "sse"
 		? [initialTransport, "sse"]
 		: [initialTransport];

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -169,25 +169,28 @@ export function registerCodexEvents(
 		state.cwd = ctx.cwd;
 		return handleCodexSessionBeforeCompact(event, ctx, state, pi);
 	});
-	pi.on("session_compact", async (event) => {
+	pi.on("session_compact", async (event, ctx) => {
 		runtime.voice.resetContextAnnouncements();
 		state.pendingPiCompactionNativeWindow = undefined;
-		if (!event.fromExtension || !isNativeCompactionDetails(event.compactionEntry.details)) return;
-		const details = event.compactionEntry.details;
-		pi.sendMessage({
-			customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
-			content: NATIVE_COMPACTION_DISPLAY_TEXT,
-			display: true,
-			details: { compactionEntryId: event.compactionEntry.id },
-		}, { triggerTurn: false });
-		if (details.strategy === NATIVE_COMPACTION_V2_STRATEGY && details.usage) {
+		if (event.fromExtension && isNativeCompactionDetails(event.compactionEntry.details)) {
+			const details = event.compactionEntry.details;
 			pi.sendMessage({
 				customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
-				content: formatCompactionUsage(details.usage),
+				content: NATIVE_COMPACTION_DISPLAY_TEXT,
 				display: true,
-				details: { compactionEntryId: event.compactionEntry.id, kind: "usage" },
+				details: { compactionEntryId: event.compactionEntry.id },
 			}, { triggerTurn: false });
+			if (details.strategy === NATIVE_COMPACTION_V2_STRATEGY && details.usage) {
+				pi.sendMessage({
+					customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
+					content: formatCompactionUsage(details.usage),
+					display: true,
+					details: { compactionEntryId: event.compactionEntry.id, kind: "usage" },
+				}, { triggerTurn: false });
+			}
 		}
+		runtime.resetTransport(ctx.sessionManager.getSessionId());
+		await runtime.startPrewarm(ctx);
 	});
 	pi.on("context", async (event) => {
 		if (state.config.voiceFeaturesOnly) return undefined;

--- a/packages/pi-codex-conversion/src/extension/tools.ts
+++ b/packages/pi-codex-conversion/src/extension/tools.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import { WEB_SEARCH_TOOL_NAME } from "../adapter/activation/tool-set.ts";
-import { registerApplyPatchTool } from "../tools/apply-patch/tool.ts";
+import { registerApplyPatchResultEvent, registerApplyPatchTool } from "../tools/apply-patch/tool.ts";
 import { registerExecCommandTool } from "../tools/exec/command-tool.ts";
 import { registerWriteStdinTool } from "../tools/exec/write-stdin-tool.ts";
 import { registerImageGenerationTool } from "../tools/imagegen/tool.ts";
@@ -21,6 +21,7 @@ export function isExplicitlyConfiguredToolProvider(model: Model<Api> | undefined
 }
 
 export function registerCodexTools(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexToolRegistration {
+	registerApplyPatchResultEvent(pi);
 	const renderOptions = (config: CodexConversionConfig) => ({ customRendering: config.ui.toolRenaming });
 	const promptOptions = (config: CodexConversionConfig) => ({ promptSnippet: config.mode === "path" });
 	const registerApplyPatch = (config: CodexConversionConfig) =>

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -20,8 +20,8 @@ import { combineAbortSignals, compressRequestBodyZstd, createSSEHeaderTimeout, p
 import type { CodexProviderStreamOptions, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { createInitialAssistantMessage } from "./openai-codex/types.ts";
 import { finalizeUsage } from "./openai-codex/usage.ts";
-import { validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
-import { processCodexResponsesStream } from "./openai-codex/stream-events.ts";
+import { isWebSocketSseFallbackActive, recordWebSocketSseFallback, validateWebSocketTimeoutOptions } from "./openai-codex/websocket.ts";
+import { isCodexNonTransportError, isWebSocketConnectionLimitReachedError, processCodexResponsesStream } from "./openai-codex/stream-events.ts";
 import { prewarmWebSocket, processWebSocketStream } from "./openai-codex/websocket-stream.ts";
 import { openaiCodexNativeOAuthProvider } from "./openai-codex/oauth.ts";
 import { CODEX_TURN_STATE_HEADER, type CodexTurnState } from "./openai-codex/turn-state.ts";
@@ -36,11 +36,13 @@ export type { CachedWebSocketContinuationState, CachedWebSocketRequestBodyResult
 export function getEffectiveCodexTransport(
 	transport: Transport | undefined,
 	config: Pick<CodexConversionConfig["openai"], "forceCachedWebSockets"> | undefined,
+	sessionId?: string | undefined,
 ): Transport {
 	const configuredTransport = transport ?? "auto";
-	if (config?.forceCachedWebSockets === false) return configuredTransport;
-	if (configuredTransport === "websocket") return "websocket-cached";
-	return configuredTransport;
+	const preferredTransport = config?.forceCachedWebSockets !== false && configuredTransport === "websocket"
+		? "websocket-cached"
+		: configuredTransport;
+	return preferredTransport !== "sse" && isWebSocketSseFallbackActive(sessionId) ? "sse" : preferredTransport;
 }
 
 async function prepareCodexRequestBody<TApi extends Api>(
@@ -73,7 +75,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	},
 ): Promise<void> {
 	const runtimeConfig = deps.getConfig?.();
-	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai) === "sse") return;
+	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai, options.sessionId) === "sse") return;
 	if (!options.apiKey || !options.sessionId) return;
 	const responsesLite = deps.useResponsesLite?.(model) ?? (runtimeConfig?.beta.codeMode === true && supportsResponsesLiteModel(model.id));
 	const body = await prepareCodexRequestBody(model, context, options, responsesLite);
@@ -87,7 +89,14 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 			client_metadata: { ...(websocketBody.client_metadata ?? {}), [CODEX_TURN_STATE_HEADER]: currentTurnState },
 		};
 	}
-	await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, options, deps.turnState);
+	try {
+		await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, options, deps.turnState);
+	} catch (error) {
+		if (!options.signal?.aborted && (!isCodexNonTransportError(error) || isWebSocketConnectionLimitReachedError(error))) {
+			recordWebSocketSseFallback(options.sessionId);
+		}
+		throw error;
+	}
 }
 
 function createCodexStream<TApi extends Api>(
@@ -102,7 +111,8 @@ function createCodexStream<TApi extends Api>(
 	},
 ): AssistantMessageEventStream {
 	const runtimeConfig = deps.getConfig?.();
-	const effectiveTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai);
+	const preferredTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai);
+	const effectiveTransport = getEffectiveCodexTransport(options?.transport, runtimeConfig?.openai, options?.sessionId);
 	const effectiveOptions: OpenAICodexStreamOptions | undefined = options
 		? { ...options, transport: effectiveTransport }
 		: { transport: effectiveTransport };
@@ -162,19 +172,21 @@ function createCodexStream<TApi extends Api>(
 					stream.end();
 					return;
 				} catch (error) {
+					const aborted = effectiveOptions?.signal?.aborted === true;
+					const connectionLimitBeforeStart = !websocketStarted && isWebSocketConnectionLimitReachedError(error);
+					if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) throw error;
 					appendAssistantMessageDiagnostic(
 						output,
 						createAssistantMessageDiagnostic("provider_transport_failure", error, {
-							configuredTransport: transport,
+							configuredTransport: preferredTransport,
 							fallbackTransport: websocketStarted ? undefined : "sse",
 							eventsEmitted: websocketStarted,
 							phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
 							requestBytes: new TextEncoder().encode(bodyJson).byteLength,
 						}),
 					);
-					if (transport === "websocket" || transport === "websocket-cached" || websocketStarted) {
-						throw error;
-					}
+					recordWebSocketSseFallback(effectiveOptions?.sessionId);
+					if (websocketStarted) throw error;
 				}
 			}
 

--- a/packages/pi-codex-conversion/src/providers/openai-codex/stream-events.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/stream-events.ts
@@ -19,6 +19,17 @@ export class CodexApiError extends Error {
 	}
 }
 
+export class CodexProtocolError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "CodexProtocolError";
+	}
+}
+
+export function isCodexNonTransportError(error: unknown): boolean {
+	return error instanceof CodexApiError || error instanceof CodexProtocolError;
+}
+
 export function isWebSocketConnectionLimitReachedError(error: unknown): boolean {
 	return error instanceof CodexApiError && error.code === WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE;
 }

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-connection.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-connection.ts
@@ -106,16 +106,40 @@ export function closeWebSocketSilently(socket: WebSocketLike, code = 1000, reaso
 	}
 }
 
-
+function nestedWebSocketError(error: Error): Error {
+	const wrapped = new Error(`WebSocket error: ${error.message}`, { cause: error }) as Error & { code?: string | number | undefined };
+	wrapped.name = "WebSocketError";
+	const code = (error as Error & { code?: unknown }).code;
+	if (typeof code === "string" || typeof code === "number") wrapped.code = code;
+	return wrapped;
+}
 
 export function extractWebSocketError(event: unknown): Error {
-	if (event && typeof event === "object" && "message" in event) {
-		const message = (event as { message?: unknown | undefined }).message;
+	if (event && typeof event === "object") {
+		const message = "message" in event ? (event as { message?: unknown | undefined }).message : undefined;
 		if (typeof message === "string" && message.length > 0) {
 			return new Error(message);
 		}
+		const nestedError = "error" in event ? (event as { error?: unknown | undefined }).error : undefined;
+		if (nestedError instanceof Error && nestedError.message.length > 0) return nestedWebSocketError(nestedError);
+		if (nestedError && typeof nestedError === "object" && "message" in nestedError) {
+			const nestedMessage = (nestedError as { message?: unknown | undefined }).message;
+			if (typeof nestedMessage === "string" && nestedMessage.length > 0) return nestedWebSocketError(new Error(nestedMessage));
+		}
 	}
 	return new Error("WebSocket error");
+}
+
+export class WebSocketCloseError extends Error {
+	readonly code?: number | undefined;
+	readonly reason?: string | undefined;
+
+	constructor(message: string, options?: { code?: number | undefined; reason?: string | undefined }) {
+		super(message);
+		this.name = "WebSocketCloseError";
+		this.code = options?.code;
+		this.reason = options?.reason;
+	}
 }
 
 export function extractWebSocketCloseError(event: unknown): Error {
@@ -127,7 +151,10 @@ export function extractWebSocketCloseError(event: unknown): Error {
 		if (!reasonText && code === WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE) {
 			reasonText = " message too big";
 		}
-		return new Error(`WebSocket closed${codeText}${reasonText}`.trim());
+		return new WebSocketCloseError(`WebSocket closed${codeText}${reasonText}`.trim(), {
+			code: typeof code === "number" ? code : undefined,
+			reason: typeof reason === "string" && reason.length > 0 ? reason : undefined,
+		});
 	}
 	return new Error("WebSocket closed");
 }

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-parser.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-parser.ts
@@ -1,6 +1,7 @@
 import type { StreamEventShape, WebSocketLike } from "./types.ts";
 import { extractWebSocketCloseError, extractWebSocketError } from "./websocket-connection.ts";
 import { extractCodexTurnStateFromWebSocketEvent } from "./turn-state.ts";
+import { CodexProtocolError } from "./stream-events.ts";
 
 async function decodeWebSocketData(data: unknown): Promise<string | null> {
 	if (typeof data === "string") return data;
@@ -54,7 +55,7 @@ export async function* parseWebSocket(socket: WebSocketLike, signal: AbortSignal
 					}
 					queue.push(parsed);
 				} catch (error) {
-					failed = new Error(`Invalid Codex WebSocket JSON: ${error instanceof Error ? error.message : String(error)}`);
+					failed = new CodexProtocolError(`Invalid Codex WebSocket JSON: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
 					done = true;
 				}
 			})
@@ -163,5 +164,5 @@ export async function* startWebSocketOutputOnFirstEvent(
 export function isRetryableEarlyWebSocketError(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : String(error);
 	if (/message too big/i.test(message)) return false;
-	return /^(?:WebSocket (?:error|closed|connect timeout)(?:\s|$)|Invalid Codex WebSocket JSON)/.test(message);
+	return /^WebSocket (?:error|closed|connect timeout)(?:\s|$)/.test(message);
 }

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
@@ -2,7 +2,16 @@ import type { AcquiredWebSocket, ProviderEnv, SessionWebSocketCacheEntry } from 
 import { closeWebSocketSilently, connectWebSocket, isWebSocketReusable } from "./websocket-connection.ts";
 
 const websocketSessionCache = new Map<string, SessionWebSocketCacheEntry>();
+const websocketSseFallbackSessions = new Set<string>();
 const SESSION_WEBSOCKET_MAX_AGE_MS = 55 * 60 * 1000;
+
+export function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
+	return sessionId ? websocketSseFallbackSessions.has(sessionId) : false;
+}
+
+export function recordWebSocketSseFallback(sessionId: string | undefined): void {
+	if (sessionId) websocketSseFallbackSessions.add(sessionId);
+}
 
 function isWebSocketSessionExpired(entry: SessionWebSocketCacheEntry): boolean {
 	return Date.now() - entry.createdAt >= SESSION_WEBSOCKET_MAX_AGE_MS;
@@ -33,6 +42,7 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		const entry = websocketSessionCache.get(sessionId);
 		if (entry) closeEntry(entry);
 		websocketSessionCache.delete(sessionId);
+		websocketSseFallbackSessions.delete(sessionId);
 		return;
 	}
 
@@ -40,6 +50,7 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		closeEntry(entry);
 	}
 	websocketSessionCache.clear();
+	websocketSseFallbackSessions.clear();
 }
 
 export async function acquireWebSocket(

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket.ts
@@ -1,7 +1,7 @@
 import type { OpenAICodexStreamOptions } from "./types.ts";
 import { normalizeTimeoutMs } from "./sse.ts";
 
-export { closeOpenAICodexWebSocketSessions, acquireWebSocket } from "./websocket-session-cache.ts";
+export { closeOpenAICodexWebSocketSessions, acquireWebSocket, isWebSocketSseFallbackActive, recordWebSocketSseFallback } from "./websocket-session-cache.ts";
 export { countWebSocketEvents, isRetryableEarlyWebSocketError, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket-parser.ts";
 
 export function validateWebSocketTimeoutOptions(options: OpenAICodexStreamOptions | undefined): void {

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -1,6 +1,8 @@
 import { Type } from "typebox";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Container, Text } from "@earendil-works/pi-tui";
+import { parsePatchActions } from "../../patch/parser.ts";
+import { resolvePatchPath } from "../../patch/paths.ts";
 import { ExecutePatchError, type ExecutePatchResult } from "../../patch/types.ts";
 import { formatPatchTarget } from "./rendering.ts";
 import { executePatchWithRust } from "./executor.ts";
@@ -71,6 +73,24 @@ function getAppliedPaths(result: ExecutePatchResult, failedFiles: string[]): str
 	return result.changedFiles.filter((path) => !failedFiles.includes(path));
 }
 
+function touchedPatchPaths(cwd: string, patchText: string): string[] {
+	try {
+		const paths = parsePatchActions({ text: patchText }).flatMap((action) => [action.path, action.movePath]);
+		return [...new Set(paths.filter((path): path is string => !!path).map((patchPath) => resolvePatchPath({ cwd, patchPath })))].sort();
+	} catch {
+		// The Rust helper remains authoritative for malformed patch errors.
+		return [];
+	}
+}
+
+async function withTouchedFileMutationQueues<T>(cwd: string, patchText: string, fn: () => Promise<T>): Promise<T> {
+	const paths = touchedPatchPaths(cwd, patchText);
+	const run = (index: number): Promise<T> => index >= paths.length
+		? fn()
+		: withFileMutationQueue(paths[index]!, () => run(index + 1));
+	return run(0);
+}
+
 function buildPartialFailureMessage(message: string, failedFiles: string[], appliedFiles: string[]): string {
 	const lines = [message];
 	if (failedFiles.length > 0) {
@@ -110,6 +130,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 		description: "Patch files",
 		...(options.promptSnippet === false ? {} : { promptSnippet: "Edit files with patch" }),
 		parameters: APPLY_PATCH_PARAMETERS,
+		executionMode: "sequential",
 		prepareArguments: prepareApplyPatchArguments,
 		async execute(toolCallId, params, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("apply_patch aborted");
@@ -118,7 +139,9 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 			setApplyPatchRenderState(toolCallId, typedParams.patchText, ctx.cwd);
 			let result: ExecutePatchResult;
 			try {
-				result = await executePatchWithRust({ cwd: ctx.cwd, patchText: typedParams.patchText, signal, customRustBinariesDir: options.customRustBinariesDir });
+				result = await withTouchedFileMutationQueues(ctx.cwd, typedParams.patchText, () =>
+					executePatchWithRust({ cwd: ctx.cwd, patchText: typedParams.patchText, signal, customRustBinariesDir: options.customRustBinariesDir }),
+				);
 			} catch (error) {
 				if (error instanceof ExecutePatchError) {
 					const partial = error.hasPartialSuccess();
@@ -174,4 +197,13 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 
 export function registerApplyPatchTool(pi: ExtensionAPI, options: ApplyPatchToolOptions = {}): void {
 	pi.registerTool(createApplyPatchTool(options));
+}
+
+export function registerApplyPatchResultEvent(pi: ExtensionAPI): void {
+	pi.on("tool_result", (event) => {
+		if (event.toolName === "apply_patch" && isApplyPatchToolDetails(event.details) && event.details.status === "partial_failure") {
+			return { isError: true };
+		}
+		return undefined;
+	});
 }

--- a/packages/pi-codex-conversion/src/tools/view-image/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/view-image/tool.ts
@@ -48,7 +48,7 @@ export function parseViewImageParams(params: unknown): ViewImageParams {
 			throw new Error(`view_image.detail only supports \`original\`, got \`${rawDetail}\``);
 		}
 	}
-	return { path: params.path };
+	return { path: params.path.startsWith("@") ? params.path.slice(1) : params.path };
 }
 
 function prepareViewImageArguments(args: unknown): Record<string, unknown> {

--- a/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
+++ b/packages/pi-codex-conversion/tests/adapter-tool-activation.test.ts
@@ -13,6 +13,7 @@ function createToolHarness(activeTools: string[]) {
 		setActiveTools: (nextTools: string[]) => {
 			activeTools = nextTools;
 		},
+		on: () => undefined,
 		registerTool: (tool: { name: string }) => registeredTools.add(tool.name),
 		activeTools: () => activeTools,
 		registeredTools: () => registeredTools,

--- a/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
@@ -118,6 +118,8 @@ class ScriptedWebSocket {
 	readonly listeners = new Map<string, Set<(event: unknown) => void>>();
 	readonly script: WebSocketScript;
 	readyState = 0;
+	private sent = false;
+	private scriptStarted = false;
 
 	constructor() {
 		const script = ScriptedWebSocket.scripts.shift();
@@ -134,6 +136,7 @@ class ScriptedWebSocket {
 		const listeners = this.listeners.get(type) ?? new Set();
 		listeners.add(listener);
 		this.listeners.set(type, listeners);
+		this.startScriptWhenReady();
 	}
 
 	removeEventListener(type: string, listener: (event: unknown) => void): void {
@@ -141,6 +144,13 @@ class ScriptedWebSocket {
 	}
 
 	send(): void {
+		this.sent = true;
+		this.startScriptWhenReady();
+	}
+
+	private startScriptWhenReady(): void {
+		if (!this.sent || this.scriptStarted || !["message", "error", "close"].every((type) => (this.listeners.get(type)?.size ?? 0) > 0)) return;
+		this.scriptStarted = true;
 		this.script(this);
 	}
 
@@ -157,10 +167,10 @@ class ScriptedWebSocket {
 	}
 }
 
-const websocketSuccess: WebSocketScript = (socket) => setImmediate(() => {
+const websocketSuccess: WebSocketScript = (socket) => {
 	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
 	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
-});
+};
 
 function installScriptedWebSocket(scripts: WebSocketScript[]): () => void {
 	const original = globalThis.WebSocket;
@@ -392,10 +402,10 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 
 test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setImmediate(() => {
+		(socket) => {
 			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
 			socket.emit("error", { error: new Error("socket reset by peer") });
-		}),
+		},
 		websocketSuccess,
 		websocketSuccess,
 	]);
@@ -431,9 +441,9 @@ test("a post-start WebSocket failure makes SSE sticky only for that session unti
 
 test("Codex API and protocol errors do not arm SSE fallback", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setImmediate(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" })),
+		(socket) => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }),
 		websocketSuccess,
-		(socket) => setImmediate(() => socket.emit("message", { data: "not-json" })),
+		(socket) => socket.emit("message", { data: "not-json" }),
 		websocketSuccess,
 	]);
 	const originalFetch = globalThis.fetch;

--- a/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { zstdDecompressSync } from "node:zlib";
 import {
 	buildRequestBody,
+	closeOpenAICodexWebSocketSessions,
 	parseSSE,
 	registerOpenAICodexCustomProvider,
 } from "../src/providers/openai-codex-custom-provider.ts";
@@ -107,6 +108,82 @@ async function collectStream(stream: AsyncIterable<unknown>): Promise<unknown[]>
 	const events: unknown[] = [];
 	for await (const event of stream) events.push(event);
 	return events;
+}
+
+type WebSocketScript = (socket: ScriptedWebSocket) => void;
+
+class ScriptedWebSocket {
+	static scripts: WebSocketScript[] = [];
+	static opened = 0;
+	readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+	readonly script: WebSocketScript;
+	readyState = 0;
+
+	constructor() {
+		const script = ScriptedWebSocket.scripts.shift();
+		if (!script) throw new Error("No scripted WebSocket behavior");
+		this.script = script;
+		ScriptedWebSocket.opened++;
+		queueMicrotask(() => {
+			this.readyState = 1;
+			this.emit("open", {});
+		});
+	}
+
+	addEventListener(type: string, listener: (event: unknown) => void): void {
+		const listeners = this.listeners.get(type) ?? new Set();
+		listeners.add(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: string, listener: (event: unknown) => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	send(): void {
+		this.script(this);
+	}
+
+	close(): void {
+		this.readyState = 3;
+	}
+
+	emit(type: string, event: unknown): void {
+		for (const listener of this.listeners.get(type) ?? []) listener(event);
+	}
+
+	emitJson(event: unknown): void {
+		this.emit("message", { data: JSON.stringify(event) });
+	}
+}
+
+const websocketSuccess: WebSocketScript = (socket) => setTimeout(() => {
+	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
+	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
+});
+
+function installScriptedWebSocket(scripts: WebSocketScript[]): () => void {
+	const original = globalThis.WebSocket;
+	ScriptedWebSocket.scripts = [...scripts];
+	ScriptedWebSocket.opened = 0;
+	globalThis.WebSocket = ScriptedWebSocket as never;
+	return () => {
+		globalThis.WebSocket = original;
+		ScriptedWebSocket.scripts = [];
+		closeOpenAICodexWebSocketSessions();
+	};
+}
+
+function codexStreamRequest(sessionId: string) {
+	return {
+		model: { ...(codexModel as object), baseUrl: "https://chatgpt.example/backend-api" } as never,
+		context: { systemPrompt: "Instructions", messages: [] } as never,
+		options: {
+			apiKey: fakeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_1" } }),
+			transport: "auto",
+			sessionId,
+		} as never,
+	};
 }
 
 function createRegisteredCodexProvider(options?: { codeMode?: boolean | undefined }) {
@@ -311,4 +388,75 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 	for await (const event of parseSSE(response)) events.push(event);
 
 	assert.deepEqual(events, [{ type: "response.created", response: { id: "resp_1" } }]);
+});
+
+test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		(socket) => setTimeout(() => {
+			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
+			socket.emit("error", { error: new Error("socket reset by peer") });
+		}),
+		websocketSuccess,
+		websocketSuccess,
+	]);
+	const originalFetch = globalThis.fetch;
+	let fetchCalls = 0;
+	globalThis.fetch = (async () => {
+		fetchCalls++;
+		return sseResponse([{ type: "response.completed", response: { id: "resp_sse", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } }]);
+	}) as typeof fetch;
+	try {
+		const registered = createRegisteredCodexProvider();
+		const sessionA = codexStreamRequest("session-a");
+		const failed = await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.match((failed.at(-1) as { error: { errorMessage: string } }).error.errorMessage, /Connection error: WebSocket error: socket reset by peer/);
+		assert.equal(fetchCalls, 0);
+
+		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.equal(fetchCalls, 1);
+		assert.equal(ScriptedWebSocket.opened, 1);
+
+		const sessionB = codexStreamRequest("session-b");
+		await collectStream(registered.provider.streamSimple(sessionB.model, sessionB.context, sessionB.options));
+		assert.equal(ScriptedWebSocket.opened, 2);
+
+		closeOpenAICodexWebSocketSessions("session-a");
+		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
+		assert.equal(ScriptedWebSocket.opened, 3);
+	} finally {
+		globalThis.fetch = originalFetch;
+		restoreWebSocket();
+	}
+});
+
+test("Codex API and protocol errors do not arm SSE fallback", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		(socket) => setTimeout(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }), 0),
+		websocketSuccess,
+		(socket) => setTimeout(() => socket.emit("message", { data: "not-json" }), 0),
+		websocketSuccess,
+	]);
+	const originalFetch = globalThis.fetch;
+	let fetchCalls = 0;
+	globalThis.fetch = (async () => {
+		fetchCalls++;
+		return sseResponse([]);
+	}) as typeof fetch;
+	try {
+		const registered = createRegisteredCodexProvider();
+		const request = codexStreamRequest("api-error-session");
+		const failed = await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+		assert.match(JSON.stringify(failed), /bad request/);
+		await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+
+		const protocolRequest = codexStreamRequest("protocol-error-session");
+		const malformed = await collectStream(registered.provider.streamSimple(protocolRequest.model, protocolRequest.context, protocolRequest.options));
+		assert.match(JSON.stringify(malformed), /Invalid Codex WebSocket JSON/);
+		await collectStream(registered.provider.streamSimple(protocolRequest.model, protocolRequest.context, protocolRequest.options));
+		assert.equal(ScriptedWebSocket.opened, 4);
+		assert.equal(fetchCalls, 0);
+	} finally {
+		globalThis.fetch = originalFetch;
+		restoreWebSocket();
+	}
 });

--- a/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-custom-provider.test.ts
@@ -157,7 +157,7 @@ class ScriptedWebSocket {
 	}
 }
 
-const websocketSuccess: WebSocketScript = (socket) => setTimeout(() => {
+const websocketSuccess: WebSocketScript = (socket) => setImmediate(() => {
 	socket.emitJson({ type: "response.created", response: { id: "resp_ws" } });
 	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
 });
@@ -392,7 +392,7 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 
 test("a post-start WebSocket failure makes SSE sticky only for that session until reset", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setTimeout(() => {
+		(socket) => setImmediate(() => {
 			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
 			socket.emit("error", { error: new Error("socket reset by peer") });
 		}),
@@ -431,9 +431,9 @@ test("a post-start WebSocket failure makes SSE sticky only for that session unti
 
 test("Codex API and protocol errors do not arm SSE fallback", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
-		(socket) => setTimeout(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" }), 0),
+		(socket) => setImmediate(() => socket.emitJson({ type: "error", code: "invalid_request", message: "bad request" })),
 		websocketSuccess,
-		(socket) => setTimeout(() => socket.emit("message", { data: "not-json" }), 0),
+		(socket) => setImmediate(() => socket.emit("message", { data: "not-json" })),
 		websocketSuccess,
 	]);
 	const originalFetch = globalThis.fetch;

--- a/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
+++ b/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Model } from "@earendil-works/pi-ai";
 import { executeRemoteCompactionV2 } from "../src/adapter/compaction/remote-v2-client.ts";
 import { buildRemoteCompactionV2Window, normalizeRemoteCompactionV2PromptInput } from "../src/adapter/compaction/remote-v2-history.ts";
+import { closeOpenAICodexWebSocketSessions, recordWebSocketSseFallback } from "../src/providers/openai-codex/websocket.ts";
 
 const model = {
 	id: "gpt-5.6-luna",
@@ -18,8 +19,10 @@ const model = {
 test("Responses compaction v2 uses the registered stream and installs one canonical checkpoint", async () => {
 	let request: Record<string, unknown> | undefined;
 	let headers: Record<string, string | null> | undefined;
+	let transport: string | undefined;
 	const streamSimple = (_model: unknown, _context: unknown, options: any) => (async function* () {
 		headers = options.headers;
+		transport = options.transport;
 		request = await options.onPayload({
 			model: model.id,
 			store: false,
@@ -41,6 +44,7 @@ test("Responses compaction v2 uses the registered stream and installs one canoni
 			},
 		};
 	})();
+	recordWebSocketSseFallback("session");
 	const result = await executeRemoteCompactionV2({
 		runtime: {
 			provider: model.provider,
@@ -61,12 +65,13 @@ test("Responses compaction v2 uses the registered stream and installs one canoni
 		promptInput: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
 		requestOptions: { reasoning: { effort: "high", summary: "auto" } },
 		sessionId: "session",
-		transport: "sse",
 		retryDelayMs: 0,
 	});
+	closeOpenAICodexWebSocketSessions("session");
 
 	assert.equal(result.ok, true);
 	assert.equal(headers?.["x-codex-beta-features"], "other,remote_compaction_v2");
+	assert.equal(transport, "sse");
 	assert.equal((request?.["input"] as Array<{ type?: string }>).at(-1)?.type, "compaction_trigger");
 	assert.deepEqual(result.ok && result.compaction, { type: "compaction", id: "cmp", encrypted_content: "sealed" });
 	assert.deepEqual(result.ok && result.usage, { inputTokens: 1_020, cachedInputTokens: 900, cacheWriteInputTokens: 20, outputTokens: 30 });

--- a/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
+++ b/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerApplyPatchResultEvent } from "../src/tools/apply-patch/tool.ts";
+import { parseViewImageParams } from "../src/tools/view-image/tool.ts";
+
+test("apply_patch partial mutations remain error results", () => {
+	let handler: ((event: { toolName: string; details: unknown }) => unknown) | undefined;
+	registerApplyPatchResultEvent({
+		on(event: string, registered: (...args: never[]) => unknown) {
+			if (event === "tool_result") handler = registered as typeof handler;
+		},
+	} as never);
+
+	assert.deepEqual(handler?.({
+		toolName: "apply_patch",
+		details: { status: "partial_failure", result: {} },
+	}), { isError: true });
+	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result: {} } }), undefined);
+});
+
+test("view_image accepts model-style path references", () => {
+	assert.deepEqual(parseViewImageParams({ path: "@assets/example.png" }), { path: "assets/example.png" });
+	assert.deepEqual(parseViewImageParams({ path: "assets/example.png" }), { path: "assets/example.png" });
+});


### PR DESCRIPTION
## Summary
- make genuine WebSocket transport failures degrade only the affected Codex session to SSE, without replaying partial output
- keep degraded compaction on SSE, then reset and prewarm a fresh cached WebSocket after successful compaction
- serialize `apply_patch` mutations through Pi's file queues and preserve partial mutations as error results
- accept Codex model-style `@path` arguments in `view_image`
- apply the same behavior to full and Lite packages

## Issue #190
Refs #190.

Adopts the patch-mutation and image-path fixes. It intentionally omits the proposed blanket HTTP status prefix: exposing `HTTP 429` in a terminal usage-limit message makes Pi classify it as retryable and can create a failure loop.

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- 20 concurrent dependent patch chains completed in order
- routing contracts cover transport isolation/reset, error classification, partial patch errors, and model-style image paths
- Tests culled: zero complete cases

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-codex-conversion-lite`
- Aggregates: generated by release automation
