### PR TITLE
Fix Codex compaction cache continuation

### DIFF
--- a/.changeset/patch-ms6boij7-e93787.md
+++ b/.changeset/patch-ms6boij7-e93787.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Preserve Codex WebSocket cache continuations when OpenAI response-item field order and transport-only metadata differ from Pi's persisted replay.
+Preserve Codex WebSocket cache continuations across Pi replay differences, prewarm fresh sockets with native compaction checkpoints, and block automatic full-context replay after a stream has already started.

--- a/.changeset/patch-ms6boij7-e93787.md
+++ b/.changeset/patch-ms6boij7-e93787.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Preserve Codex WebSocket cache continuations when OpenAI response-item field order and transport-only metadata differ from Pi's persisted replay.

--- a/packages/pi-codex-conversion/AGENTS.md
+++ b/packages/pi-codex-conversion/AGENTS.md
@@ -1,5 +1,5 @@
 - Keep Pi behavior as close as practical to the Codex toolkit; document intentional differences.
-- Post-start transport recovery intentionally uses three WebSocket attempts, then SSE on Pi's final retry; a successful recovery reopens the WebSocket cache lane for later turns.
+- Post-start stream failures must not trigger Pi's automatic full-context replay; preserve the raw cause in diagnostics and require an explicit new message.
 - Before npm, publish, release, or merge work, compare `src/providers/openai-codex-custom-provider.ts` with Pi's stock `openai-codex-responses` provider: request shape, transport/headers, reasoning/service tier, retry, stream termination, and touched behavior.
 - Structured mode uses flat TypeScript tools over standard Responses. GPT-5.6 Code Mode uses `exec`/`wait` over Responses Lite.
 - Keep prompt guidance short and argv-shaped.

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -6,26 +6,44 @@ import { isAdapterRuntime, resolveCodexRuntimePlan } from "./activation/runtime-
 import { injectPendingNativeWindowIntoPiCompactionRequest, rewriteCodexCompactedProviderRequest } from "./compaction/compaction.ts";
 import { applyResponsesLiteRequest, type ResponsesLiteCompatibleBody } from "../providers/openai-codex/responses-lite.ts";
 
-export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
+function prepareCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState) {
 	if (state.config.voiceFeaturesOnly) return undefined;
 	const plan = resolveCodexRuntimePlan(ctx, state.config);
 	if (!isAdapterRuntime(plan) || (!plan.effectiveOpenAICodex && !isResponsesContext(ctx))) {
 		return undefined;
 	}
+	return {
+		plan,
+		configuredPayload: applyCodexRequestOptions(payload, state.config, {
+			serviceTier: plan.effectiveOpenAICodex,
+			verbosity: true,
+		}),
+	};
+}
 
-	const configuredPayload = applyCodexRequestOptions(payload, state.config, {
-		serviceTier: plan.effectiveOpenAICodex,
-		verbosity: true,
-	});
+function applyCodexRuntimePayload(payload: unknown, codeMode: boolean): unknown {
+	return codeMode && isCodeModeCompatibleBody(payload) ? applyResponsesLiteRequest(payload) : payload;
+}
+
+export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
+	const prepared = prepareCodexProviderRequest(payload, ctx, state);
+	if (!prepared) return undefined;
+	const { plan, configuredPayload } = prepared;
 	let rewrittenPayload = configuredPayload;
 	if (plan.nativeCompaction || state.pendingPiCompactionNativeWindow) {
 		const piCompactionPayload = await injectPendingNativeWindowIntoPiCompactionRequest(configuredPayload, ctx, state);
 		rewrittenPayload = piCompactionPayload ?? (await rewriteCodexCompactedProviderRequest(configuredPayload, ctx, state)) ?? configuredPayload;
 	}
