### PR TITLE
Fix Codex compaction and exec redraw CPU use

### DIFF
--- a/.changeset/patch-ms6ghx7s-cd0698.md
+++ b/.changeset/patch-ms6ghx7s-cd0698.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Capture final provider instructions after downstream prompt extensions so native Codex compaction reuses the active WebSocket cache.

--- a/.changeset/patch-ms6ghx7s-cd0698.md
+++ b/.changeset/patch-ms6ghx7s-cd0698.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Capture final provider instructions after downstream prompt extensions so native Codex compaction reuses the active WebSocket cache.
+Capture final provider instructions after downstream prompt extensions so native Codex compaction reuses the active WebSocket cache. Cache settled collapsed exec previews by terminal width to prevent historical command output from consuming CPU on every TUI redraw.

--- a/packages/pi-codex-conversion/src/adapter/activation/state.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/state.ts
@@ -19,6 +19,7 @@ export interface AdapterState {
 	previousToolNames?: string[] | undefined;
 	promptSkills: PromptSkill[];
 	activeProviderSystemPrompt?: string | undefined;
+	pendingActiveProviderPromptCapture?: boolean | undefined;
 	config: CodexConversionConfig;
 	codexTurnState: CodexTurnState;
 	pendingPiCompactionNativeWindow?: PendingPiCompactionNativeWindow | undefined;

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -25,6 +25,12 @@ function applyCodexRuntimePayload(payload: unknown, codeMode: boolean): unknown 
 	return codeMode && isCodeModeCompatibleBody(payload) ? applyResponsesLiteRequest(payload) : payload;
 }
 
+export function captureActiveProviderSystemPrompt(payload: unknown, state: AdapterState): void {
+	if (!isRecord(payload)) return;
+	const instructions = providerSystemPrompt(payload);
+	if (instructions !== undefined) state.activeProviderSystemPrompt = instructions;
+}
+
 export async function rewriteCodexProviderRequest(payload: unknown, ctx: ExtensionContext, state: AdapterState): Promise<unknown | undefined> {
 	const prepared = prepareCodexProviderRequest(payload, ctx, state);
 	if (!prepared) return undefined;
@@ -50,4 +56,22 @@ function isCodeModeCompatibleBody(value: unknown): value is ResponsesLiteCompati
 	return typeof value === "object" && value !== null
 		&& typeof (value as { model?: unknown }).model === "string"
 		&& Array.isArray((value as { input?: unknown }).input);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function providerSystemPrompt(payload: Record<string, unknown>): string | undefined {
+	if (typeof payload["instructions"] === "string") return payload["instructions"];
+	if (!Array.isArray(payload["input"])) return undefined;
+	for (const item of payload["input"]) {
+		if (!isRecord(item) || item["role"] !== "developer" || !Array.isArray(item["content"])) continue;
+		const text = item["content"]
+			.filter((part): part is Record<string, unknown> => isRecord(part) && part["type"] === "input_text" && typeof part["text"] === "string")
+			.map((part) => part["text"] as string)
+			.join("\n");
+		if (text !== "") return text;
+	}
+	return undefined;
 }

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -152,10 +152,14 @@ export function registerCodexEvents(
 	pi.on("before_agent_start", async (event, ctx) => {
 		if (runtime.voice.consumeDelegatedTurnStart()) state.codexTurnState.beginTurn();
 		const systemPrompt = event.systemPrompt;
-		if (!isAdapterRuntime(resolveCodexRuntimePlan(ctx, state.config))) return undefined;
+		if (!isAdapterRuntime(resolveCodexRuntimePlan(ctx, state.config))) {
+			state.pendingActiveProviderPromptCapture = false;
+			return undefined;
+		}
 		const skills = resolvePromptSkills(event.systemPromptOptions?.skills, hasNoSkillsFlag() ? [] : state.promptSkills);
 		const codexSystemPrompt = runtime.codexSystemPrompt(systemPrompt, ctx, skills, event.systemPromptOptions);
 		state.activeProviderSystemPrompt = codexSystemPrompt;
+		state.pendingActiveProviderPromptCapture = true;
 		await runtime.waitForPrewarm(ctx, codexSystemPrompt);
 		return { systemPrompt: codexSystemPrompt };
 	});
@@ -164,7 +168,12 @@ export function registerCodexEvents(
 		if ((update.type === "text_delta" || update.type === "thinking_delta") && typeof update.delta === "string") runtime.voice.streamDelta(update.type, update.delta);
 	});
 	pi.on("agent_start", async () => { runtime.voice.agentStarted(); runtime.lanVoice.agentStarted(); });
-	pi.on("agent_settled", async () => { state.codexTurnState.reset(); runtime.voice.settleTurn(); runtime.lanVoice.agentSettled(); });
+	pi.on("agent_settled", async () => {
+		state.pendingActiveProviderPromptCapture = false;
+		state.codexTurnState.reset();
+		runtime.voice.settleTurn();
+		runtime.lanVoice.agentSettled();
+	});
 	pi.on("before_provider_request", async (event, ctx) => {
 		state.cwd = ctx.cwd;
 		return rewriteCodexProviderRequest(event.payload, ctx, state);

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -9,6 +9,7 @@ import { registerCodexTools } from "./tools.ts";
 import { registerCodexUi } from "./ui.ts";
 import { registerCodexVoiceRenderer } from "../voice/ui.ts";
 import { resolveCodexRuntimePlan } from "../adapter/activation/runtime-plan.ts";
+import { captureActiveProviderSystemPrompt } from "../adapter/provider-request.ts";
 
 export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 	registerCodexVoiceRenderer(pi);
@@ -20,6 +21,11 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 			getConfig: () => ({ openai: runtime.state.config.openai, beta: runtime.state.config.beta, compaction: runtime.state.config.compaction }),
 			useResponsesLite: (model) => resolveCodexRuntimePlan({ model }, runtime.state.config).kind === "code",
 			turnState: runtime.state.codexTurnState,
+			onPreparedPayload: (payload) => {
+				if (!runtime.state.pendingActiveProviderPromptCapture) return;
+				captureActiveProviderSystemPrompt(payload, runtime.state);
+				runtime.state.pendingActiveProviderPromptCapture = false;
+			},
 		});
 		const proxyProvider = registerCodeModeProxyProvider(pi, () => runtime.state.config);
 		cleanupProxyProvider = proxyProvider;

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -125,6 +125,7 @@ function createCodexStream<TApi extends Api>(
 		getConfig?: () => CodexProviderRuntimeConfig | undefined;
 		useResponsesLite?: (model: Model<Api>) => boolean;
 		turnState?: CodexTurnState | undefined;
+		onPreparedPayload?: ((payload: ResponsesBody) => void) | undefined;
 		onStreamSettled?: () => void | undefined;
 	},
 ): AssistantMessageEventStream {
@@ -153,6 +154,7 @@ function createCodexStream<TApi extends Api>(
 
 			const accountId = extractAccountId(apiKey);
 			const body = await prepareCodexRequestBody(model, context, effectiveOptions, responsesLite);
+			deps.onPreparedPayload?.(body);
 			const websocketRequestId = effectiveOptions?.sessionId || createCodexRequestId();
 			const originator = runtimeConfig?.openai.harnessIdentifierHeader ? PI_CODEX_CONVERSION_ORIGINATOR : undefined;
 			const sseHeaders = buildSSEHeaders(model.headers, effectiveOptions?.headers, accountId, apiKey, effectiveOptions?.sessionId, responsesLite, originator);
@@ -320,7 +322,12 @@ function createCodexStream<TApi extends Api>(
 	return stream;
 }
 
-export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { getConfig?: () => CodexProviderRuntimeConfig | undefined; useResponsesLite?: (model: Model<Api>) => boolean; turnState?: CodexTurnState | undefined }): void {
+export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: {
+	getConfig?: () => CodexProviderRuntimeConfig | undefined;
+	useResponsesLite?: (model: Model<Api>) => boolean;
+	turnState?: CodexTurnState | undefined;
+	onPreparedPayload?: ((payload: ResponsesBody) => void) | undefined;
+}): void {
 	pi.registerProvider("openai-codex", {
 		api: "openai-codex-responses",
 		oauth: openaiCodexNativeOAuthProvider,
@@ -328,6 +335,7 @@ export function registerOpenAICodexCustomProvider(pi: ExtensionAPI, options: { g
 			...(options.getConfig ? { getConfig: options.getConfig } : {}),
 			...(options.useResponsesLite ? { useResponsesLite: options.useResponsesLite } : {}),
 			...(options.turnState ? { turnState: options.turnState } : {}),
+			...(options.onPreparedPayload ? { onPreparedPayload: options.onPreparedPayload } : {}),
 		}),
 	});
 }

--- a/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/command-tool.ts
@@ -106,16 +106,21 @@ function collapsedOutput(result: CollapsedExecOutput, theme: { fg(role: string, 
 }
 
 function renderCollapsedOutput(result: CollapsedExecOutput, theme: { fg(role: string, text: string): string }) {
+	let cached: { width: number; lines: string[]; skipped: number; rawTruncated: boolean } | undefined;
 	return {
 		render(width: number): string[] {
-			const output = collapsedOutput(result, theme);
-			if (!output.text) return [];
-			const preview = truncateToVisualLines(theme.fg("dim", output.text), COLLAPSED_OUTPUT_MAX_VISUAL_LINES, width, 4);
-			if (!output.truncated && preview.skippedCount <= 0) return preview.visualLines;
-			const hint = output.truncated ? "... (earlier output hidden," : `... (${preview.skippedCount} earlier lines,`;
-			return [truncateToWidth(`    ${theme.fg("muted", hint)} ${expandHint()}${theme.fg("muted", ")")}`, width, "..."), ...preview.visualLines];
+			if (!cached || cached.width !== width) {
+				const output = collapsedOutput(result, theme);
+				const preview = output.text
+					? truncateToVisualLines(theme.fg("dim", output.text), COLLAPSED_OUTPUT_MAX_VISUAL_LINES, width, 4)
+					: { visualLines: [], skippedCount: 0 };
+				cached = { width, lines: preview.visualLines, skipped: preview.skippedCount, rawTruncated: output.truncated };
+			}
+			if (!cached.rawTruncated && cached.skipped <= 0) return cached.lines;
+			const hint = cached.rawTruncated ? "... (earlier output hidden," : `... (${cached.skipped} earlier lines,`;
+			return [truncateToWidth(`    ${theme.fg("muted", hint)} ${expandHint()}${theme.fg("muted", ")")}`, width, "..."), ...cached.lines];
 		},
-		invalidate(): void {},
+		invalidate(): void { cached = undefined; },
 	};
 }
 

--- a/packages/pi-codex-conversion/tests/cache-continuity.test.ts
+++ b/packages/pi-codex-conversion/tests/cache-continuity.test.ts
@@ -4,7 +4,8 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { isRetryableAssistantError, type AssistantMessage, type Context, type Model } from "@earendil-works/pi-ai";
 import { buildSessionContext, convertToLlm, type SessionEntry } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
-import { rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import { captureActiveProviderSystemPrompt, rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import type { AdapterState } from "../src/adapter/activation/state.ts";
 import { executeRemoteCompactionV2 } from "../src/adapter/compaction/remote-v2-client.ts";
 import { serializeMessagesToResponsesInput } from "../src/adapter/compaction/serializer.ts";
 import { NATIVE_COMPACTION_SHIM_SUMMARY, NATIVE_COMPACTION_STRATEGY } from "../src/adapter/compaction/types.ts";
@@ -151,11 +152,25 @@ test("Code Mode normal turns and V2 compaction share one exact WebSocket continu
 		compactionResponse("resp_compact"),
 	]]);
 	try {
-		const registered = createRegisteredCodexProvider({ codeMode: true });
+		const downstreamPrompt = "Stable instructions\n\nDownstream machine identity";
+		const promptState = { activeProviderSystemPrompt: "Stale pre-extension instructions" } as AdapterState;
+		let captureNextProviderPrompt = true;
+		const registered = createRegisteredCodexProvider({
+			codeMode: true,
+			onPreparedPayload: (payload) => {
+				if (!captureNextProviderPrompt) return;
+				captureActiveProviderSystemPrompt(payload, promptState);
+				captureNextProviderPrompt = false;
+			},
+		});
 		const sessionId = "shared-continuation";
+		const activeTurnOptions = {
+			...streamOptions(sessionId),
+			onPayload: (body: unknown) => ({ ...(body as object), instructions: downstreamPrompt }),
+		};
 		const firstUser = user("first user", 1);
 		const toolCallAssistant = doneMessage(await collectStream(
-				registered.provider.streamSimple(model as never, context([firstUser]) as never, streamOptions(sessionId) as never),
+				registered.provider.streamSimple(model as never, context([firstUser]) as never, activeTurnOptions as never),
 		));
 		const toolCall = toolCallAssistant.content.find((item) => item.type === "toolCall");
 		assert.equal(toolCall?.type, "toolCall");
@@ -169,12 +184,12 @@ test("Code Mode normal turns and V2 compaction share one exact WebSocket continu
 		} as AgentMessage;
 		const firstMessages = [firstUser, toolCallAssistant as AgentMessage, toolResult];
 		const firstAssistant = doneMessage(await collectStream(
-				registered.provider.streamSimple(model as never, context(firstMessages) as never, streamOptions(sessionId) as never),
+				registered.provider.streamSimple(model as never, context(firstMessages) as never, activeTurnOptions as never),
 		));
 		const secondUser = user("second user", 2);
 		const messages = [...firstMessages, firstAssistant as AgentMessage, secondUser];
 		const secondAssistant = doneMessage(await collectStream(
-				registered.provider.streamSimple(model as never, context(messages) as never, streamOptions(sessionId) as never),
+				registered.provider.streamSimple(model as never, context(messages) as never, activeTurnOptions as never),
 		));
 		const completeHistory = [...messages, secondAssistant as AgentMessage];
 		const compactResult = await executeRemoteCompactionV2({
@@ -191,7 +206,7 @@ test("Code Mode normal turns and V2 compaction share one exact WebSocket continu
 			modelRegistry: {
 				getRegisteredProviderConfig: () => ({ api: model.api, streamSimple: registered.provider.streamSimple }),
 			} as never,
-			context: context([], "Stable instructions"),
+			context: context([], promptState.activeProviderSystemPrompt),
 			promptInput: serializeMessagesToResponsesInput(model, completeHistory, {
 				grammarToolInputProperties: CODE_MODE_EXEC_GRAMMAR_INPUTS,
 			}),
@@ -201,6 +216,7 @@ test("Code Mode normal turns and V2 compaction share one exact WebSocket continu
 		});
 
 		assert.equal(compactResult.ok, true);
+		assert.equal(promptState.activeProviderSystemPrompt, downstreamPrompt);
 		assert.equal(ScriptedWebSocket.opened, 1);
 		assert.equal(sentFrames().length, 4);
 		assert.equal(sentFrames()[0]?.previous_response_id, undefined);

--- a/packages/pi-codex-conversion/tests/exec-output.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-output.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createExecCommandTracker } from "../src/tools/exec/command-state.ts";
+import { createExecCommandTool } from "../src/tools/exec/command-tool.ts";
 import { consumeOutput, peekOutputSince, truncateOutput, truncateToTail } from "../src/tools/exec/output.ts";
+import type { ExecSessionManager } from "../src/tools/exec/session-manager.ts";
 
 test("bounded raw output resumes deltas after rollover", () => {
 	const session = { buffer: "abcdefghij", bufferStartOffset: 0, emittedOffset: 0 };
@@ -19,4 +22,36 @@ test("bounded raw output resumes deltas after rollover", () => {
 	assert.deepEqual(consumeOutput(session), { output: "xyzABCDEFG", original_token_count: 5 });
 	assert.equal(truncateToTail(`${"x".repeat(4)}😀z`, 2).output, "z");
 	assert.equal(truncateOutput(`x😀${"y".repeat(255)}`, 1).output, "y".repeat(255));
+});
+
+test("settled collapsed exec output is recomputed only after width changes or invalidation", () => {
+	const tool = createExecCommandTool(createExecCommandTracker(), {} as ExecSessionManager, { showOutputWhenCollapsed: true });
+	const renderResult = tool.renderResult!;
+	let outputReads = 0;
+	const details = {
+		chunk_id: "chunk",
+		wall_time_seconds: 1,
+		get output() {
+			outputReads += 1;
+			return "x".repeat(1_000);
+		},
+	};
+	const component = renderResult(
+		{ content: [], details },
+		{ expanded: false, isPartial: false },
+		{ fg: (_role: string, text: string) => text } as never,
+		{ args: { cmd: "printf output" } } as never,
+	);
+	outputReads = 0;
+
+	component.render(80);
+	component.render(80);
+	assert.equal(outputReads, 1);
+
+	component.render(100);
+	assert.equal(outputReads, 2);
+
+	component.invalidate();
+	component.render(100);
+	assert.equal(outputReads, 3);
 });

--- a/packages/pi-codex-conversion/tests/openai-codex-test-support.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-test-support.ts
@@ -189,7 +189,7 @@ export function codexStreamRequest(sessionId: string) {
 	};
 }
 
-export function createRegisteredCodexProvider(options?: { codeMode?: boolean | undefined }) {
+export function createRegisteredCodexProvider(options?: { codeMode?: boolean | undefined; onPreparedPayload?: ((payload: unknown) => void) | undefined }) {
 	const turnState = createCodexTurnState();
 	const providers = new Map<string, { streamSimple: (...args: never[]) => AsyncIterable<unknown> }>();
 	const handlers = new Map<string, Array<(...args: never[]) => unknown>>();
@@ -216,6 +216,7 @@ export function createRegisteredCodexProvider(options?: { codeMode?: boolean | u
 			beta: { ...DEFAULT_CODEX_CONVERSION_CONFIG.beta, codeMode: options?.codeMode ?? false },
 		}),
 		turnState,
+		...(options?.onPreparedPayload ? { onPreparedPayload: options.onPreparedPayload as never } : {}),
 	});
 	return { provider: providers.get("openai-codex")!, handlers, renderers, sentMessages, turnState };
 }

--- a/packages/pi-codex-conversion/tests/provider-request.test.ts
+++ b/packages/pi-codex-conversion/tests/provider-request.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
-import { rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import { captureActiveProviderSystemPrompt, rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
 import type { AdapterState } from "../src/adapter/activation/state.ts";
 import { createCodexTurnState } from "../src/providers/openai-codex/turn-state.ts";
 
@@ -40,6 +40,16 @@ test("Code Mode relocates native freeform tools into Responses Lite", async () =
 	assert.equal(liteTools[0]?.format.syntax, "lark");
 	assert.deepEqual((rewritten.input[1] as { content: unknown }).content, [{ type: "input_text", text: "Instructions" }]);
 	assert.equal((rewritten.input[2] as { role: string }).role, "user");
+});
+
+test("captures downstream system-prompt additions from the final provider payload", () => {
+	const adapterState = state();
+	adapterState.activeProviderSystemPrompt = "Codex prompt before later extensions";
+	const finalInstructions = "Codex prompt before later extensions\n\nDownstream machine identity";
+
+	captureActiveProviderSystemPrompt({ ...payload, instructions: finalInstructions }, adapterState);
+
+	assert.equal(adapterState.activeProviderSystemPrompt, finalInstructions);
 });
 
 test("voice-only mode does not rewrite provider requests", async () => {


### PR DESCRIPTION
## Summary
- capture the final OpenAI Codex provider instructions after the complete provider-payload hook chain
- use those exact instructions for native compaction and post-compaction prewarm instead of the prompt seen before later extensions append context
- cache settled collapsed `exec_command` previews by terminal width, clearing the cache on component invalidation
- strengthen the cache-continuity wire contract and the collapsed-preview redraw contract

## Validation
- `bun run check:changed`
- `bun run changeset:check`
- `bun run knip`
- collapsed-preview regression: the new contract fails before the fix with two output reads for two same-width redraws, then passes after the fix with one
- live Luna-low reproduction: before the compaction fix, compaction sent the full 35-item history and reported zero cache; after the fix, it sent only the continuation trigger and the compaction endpoint reported 25,344 cached of 26,107 input tokens
- stock `openai-codex-responses` request, transport, reasoning, service-tier, and callback boundaries compared; these changes do not alter their request shape
- Tests culled: zero complete cases. The provider wire test protects the cross-extension prompt boundary; the collapsed-preview test protects the redraw cache boundary behind #201.

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation

Closes #201