-	if (plan.kind === "code" && isCodeModeCompatibleBody(rewrittenPayload)) {
-		return applyResponsesLiteRequest(rewrittenPayload);
-	}
-	return rewrittenPayload;
+	return applyCodexRuntimePayload(rewrittenPayload, plan.kind === "code");
+}
+
+export function rewriteCodexPrewarmProviderRequest(
+	payload: unknown,
+	ctx: ExtensionContext,
+	state: AdapterState,
+): unknown | undefined {
+	const prepared = prepareCodexProviderRequest(payload, ctx, state);
+	return prepared ? applyCodexRuntimePayload(prepared.configuredPayload, prepared.plan.kind === "code") : undefined;
 }
 
 function isCodeModeCompatibleBody(value: unknown): value is ResponsesLiteCompatibleBody {

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -177,8 +177,10 @@ export function registerCodexEvents(
 	pi.on("session_compact", async (event, ctx) => {
 		runtime.voice.resetContextAnnouncements();
 		state.pendingPiCompactionNativeWindow = undefined;
+		let nativeCompaction = false;
 		if (event.fromExtension && isNativeCompactionDetails(event.compactionEntry.details)) {
 			const details = event.compactionEntry.details;
+			nativeCompaction = true;
 			pi.sendMessage({
 				customType: NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE,
 				content: NATIVE_COMPACTION_DISPLAY_TEXT,
@@ -195,7 +197,7 @@ export function registerCodexEvents(
 			}
 		}
 		runtime.resetTransport(ctx.sessionManager.getSessionId());
-		await runtime.startPrewarm(ctx);
+		await (nativeCompaction ? runtime.startCompactionPrewarm(ctx) : runtime.startPrewarm(ctx));
 	});
 	pi.on("context", async (event) => {
 		if (state.config.voiceFeaturesOnly) return undefined;

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -1,12 +1,13 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { buildSessionContext, convertToLlm, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Context } from "@earendil-works/pi-ai";
 import { dirname } from "node:path";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import { getCodexConversionConfigPath, readCodexConversionConfig } from "../adapter/activation/config-store.ts";
 import { isAdapterRuntime, resolveCodexRuntimePlan } from "../adapter/activation/runtime-plan.ts";
 import type { AdapterState } from "../adapter/activation/state.ts";
-import { rewriteCodexProviderRequest } from "../adapter/provider-request.ts";
+import { rewriteCodexPrewarmProviderRequest, rewriteCodexProviderRequest } from "../adapter/provider-request.ts";
 import { getDefaultCodexRuntimeShell } from "../adapter/prompt/runtime-shell.ts";
+import { isAdapterContextExcludedCustomMessage } from "../adapter/prompt/context-filter.ts";
 import { buildCodexSystemPrompt, type PiSystemPromptOptions } from "../prompt/build-system-prompt.ts";
 import { closeOpenAICodexWebSocketSessions, prewarmOpenAICodexWebSocket } from "../providers/openai-codex-custom-provider.ts";
 import { createCodexTurnState } from "../providers/openai-codex/turn-state.ts";
@@ -31,6 +32,7 @@ export interface CodexExtensionRuntime {
 	execEnv(config?: CodexConversionConfig): NodeJS.ProcessEnv;
 	codexSystemPrompt(basePrompt: string, ctx: CodexContext, skills?: AdapterState["promptSkills"], systemPromptOptions?: PiSystemPromptOptions): string;
 	startPrewarm(ctx: CodexContext, systemPrompt?: string, prepared?: boolean): Promise<void> | undefined;
+	startCompactionPrewarm(ctx: CodexContext): Promise<void> | undefined;
 	resetTransport(sessionId?: string): void;
 	shutdownTransport(sessionId: string): void;
 	waitForPrewarm(ctx: CodexContext, systemPrompt: string): Promise<void> | undefined;
@@ -73,6 +75,55 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	let prewarmPromise: Promise<void> | undefined;
 	let websocketPrewarmed = false;
 	const voice = new CodexVoiceController(pi);
+	const startPrewarm = (
+		ctx: CodexContext,
+		systemPrompt = ctx.getSystemPrompt(),
+		prepared = false,
+		messages: Context["messages"] = [],
+		rewriteCompactedReplay = false,
+	): Promise<void> | undefined => {
+		const model = ctx.model;
+		if (websocketPrewarmed || !model || model.provider !== "openai-codex" || !isAdapterRuntime(resolveCodexRuntimePlan(ctx, state.config)) || !state.config.openai.forceCachedWebSockets) return undefined;
+		prewarmController?.abort();
+		const controller = new AbortController();
+		prewarmController = controller;
+		const promise = (async () => {
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+			if (!auth.ok || !auth.apiKey || controller.signal.aborted) return;
+			await prewarmOpenAICodexWebSocket(
+				model,
+				{ systemPrompt: prepared ? systemPrompt : runtime.codexSystemPrompt(systemPrompt, ctx), messages, tools: activeToolContext(pi) },
+				{
+					apiKey: auth.apiKey,
+					...(auth.headers ? { headers: auth.headers } : {}),
+					...(auth.env ? { env: auth.env } : {}),
+					sessionId: ctx.sessionManager.getSessionId(),
+					signal: controller.signal,
+					...prewarmReasoningOption(pi.getThinkingLevel()),
+					textVerbosity: state.config.openai.verbosity,
+					...(state.config.openai.fast ? { serviceTier: "priority" as const } : {}),
+					onPayload: (body) => rewriteCompactedReplay
+						? rewriteCodexProviderRequest(body, ctx, state)
+						: rewriteCodexPrewarmProviderRequest(body, ctx, state),
+				},
+				{
+					getConfig: () => ({ openai: state.config.openai, beta: state.config.beta, compaction: state.config.compaction }),
+					useResponsesLite: (currentModel) => resolveCodexRuntimePlan({ model: currentModel }, state.config).kind === "code",
+					turnState: state.codexTurnState,
+				},
+			);
+			if (!controller.signal.aborted) websocketPrewarmed = true;
+		})().catch((error: unknown) => {
+			if (!controller.signal.aborted && process.env["PI_DEBUG"] === "1") {
+				console.warn(`[pi-codex-conversion] WebSocket prewarm failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}).finally(() => {
+			if (prewarmPromise === promise) prewarmPromise = undefined;
+			if (prewarmController === controller) prewarmController = undefined;
+		});
+		prewarmPromise = promise;
+		return promise;
+	};
 
 	const runtime: CodexExtensionRuntime = {
 		state,
@@ -102,46 +153,20 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 				systemPromptOptions,
 			});
 		},
-		startPrewarm(ctx, systemPrompt = ctx.getSystemPrompt(), prepared = false) {
-			const model = ctx.model;
-			if (websocketPrewarmed || !model || model.provider !== "openai-codex" || !isAdapterRuntime(resolveCodexRuntimePlan(ctx, state.config)) || !state.config.openai.forceCachedWebSockets) return undefined;
-			prewarmController?.abort();
-			const controller = new AbortController();
-			prewarmController = controller;
-			const promise = (async () => {
-				const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-				if (!auth.ok || !auth.apiKey || controller.signal.aborted) return;
-					await prewarmOpenAICodexWebSocket(
-						model,
-						{ systemPrompt: prepared ? systemPrompt : runtime.codexSystemPrompt(systemPrompt, ctx), messages: [], tools: activeToolContext(pi) },
-					{
-						apiKey: auth.apiKey,
-						...(auth.headers ? { headers: auth.headers } : {}),
-						...(auth.env ? { env: auth.env } : {}),
-						sessionId: ctx.sessionManager.getSessionId(),
-						signal: controller.signal,
-						...prewarmReasoningOption(pi.getThinkingLevel()),
-						textVerbosity: state.config.openai.verbosity,
-						...(state.config.openai.fast ? { serviceTier: "priority" as const } : {}),
-						onPayload: (body) => rewriteCodexProviderRequest(body, ctx, state),
-					},
-					{
-						getConfig: () => ({ openai: state.config.openai, beta: state.config.beta, compaction: state.config.compaction }),
-						useResponsesLite: (currentModel) => resolveCodexRuntimePlan({ model: currentModel }, state.config).kind === "code",
-						turnState: state.codexTurnState,
-					},
-				);
-				if (!controller.signal.aborted) websocketPrewarmed = true;
-			})().catch((error: unknown) => {
-				if (!controller.signal.aborted && process.env["PI_DEBUG"] === "1") {
-					console.warn(`[pi-codex-conversion] WebSocket prewarm failed: ${error instanceof Error ? error.message : String(error)}`);
-				}
-			}).finally(() => {
-				if (prewarmPromise === promise) prewarmPromise = undefined;
-				if (prewarmController === controller) prewarmController = undefined;
-			});
-			prewarmPromise = promise;
-			return promise;
+		startPrewarm(ctx, systemPrompt, prepared) {
+			return startPrewarm(ctx, systemPrompt, prepared);
+		},
+		startCompactionPrewarm(ctx) {
+			const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
+				.filter((message) => !isAdapterContextExcludedCustomMessage(message));
+			const activeSystemPrompt = state.activeProviderSystemPrompt;
+			return startPrewarm(
+				ctx,
+				activeSystemPrompt ?? ctx.getSystemPrompt(),
+				activeSystemPrompt !== undefined,
+				convertToLlm(messages),
+				true,
+			);
 		},
 		resetTransport(sessionId) {
 			prewarmController?.abort();

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -24,7 +24,6 @@ import { finalizeUsage } from "./openai-codex/usage.ts";
 import {
 	clearWebSocketTransportFailures,
 	isWebSocketSseFallbackActive,
-	recordWebSocketPostStartFailure,
 	recordWebSocketSseFallback,
 	validateWebSocketTimeoutOptions,
 } from "./openai-codex/websocket.ts";
@@ -201,25 +200,26 @@ function createCodexStream<TApi extends Api>(
 				} catch (error) {
 					const aborted = effectiveOptions?.signal?.aborted === true;
 					const connectionLimitBeforeStart = !websocketStarted && isWebSocketConnectionLimitReachedError(error);
+					const nonTransportError = isCodexNonTransportError(error) && !connectionLimitBeforeStart;
 					if (aborted) throw error;
-					if (isCodexNonTransportError(error) && !connectionLimitBeforeStart) {
+					if (nonTransportError && !websocketStarted) {
 						clearWebSocketTransportFailures(effectiveOptions?.sessionId);
 						throw error;
 					}
-					const fallbackArmed = websocketStarted
-						? recordWebSocketPostStartFailure(effectiveOptions?.sessionId)
-						: true;
 					appendAssistantMessageDiagnostic(
 						output,
-						createAssistantMessageDiagnostic("provider_transport_failure", error, {
+						createAssistantMessageDiagnostic(nonTransportError ? "provider_stream_failure" : "provider_transport_failure", error, {
 							configuredTransport: preferredTransport,
-							fallbackTransport: fallbackArmed ? "sse" : undefined,
+							fallbackTransport: websocketStarted ? undefined : "sse",
 							eventsEmitted: websocketStarted,
 							phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
 							requestBytes: new TextEncoder().encode(bodyJson).byteLength,
 						}),
 					);
-					if (websocketStarted) throw error;
+					if (websocketStarted) {
+						if (nonTransportError) clearWebSocketTransportFailures(effectiveOptions?.sessionId);
+						throw new NonRetryableProviderError("Codex stream stopped after output began. Automatic full-context replay was blocked to avoid duplicate output and an unconfirmed cache charge. Submit a new message to continue.");
+					}
 					recordWebSocketSseFallback(effectiveOptions?.sessionId);
 				}
 			}

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-continuation.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-continuation.ts
@@ -20,21 +20,29 @@ export function requestBodyForWebSocketContinuationComparison(body: ResponsesBod
 function responseInputsEqual(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
 	const left = a ?? [];
 	const right = b ?? [];
-	return left.length === right.length && left.every((item, index) => {
-		const candidate = right[index];
-		if (JSON.stringify(item) === JSON.stringify(candidate)) return true;
-		return JSON.stringify(withoutInternalMetadata(item)) === JSON.stringify(withoutInternalMetadata(candidate));
-	});
+	return left.length === right.length && left.every((item, index) => responsesValuesEqual(item, right[index]));
 }
 
-function withoutInternalMetadata(value: unknown): unknown {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-	const { internal_chat_message_metadata_passthrough: _metadata, ...item } = value as Record<string, unknown>;
-	return item;
+function canonicalResponseValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalResponseValue);
+	if (!value || typeof value !== "object") return value;
+	const record = value as Record<string, unknown>;
+	const canonical: Record<string, unknown> = {};
+	for (const key of Object.keys(record).sort()) {
+		if (key === "internal_chat_message_metadata_passthrough") continue;
+		if (key === "logprobs" && record["type"] === "output_text" && Array.isArray(record[key]) && record[key].length === 0) continue;
+		if (key === "status" && record[key] === "completed" && (record["type"] === "function_call" || record["type"] === "custom_tool_call")) continue;
+		canonical[key] = canonicalResponseValue(record[key]);
+	}
+	return canonical;
+}
+
+function responsesValuesEqual(a: unknown, b: unknown): boolean {
+	return JSON.stringify(canonicalResponseValue(a)) === JSON.stringify(canonicalResponseValue(b));
 }
 
 function requestBodiesMatchExceptInput(a: ResponsesBody, b: ResponsesBody): boolean {
-	return JSON.stringify(requestBodyForWebSocketContinuationComparison(a)) === JSON.stringify(requestBodyForWebSocketContinuationComparison(b));
+	return responsesValuesEqual(requestBodyForWebSocketContinuationComparison(a), requestBodyForWebSocketContinuationComparison(b));
 }
 
 function getFunctionCallId(item: unknown): string | undefined {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
@@ -3,11 +3,7 @@ import { closeWebSocketSilently, connectWebSocket, isWebSocketReusable } from ".
 
 const websocketSessionCache = new Map<string, SessionWebSocketCacheEntry>();
 const websocketSseFallbackSessions = new Set<string>();
-const websocketPostStartFailures = new Map<string, number>();
 const SESSION_WEBSOCKET_MAX_AGE_MS = 55 * 60 * 1000;
-// Pi makes one initial attempt plus three automatic retries. Preserve cached
-// WebSockets through the first two retries and reserve the final retry for SSE.
-const POST_START_FAILURES_BEFORE_SSE = 3;
 
 export function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
 	return sessionId ? websocketSseFallbackSessions.has(sessionId) : false;
@@ -17,18 +13,8 @@ export function recordWebSocketSseFallback(sessionId: string | undefined): void 
 	if (sessionId) websocketSseFallbackSessions.add(sessionId);
 }
 
-export function recordWebSocketPostStartFailure(sessionId: string | undefined): boolean {
-	if (!sessionId) return false;
-	const failures = (websocketPostStartFailures.get(sessionId) ?? 0) + 1;
-	websocketPostStartFailures.set(sessionId, failures);
-	if (failures < POST_START_FAILURES_BEFORE_SSE) return false;
-	websocketSseFallbackSessions.add(sessionId);
-	return true;
-}
-
 export function clearWebSocketTransportFailures(sessionId: string | undefined): void {
 	if (!sessionId) return;
-	websocketPostStartFailures.delete(sessionId);
 	websocketSseFallbackSessions.delete(sessionId);
 }
 
@@ -62,7 +48,6 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		if (entry) closeEntry(entry);
 		websocketSessionCache.delete(sessionId);
 		websocketSseFallbackSessions.delete(sessionId);
-		websocketPostStartFailures.delete(sessionId);
 		return;
 	}
 
@@ -71,7 +56,6 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 	}
 	websocketSessionCache.clear();
 	websocketSseFallbackSessions.clear();
-	websocketPostStartFailures.clear();
 }
 
 export async function acquireWebSocket(

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -89,9 +89,10 @@ export async function processWebSocketStream<TApi extends Api>(
 			releaseOnce({ keep: false });
 			// A missing continuation retries once with full context. Other transport
 			// failures retry only before output starts, preserving safe SSE fallback.
-			if (attempt === 0 && !options?.signal?.aborted && (
+			if (attempt === 0 && !options?.signal?.aborted && !streamStarted && (
 				isPreviousResponseNotFoundError(error)
-				|| (!streamStarted && (isWebSocketConnectionLimitReachedError(error) || (eventCount === 0 && isRetryableEarlyWebSocketError(error))))
+				|| isWebSocketConnectionLimitReachedError(error)
+				|| (eventCount === 0 && isRetryableEarlyWebSocketError(error))
 			)) {
 				continue;
 			}

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket.ts
@@ -6,7 +6,6 @@ export {
 	clearWebSocketTransportFailures,
 	closeOpenAICodexWebSocketSessions,
 	isWebSocketSseFallbackActive,
-	recordWebSocketPostStartFailure,
 	recordWebSocketSseFallback,
 } from "./websocket-session-cache.ts";
 export { countWebSocketEvents, isRetryableEarlyWebSocketError, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket-parser.ts";

--- a/packages/pi-codex-conversion/tests/cache-continuity.test.ts
+++ b/packages/pi-codex-conversion/tests/cache-continuity.test.ts
@@ -1,0 +1,514 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { isRetryableAssistantError, type AssistantMessage, type Context, type Model } from "@earendil-works/pi-ai";
+import { buildSessionContext, convertToLlm, type SessionEntry } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import { rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import { executeRemoteCompactionV2 } from "../src/adapter/compaction/remote-v2-client.ts";
+import { serializeMessagesToResponsesInput } from "../src/adapter/compaction/serializer.ts";
+import { NATIVE_COMPACTION_SHIM_SUMMARY, NATIVE_COMPACTION_STRATEGY } from "../src/adapter/compaction/types.ts";
+import { CODE_MODE_EXEC_GRAMMAR_INPUTS } from "../src/tools/code-mode/exec-contract.ts";
+import { closeOpenAICodexWebSocketSessions } from "../src/providers/openai-codex-custom-provider.ts";
+import { createCodexExtensionRuntime } from "../src/extension/runtime.ts";
+import {
+	ScriptedWebSocket,
+	codeModeTools,
+	codexModel,
+	collectStream,
+	createRegisteredCodexProvider,
+	fakeJwt,
+	installScriptedWebSocket,
+	websocketSuccess,
+} from "./openai-codex-test-support.ts";
+
+type ResponseCreateFrame = {
+	type: "response.create";
+	input?: unknown[] | undefined;
+	previous_response_id?: string | undefined;
+};
+
+const model = {
+	...(codexModel as object),
+	id: "gpt-5.6-luna",
+	baseUrl: "https://chatgpt.example/backend-api",
+} as Model<any>;
+
+const apiKey = fakeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_1" } });
+
+function user(text: string, timestamp: number): AgentMessage {
+	return { role: "user", content: text, timestamp } as AgentMessage;
+}
+
+function textResponse(responseId: string, text: string) {
+	return (socket: ScriptedWebSocket) => {
+		const item = {
+			id: `msg_${responseId}`,
+			type: "message",
+			status: "completed",
+			content: [{ type: "output_text", annotations: [], logprobs: [], text }],
+			phase: "final_answer",
+			role: "assistant",
+			internal_chat_message_metadata_passthrough: { turn_id: `turn_${responseId}` },
+		};
+		socket.emitJson({ type: "response.created", response: { id: responseId } });
+		socket.emitJson({ type: "response.output_item.done", output_index: 0, item });
+		socket.emitJson({
+			type: "response.completed",
+			response: { id: responseId, status: "completed", usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 } },
+		});
+	};
+}
+
+function customToolResponse(responseId: string) {
+	return (socket: ScriptedWebSocket) => {
+		const item = {
+			id: `ctc_${responseId}`,
+			type: "custom_tool_call",
+			status: "completed",
+			call_id: `call_${responseId}`,
+			input: 'text("tool result")',
+			name: "exec",
+			internal_chat_message_metadata_passthrough: { turn_id: `turn_${responseId}` },
+		};
+		socket.emitJson({ type: "response.created", response: { id: responseId } });
+		socket.emitJson({ type: "response.output_item.done", output_index: 0, item });
+		socket.emitJson({
+			type: "response.completed",
+			response: { id: responseId, status: "completed", usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 } },
+		});
+	};
+}
+
+function compactionResponse(responseId: string) {
+	return (socket: ScriptedWebSocket) => {
+		socket.emitJson({ type: "response.created", response: { id: responseId } });
+		socket.emitJson({
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				id: `cmp_${responseId}`,
+				type: "compaction",
+				encrypted_content: "sealed",
+				internal_chat_message_metadata_passthrough: { turn_id: `turn_${responseId}` },
+			},
+		});
+		socket.emitJson({
+			type: "response.completed",
+			response: { id: responseId, status: "completed", usage: { input_tokens: 100, output_tokens: 2, total_tokens: 102 } },
+		});
+	};
+}
+
+function failAfterStart(socket: ScriptedWebSocket) {
+	socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
+	socket.emit("error", { error: new Error("socket reset by peer") });
+}
+
+function apiFailAfterStart(socket: ScriptedWebSocket) {
+	socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
+	socket.emitJson({ type: "error", code: "server_error", message: "internal server error" });
+}
+
+function missingContinuationAfterStart(socket: ScriptedWebSocket) {
+	socket.emitJson({ type: "response.created", response: { id: "resp_missing" } });
+	socket.emitJson({ type: "error", code: "previous_response_not_found", message: "previous response not found" });
+}
+
+function missingContinuationBeforeStart(socket: ScriptedWebSocket) {
+	socket.emitJson({ type: "error", code: "previous_response_not_found", message: "previous response not found" });
+}
+
+function streamOptions(sessionId: string) {
+	return {
+		apiKey,
+		transport: "websocket-cached" as const,
+		sessionId,
+		reasoning: "low" as const,
+		textVerbosity: "low",
+	};
+}
+
+function context(messages: AgentMessage[], systemPrompt = "Stable instructions", tools = codeModeTools): Context {
+	return { systemPrompt, messages: messages as Context["messages"], tools };
+}
+
+function doneMessage(events: unknown[]): AssistantMessage {
+	const done = events.find((event) => (event as { type?: string }).type === "done") as { message?: AssistantMessage } | undefined;
+	assert.ok(done?.message, "provider stream must finish with an assistant message");
+	return done.message;
+}
+
+function sentFrames(): ResponseCreateFrame[] {
+	return ScriptedWebSocket.sentFrames as ResponseCreateFrame[];
+}
+
+test("Code Mode normal turns and V2 compaction share one exact WebSocket continuation", async () => {
+	const restoreWebSocket = installScriptedWebSocket([[
+		customToolResponse("resp_tool"),
+		textResponse("resp_1", "first"),
+		textResponse("resp_2", "second"),
+		compactionResponse("resp_compact"),
+	]]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const sessionId = "shared-continuation";
+		const firstUser = user("first user", 1);
+		const toolCallAssistant = doneMessage(await collectStream(
+				registered.provider.streamSimple(model as never, context([firstUser]) as never, streamOptions(sessionId) as never),
+		));
+		const toolCall = toolCallAssistant.content.find((item) => item.type === "toolCall");
+		assert.equal(toolCall?.type, "toolCall");
+		const toolResult = {
+			role: "toolResult",
+			toolCallId: toolCall!.id,
+			toolName: "exec",
+			content: [{ type: "text", text: "tool result" }],
+			isError: false,
+			timestamp: 2,
+		} as AgentMessage;
+		const firstMessages = [firstUser, toolCallAssistant as AgentMessage, toolResult];
+		const firstAssistant = doneMessage(await collectStream(
+				registered.provider.streamSimple(model as never, context(firstMessages) as never, streamOptions(sessionId) as never),
+		));
+		const secondUser = user("second user", 2);
+		const messages = [...firstMessages, firstAssistant as AgentMessage, secondUser];
+		const secondAssistant = doneMessage(await collectStream(
+				registered.provider.streamSimple(model as never, context(messages) as never, streamOptions(sessionId) as never),
+		));
+		const completeHistory = [...messages, secondAssistant as AgentMessage];
+		const compactResult = await executeRemoteCompactionV2({
+			runtime: {
+				provider: model.provider,
+				api: model.api,
+				apiFamily: model.api,
+				model: model.id,
+				baseUrl: model.baseUrl!,
+				apiKey,
+				headers: {},
+				currentModel: model,
+			},
+			modelRegistry: {
+				getRegisteredProviderConfig: () => ({ api: model.api, streamSimple: registered.provider.streamSimple }),
+			} as never,
+			context: context([], "Stable instructions"),
+			promptInput: serializeMessagesToResponsesInput(model, completeHistory, {
+				grammarToolInputProperties: CODE_MODE_EXEC_GRAMMAR_INPUTS,
+			}),
+			requestOptions: { reasoning: { effort: "low", summary: "auto" }, text: { verbosity: "low" } },
+			sessionId,
+			retryDelayMs: 0,
+		});
+
+		assert.equal(compactResult.ok, true);
+		assert.equal(ScriptedWebSocket.opened, 1);
+		assert.equal(sentFrames().length, 4);
+		assert.equal(sentFrames()[0]?.previous_response_id, undefined);
+		assert.equal(sentFrames()[1]?.previous_response_id, "resp_tool");
+		assert.deepEqual(sentFrames()[1]?.input, [{
+			type: "custom_tool_call_output",
+			call_id: "call_resp_tool",
+			output: "tool result",
+		}]);
+		assert.equal(sentFrames()[2]?.previous_response_id, "resp_1");
+		assert.deepEqual(sentFrames()[2]?.input, [{ role: "user", content: [{ type: "input_text", text: "second user" }] }]);
+		assert.equal(sentFrames()[3]?.previous_response_id, "resp_2");
+		assert.deepEqual(sentFrames()[3]?.input, [
+			{ type: "compaction_trigger" },
+		]);
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("cache continuation rejects meaningful prompt, tool, and persisted-history rewrites", async () => {
+	const cases: Array<{
+		name: string;
+		mutate: (base: { systemPrompt: string; tools: typeof codeModeTools; messages: AgentMessage[] }) => void;
+	}> = [
+		{
+			name: "system prompt",
+			mutate: (base) => { base.systemPrompt = "Changed instructions"; },
+		},
+		{
+			name: "tool schema",
+			mutate: (base) => {
+				base.tools = structuredClone(codeModeTools) as typeof codeModeTools;
+				(base.tools[1] as { description: string }).description = "Changed wait contract";
+			},
+		},
+		{
+			name: "tool order",
+			mutate: (base) => { base.tools = [...codeModeTools].reverse() as typeof codeModeTools; },
+		},
+		{
+			name: "assistant history",
+			mutate: (base) => {
+				const assistant = structuredClone(base.messages[1]!) as AssistantMessage;
+				const text = assistant.content.find((item) => item.type === "text");
+				if (text?.type === "text") text.text = "rewritten assistant history";
+				base.messages[1] = assistant as AgentMessage;
+			},
+		},
+	];
+
+	for (const candidate of cases) {
+		const restoreWebSocket = installScriptedWebSocket([[
+			textResponse("resp_base", "stable assistant"),
+			textResponse("resp_changed", "changed"),
+		]]);
+		try {
+			const registered = createRegisteredCodexProvider({ codeMode: true });
+			const sessionId = `invalidate-${candidate.name}`;
+			const firstUser = user("first user", 1);
+			const assistant = doneMessage(await collectStream(
+				registered.provider.streamSimple(model as never, context([firstUser]) as never, streamOptions(sessionId) as never),
+			));
+			const base = {
+				systemPrompt: "Stable instructions",
+				tools: codeModeTools,
+				messages: [firstUser, assistant as AgentMessage, user("new user", 2)],
+			};
+			candidate.mutate(base);
+			await collectStream(registered.provider.streamSimple(
+				model as never,
+				context(base.messages, base.systemPrompt, base.tools) as never,
+				streamOptions(sessionId) as never,
+			));
+
+			const changedFrame = sentFrames()[1]!;
+			assert.equal(changedFrame.previous_response_id, undefined, `${candidate.name} must invalidate continuation`);
+			assert.ok((changedFrame.input?.length ?? 0) > 1, `${candidate.name} must be sent in full`);
+		} finally {
+			restoreWebSocket();
+		}
+	}
+});
+
+test("WebSocket continuations never cross session IDs", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		textResponse("resp_session_a", "session A"),
+		textResponse("resp_session_b", "session B"),
+	]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const firstUser = user("session A user", 1);
+		const assistant = doneMessage(await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([firstUser]) as never,
+			streamOptions("session-a") as never,
+		)));
+		await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([firstUser, assistant as AgentMessage, user("session B user", 2)]) as never,
+			streamOptions("session-b") as never,
+		));
+
+		assert.equal(ScriptedWebSocket.opened, 2);
+		assert.equal(sentFrames()[1]?.previous_response_id, undefined);
+		assert.ok((sentFrames()[1]?.input?.length ?? 0) > 3, "a new session must send its full independent input");
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("post-start WebSocket loss blocks automatic replay while an explicit replay stays byte-identical", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		failAfterStart,
+		textResponse("resp_retry", "recovered"),
+	]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const sessionId = "post-start-retry";
+		const requestContext = context([user("same user", 1)]);
+		const failed = await collectStream(
+				registered.provider.streamSimple(model as never, requestContext as never, streamOptions(sessionId) as never),
+		);
+		const failedEvent = failed.at(-1) as { type?: string; error?: AssistantMessage };
+		assert.equal(failedEvent.type, "error");
+		assert.ok(failedEvent.error);
+		assert.equal(isRetryableAssistantError(failedEvent.error), false, "Pi must not automatically replay a post-start failure");
+		assert.match(failedEvent.error.errorMessage ?? "", /Automatic full-context replay was blocked/);
+		assert.match(JSON.stringify(failedEvent.error.diagnostics), /socket reset by peer/);
+		await collectStream(registered.provider.streamSimple(
+			model as never,
+				requestContext as never,
+			streamOptions(sessionId) as never,
+		));
+
+		assert.equal(ScriptedWebSocket.opened, 2);
+		assert.equal(sentFrames()[0]?.previous_response_id, undefined);
+		assert.equal(sentFrames()[1]?.previous_response_id, undefined);
+		assert.deepEqual(sentFrames()[1], sentFrames()[0]);
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("post-start API failures also block Pi's automatic replay", async () => {
+	const restoreWebSocket = installScriptedWebSocket([apiFailAfterStart]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const failed = await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([user("charged request", 1)]) as never,
+			streamOptions("post-start-api-error") as never,
+		));
+		const failedEvent = failed.at(-1) as { error?: AssistantMessage };
+		assert.ok(failedEvent.error);
+		assert.equal(isRetryableAssistantError(failedEvent.error), false);
+		assert.match(failedEvent.error.errorMessage ?? "", /Automatic full-context replay was blocked/);
+		assert.match(JSON.stringify(failedEvent.error.diagnostics), /internal server error/);
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("missing continuation after stream start cannot trigger an internal full replay", async () => {
+	const restoreWebSocket = installScriptedWebSocket([missingContinuationAfterStart]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const failed = await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([user("do not replay", 1)]) as never,
+			streamOptions("post-start-missing-continuation") as never,
+		));
+		const failedEvent = failed.at(-1) as { error?: AssistantMessage };
+		assert.ok(failedEvent.error);
+		assert.equal(isRetryableAssistantError(failedEvent.error), false);
+		assert.equal(sentFrames().length, 1);
+		assert.match(JSON.stringify(failedEvent.error.diagnostics), /previous_response_not_found/);
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("missing continuation before stream start retries once with full context", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		[textResponse("resp_base", "base"), missingContinuationBeforeStart],
+		textResponse("resp_recovered", "recovered"),
+	]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const firstUser = user("first", 1);
+		const assistant = doneMessage(await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([firstUser]) as never,
+			streamOptions("pre-start-missing-continuation") as never,
+		)));
+		const recovered = await collectStream(registered.provider.streamSimple(
+			model as never,
+			context([firstUser, assistant as AgentMessage, user("second", 2)]) as never,
+			streamOptions("pre-start-missing-continuation") as never,
+		));
+
+		assert.equal((recovered.at(-1) as { type?: string }).type, "done");
+		assert.equal(ScriptedWebSocket.opened, 2);
+		assert.equal(sentFrames()[1]?.previous_response_id, "resp_base");
+		assert.equal(sentFrames()[2]?.previous_response_id, undefined);
+		assert.ok((sentFrames()[2]?.input?.length ?? 0) > 3);
+	} finally {
+		restoreWebSocket();
+	}
+});
+
+test("post-compaction prewarm opens a fresh socket with the encrypted checkpoint and makes the next turn delta-only", async () => {
+	const restoreWebSocket = installScriptedWebSocket([
+		textResponse("resp_old", "before compaction"),
+		[websocketSuccess, textResponse("resp_after", "after compaction")],
+	]);
+	try {
+		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const sessionId = "post-compaction-prewarm";
+		await collectStream(registered.provider.streamSimple(
+			model as never,
+				context([user("before compaction", 1)]) as never,
+			streamOptions(sessionId) as never,
+		));
+
+		closeOpenAICodexWebSocketSessions(sessionId);
+		const compactedWindow = [{ type: "compaction", encrypted_content: "sealed-checkpoint" }];
+		const config = {
+			...DEFAULT_CODEX_CONVERSION_CONFIG,
+			beta: { ...DEFAULT_CODEX_CONVERSION_CONFIG.beta, codeMode: true },
+			compaction: { ...DEFAULT_CODEX_CONVERSION_CONFIG.compaction, responsesCompaction: true },
+		};
+		const firstUser = user("before compaction", 1);
+		const nextUser = user("after compaction", 2);
+		const preEntry = {
+			type: "message",
+			id: "pre",
+			parentId: null,
+			timestamp: new Date(1).toISOString(),
+			message: firstUser,
+		};
+		const compactionEntry = {
+			type: "compaction",
+			id: "compact",
+			parentId: "pre",
+			timestamp: new Date(2).toISOString(),
+			summary: NATIVE_COMPACTION_SHIM_SUMMARY,
+			firstKeptEntryId: "pre",
+			tokensBefore: 100,
+			details: {
+				strategy: NATIVE_COMPACTION_STRATEGY,
+				provider: model.provider,
+				api: model.api,
+				model: model.id,
+				baseUrl: model.baseUrl,
+				createdAt: new Date(2).toISOString(),
+				compactedWindow,
+			},
+		};
+		const currentEntry = {
+			type: "message",
+			id: "current",
+			parentId: "compact",
+			timestamp: new Date(3).toISOString(),
+			message: nextUser,
+		};
+		let branchEntries = [preEntry, compactionEntry] as SessionEntry[];
+		const extensionContext = {
+			model,
+			getSystemPrompt: () => "Stable instructions",
+			modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey }) },
+			sessionManager: {
+				getBranch: () => branchEntries,
+				getSessionId: () => sessionId,
+			},
+			ui: { notify: () => undefined },
+		} as never;
+		const runtime = createCodexExtensionRuntime({
+			getActiveTools: () => ["exec", "wait"],
+			getAllTools: () => codeModeTools,
+			getThinkingLevel: () => "low",
+			sendUserMessage: () => undefined,
+		} as never);
+		runtime.state.config = config;
+		const activeProviderPrompt = `${runtime.codexSystemPrompt("Stable instructions", extensionContext)}\nACTIVE PROVIDER PROMPT`;
+		runtime.state.activeProviderSystemPrompt = activeProviderPrompt;
+		await runtime.startCompactionPrewarm(extensionContext);
+
+		branchEntries = [preEntry, compactionEntry, currentEntry] as SessionEntry[];
+		const postCompactionMessages = convertToLlm(buildSessionContext(branchEntries).messages);
+		await collectStream(registered.provider.streamSimple(
+			model as never,
+			context(postCompactionMessages as never, activeProviderPrompt) as never,
+			{
+				...streamOptions(sessionId),
+				onPayload: (body: unknown) => rewriteCodexProviderRequest(body, extensionContext, runtime.state),
+			} as never,
+		));
+
+		assert.equal(ScriptedWebSocket.opened, 2);
+		const prewarmFrame = sentFrames()[1] as ResponseCreateFrame & { generate?: boolean };
+		assert.equal(prewarmFrame.generate, false);
+		assert.equal(JSON.stringify(prewarmFrame.input).match(/sealed-checkpoint/g)?.length, 1);
+		assert.equal(JSON.stringify(prewarmFrame.input).match(/ACTIVE PROVIDER PROMPT/g)?.length, 1);
+		assert.doesNotMatch(JSON.stringify(prewarmFrame.input), /before compaction/);
+		assert.equal(sentFrames()[2]?.previous_response_id, "resp_ws");
+		assert.deepEqual(sentFrames()[2]?.input, [{ role: "user", content: [{ type: "input_text", text: "after compaction" }] }]);
+	} finally {
+		restoreWebSocket();
+	}
+});

--- a/packages/pi-codex-conversion/tests/openai-codex-test-support.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-test-support.ts
@@ -92,18 +92,19 @@ export async function collectStream(stream: AsyncIterable<unknown>): Promise<unk
 type WebSocketScript = (socket: ScriptedWebSocket) => void;
 
 export class ScriptedWebSocket {
-	static scripts: WebSocketScript[] = [];
+	static scripts: Array<WebSocketScript | WebSocketScript[]> = [];
+	static sentFrames: unknown[] = [];
 	static opened = 0;
 	readonly listeners = new Map<string, Set<(event: unknown) => void>>();
-	readonly script: WebSocketScript;
+	readonly scripts: WebSocketScript[];
 	readyState = 0;
-	private sent = false;
-	private scriptStarted = false;
+	private sends = 0;
+	private scriptsStarted = 0;
 
 	constructor() {
-		const script = ScriptedWebSocket.scripts.shift();
-		if (!script) throw new Error("No scripted WebSocket behavior");
-		this.script = script;
+		const scripts = ScriptedWebSocket.scripts.shift();
+		if (!scripts) throw new Error("No scripted WebSocket behavior");
+		this.scripts = Array.isArray(scripts) ? scripts : [scripts];
 		ScriptedWebSocket.opened++;
 		queueMicrotask(() => {
 			this.readyState = 1;
@@ -122,15 +123,26 @@ export class ScriptedWebSocket {
 		this.listeners.get(type)?.delete(listener);
 	}
 
-	send(): void {
-		this.sent = true;
+	send(data?: unknown): void {
+		if (typeof data === "string") {
+			try {
+				ScriptedWebSocket.sentFrames.push(JSON.parse(data));
+			} catch {
+				ScriptedWebSocket.sentFrames.push(data);
+			}
+		} else {
+			ScriptedWebSocket.sentFrames.push(data);
+		}
+		this.sends++;
 		this.startScriptWhenReady();
 	}
 
 	private startScriptWhenReady(): void {
-		if (!this.sent || this.scriptStarted || !["message", "error", "close"].every((type) => (this.listeners.get(type)?.size ?? 0) > 0)) return;
-		this.scriptStarted = true;
-		this.script(this);
+		if (this.scriptsStarted >= this.sends || !["message", "error", "close"].every((type) => (this.listeners.get(type)?.size ?? 0) > 0)) return;
+		const script = this.scripts[this.scriptsStarted];
+		if (!script) throw new Error(`No scripted WebSocket behavior for send ${this.scriptsStarted + 1}`);
+		this.scriptsStarted++;
+		script(this);
 	}
 
 	close(): void {
@@ -151,14 +163,16 @@ export const websocketSuccess: WebSocketScript = (socket) => {
 	socket.emitJson({ type: "response.completed", response: { id: "resp_ws", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } });
 };
 
-export function installScriptedWebSocket(scripts: WebSocketScript[]): () => void {
+export function installScriptedWebSocket(scripts: Array<WebSocketScript | WebSocketScript[]>): () => void {
 	const original = globalThis.WebSocket;
 	ScriptedWebSocket.scripts = [...scripts];
+	ScriptedWebSocket.sentFrames = [];
 	ScriptedWebSocket.opened = 0;
 	globalThis.WebSocket = ScriptedWebSocket as never;
 	return () => {
 		globalThis.WebSocket = original;
 		ScriptedWebSocket.scripts = [];
+		ScriptedWebSocket.sentFrames = [];
 		closeOpenAICodexWebSocketSessions();
 	};
 }

--- a/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildCachedWebSocketRequestBody, parseSSE, type ResponsesBody } from "../src/providers/openai-codex-custom-provider.ts";
+import { parseSSE } from "../src/providers/openai-codex-custom-provider.ts";
 import {
 	ScriptedWebSocket,
 	codexStreamRequest,
@@ -29,100 +29,6 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 	for await (const event of parseSSE(response)) events.push(event);
 
 	assert.deepEqual(events, [{ type: "response.created", response: { id: "resp_1" } }]);
-});
-
-test("WebSocket continuation ignores response-item transport metadata", () => {
-	const previousInput = { role: "user", content: [{ type: "input_text", text: "hello" }] };
-	const responseItem = {
-		id: "msg_1",
-		type: "message",
-		status: "completed",
-		content: [{ type: "output_text", annotations: [], logprobs: [], text: "Hello" }],
-		role: "assistant",
-		internal_chat_message_metadata_passthrough: { turn_id: "turn_1" },
-	};
-	const persistedResponseItem = {
-		type: "message",
-		role: "assistant",
-		content: [{ type: "output_text", text: "Hello", annotations: [] }],
-		status: "completed",
-		id: "msg_1",
-	};
-	const responseToolCall = {
-		id: "ctc_1",
-		type: "custom_tool_call",
-		status: "completed",
-		call_id: "call_1",
-		input: "text('done')",
-		name: "exec",
-	};
-	const persistedToolCall = {
-		type: "custom_tool_call",
-		id: "ctc_1",
-		call_id: "call_1",
-		name: "exec",
-		input: "text('done')",
-	};
-	const request = {
-		model: "gpt-test",
-		store: false,
-		stream: true,
-		instructions: "instructions",
-		input: [previousInput, persistedResponseItem, persistedToolCall, { type: "compaction_trigger" }],
-		text: { verbosity: "low" },
-		include: [],
-		tool_choice: "auto",
-		parallel_tool_calls: true,
-	} satisfies ResponsesBody;
-	const result = buildCachedWebSocketRequestBody({
-		lastRequestBody: { ...request, input: [previousInput] },
-		lastResponseId: "resp_1",
-		lastResponseItems: [responseItem, responseToolCall],
-	}, request);
-
-	assert.deepEqual(result, {
-		decision: "delta",
-		body: { ...request, previous_response_id: "resp_1", input: [{ type: "compaction_trigger" }] },
-	});
-});
-
-test("three post-start WebSocket failures reserve Pi's final retry for SSE", async () => {
-	const failAfterStart = (socket: ScriptedWebSocket) => {
-		socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
-		socket.emit("error", { error: new Error("socket reset by peer") });
-	};
-	const restoreWebSocket = installScriptedWebSocket([
-		failAfterStart,
-		failAfterStart,
-		failAfterStart,
-		websocketSuccess,
-	]);
-	const originalFetch = globalThis.fetch;
-	let fetchCalls = 0;
-	globalThis.fetch = (async () => {
-		fetchCalls++;
-		return sseResponse([{ type: "response.completed", response: { id: "resp_sse", status: "completed", usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } }]);
-	}) as typeof fetch;
-	try {
-		const registered = createRegisteredCodexProvider();
-		const sessionA = codexStreamRequest("session-a");
-		for (let attempt = 0; attempt < 3; attempt++) {
-			const failed = await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
-			assert.match((failed.at(-1) as { error: { errorMessage: string } }).error.errorMessage, /Connection error: WebSocket error: socket reset by peer/);
-			assert.equal(fetchCalls, 0);
-		}
-
-		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
-		assert.equal(ScriptedWebSocket.opened, 3);
-		assert.equal(fetchCalls, 1);
-
-		await collectStream(registered.provider.streamSimple(sessionA.model, sessionA.context, sessionA.options));
-		assert.equal(ScriptedWebSocket.opened, 4);
-		assert.equal(fetchCalls, 1);
-	} finally {
-		globalThis.fetch = originalFetch;
-		restoreWebSocket();
-	}
 });
 
 test("Codex API and protocol errors do not arm SSE fallback", async () => {

--- a/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
@@ -34,20 +34,41 @@ test("parseSSE accepts CRLF chunks, joined data lines, and ignores done sentinel
 test("WebSocket continuation ignores response-item transport metadata", () => {
 	const previousInput = { role: "user", content: [{ type: "input_text", text: "hello" }] };
 	const responseItem = {
-		type: "message",
 		id: "msg_1",
+		type: "message",
+		status: "completed",
+		content: [{ type: "output_text", annotations: [], logprobs: [], text: "Hello" }],
+		role: "assistant",
+		internal_chat_message_metadata_passthrough: { turn_id: "turn_1" },
+	};
+	const persistedResponseItem = {
+		type: "message",
 		role: "assistant",
 		content: [{ type: "output_text", text: "Hello", annotations: [] }],
 		status: "completed",
-		internal_chat_message_metadata_passthrough: { turn_id: "turn_1" },
+		id: "msg_1",
 	};
-	const { internal_chat_message_metadata_passthrough: _metadata, ...persistedResponseItem } = responseItem;
+	const responseToolCall = {
+		id: "ctc_1",
+		type: "custom_tool_call",
+		status: "completed",
+		call_id: "call_1",
+		input: "text('done')",
+		name: "exec",
+	};
+	const persistedToolCall = {
+		type: "custom_tool_call",
+		id: "ctc_1",
+		call_id: "call_1",
+		name: "exec",
+		input: "text('done')",
+	};
 	const request = {
 		model: "gpt-test",
 		store: false,
 		stream: true,
 		instructions: "instructions",
-		input: [previousInput, persistedResponseItem, { type: "compaction_trigger" }],
+		input: [previousInput, persistedResponseItem, persistedToolCall, { type: "compaction_trigger" }],
 		text: { verbosity: "low" },
 		include: [],
 		tool_choice: "auto",
@@ -56,7 +77,7 @@ test("WebSocket continuation ignores response-item transport metadata", () => {
 	const result = buildCachedWebSocketRequestBody({
 		lastRequestBody: { ...request, input: [previousInput] },
 		lastResponseId: "resp_1",
-		lastResponseItems: [responseItem],
+		lastResponseItems: [responseItem, responseToolCall],
 	}, request);
 
 	assert.deepEqual(result, {


### PR DESCRIPTION
## Summary
- compare cached Responses history semantically instead of by JSON field order and ignore only observed OpenAI transport-only replay differences
- adversarially verify normal turns, tool calls, session isolation, prompt/tool/history invalidation, V2 compaction, and fresh-socket replay using captured WebSocket frames
- close the old socket after native compaction and prewarm a fresh one from Pi's actual compacted session context and active provider prompt, making the next turn delta-only
- block automatic full-context replay after any WebSocket stream has started while preserving the raw failure in diagnostics; retain one safe full retry for a missing continuation before output starts

## Validation
- `bun run check:changed` (69 tests, extension artifact, knip)
- `bun run changeset:check`
- `bun test packages/pi-codex-conversion/tests/cache-continuity.test.ts`
- final reviewer: no actionable issues
- live `gpt-5.6-luna` low V2 compaction: 253,680 input, 252,672 cached input

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
