### PR TITLE
Fix Code Mode custom-tool promotion cache boundaries

### DIFF
--- a/.changeset/patch-ms7sg8do-4af7de.md
+++ b/.changeset/patch-ms7sg8do-4af7de.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep promoted Code Mode custom tools deferred until a cache-safe session or compaction boundary

--- a/.changeset/patch-ms7sg8do-4af7de.md
+++ b/.changeset/patch-ms7sg8do-4af7de.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Keep promoted Code Mode custom tools deferred until a cache-safe session or compaction boundary
+Keep new Code Mode custom tools out of the prompt until the session restarts or compacts

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -36,6 +36,8 @@ export async function registerCodexCodeMode(
 	});
 	return {
 		prepare: (ctx) => programmaticRuntime.prepare(ctx),
+		refreshPromptTools: (systemPrompt, ctx) =>
+			programmaticRuntime.refreshPromptTools(systemPrompt, ctx),
 		shutdownHost: () => programmaticRuntime.shutdownHost(),
 		async shutdown() {
 			await programmaticRuntime.shutdown();

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -205,8 +205,15 @@ export function registerCodexEvents(
 				}, { triggerTurn: false });
 			}
 		}
+		const postCompactionPrompt = codeMode.refreshPromptTools(
+			state.activeProviderSystemPrompt ?? ctx.getSystemPrompt(),
+			ctx,
+		);
+		state.activeProviderSystemPrompt = postCompactionPrompt;
 		runtime.resetTransportAfterCompaction(ctx.sessionManager.getSessionId());
-		await (nativeCompaction ? runtime.startCompactionPrewarm(ctx) : runtime.startPrewarm(ctx));
+		await (nativeCompaction
+			? runtime.startCompactionPrewarm(ctx)
+			: runtime.startPrewarm(ctx, postCompactionPrompt, true));
 	});
 	pi.on("context", async (event) => {
 		if (state.config.voiceFeaturesOnly) return undefined;

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -11,6 +11,8 @@ Definitions are top-level `*.toml` files in either location:
 
 Only the active session working directory is checked; parent directories are not searched. Project-local definitions are ignored unless Pi trusts the project. A project-local definition replaces a global definition with the same tool name. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
 
+Definitions remain live for execution, but prompt promotion is snapshotted when a session starts. A promoted tool added during a session remains deferred until compaction, reload, or a new, resumed, or forked session. Post-compaction promotion is included in the fresh compacted prewarm so the next turn keeps V2 cache continuation.
+
 ```toml
 usage = 'await tools.port_info(port_number)'
 description = "Returns listener and owning-process information."

--- a/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
+++ b/packages/pi-codex-conversion/src/tools/code-mode/CUSTOM-TOOLS.md
@@ -11,7 +11,7 @@ Definitions are top-level `*.toml` files in either location:
 
 Only the active session working directory is checked; parent directories are not searched. Project-local definitions are ignored unless Pi trusts the project. A project-local definition replaces a global definition with the same tool name. Each filename becomes a JavaScript method on `tools`, so use a JavaScript-compatible identifier.
 
-Definitions remain live for execution, but prompt promotion is snapshotted when a session starts. A promoted tool added during a session remains deferred until compaction, reload, or a new, resumed, or forked session. Post-compaction promotion is included in the fresh compacted prewarm so the next turn keeps V2 cache continuation.
+Definitions remain live for execution, but the custom-tool prompt is snapshotted when a session starts. A promoted tool added or renamed during a session remains deferred until compaction, reload, or a new, resumed, or forked session. Compaction refreshes custom-tool promotion for subsequent turns.
 
 ```toml
 usage = 'await tools.port_info(port_number)'

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -91,15 +91,17 @@ export function injectCodeModeToolsPrompt(
 
 export function replaceCodeModeToolsPrompt(
 	systemPrompt: string,
-	previousTools: CodeModeToolDefinition[],
+	previousSection: string | undefined,
 	nextTools: CodeModeToolDefinition[],
 	documentationPath?: string,
-): string {
-	const previous = buildCodeModeToolsPrompt(previousTools, documentationPath);
-	const next = buildCodeModeToolsPrompt(nextTools, documentationPath);
-	if (previous === next) return systemPrompt;
-	if (!previous || !systemPrompt.includes(previous)) {
-		return injectCodeModeToolsPrompt(systemPrompt, nextTools, documentationPath);
-	}
-	return systemPrompt.replace(previous, next);
+): { systemPrompt: string; section: string } {
+	const hasPrevious = Boolean(previousSection && systemPrompt.includes(previousSection));
+	const basePrompt = hasPrevious ? systemPrompt.replace(previousSection!, "") : systemPrompt;
+	const section = buildCodeModeToolsPrompt(nextTools, documentationPath, basePrompt);
+	return {
+		systemPrompt: hasPrevious
+			? systemPrompt.replace(previousSection!, section)
+			: injectCodeModeToolsPrompt(systemPrompt, nextTools, documentationPath),
+		section,
+	};
 }

--- a/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/custom-tool-prompt.ts
@@ -88,3 +88,18 @@ export function injectCodeModeToolsPrompt(
 		markers.length > 0 ? Math.min(...markers) : systemPrompt.length;
 	return `${systemPrompt.slice(0, insertAt).trimEnd()}\n\n${section}${systemPrompt.slice(insertAt)}`;
 }
+
+export function replaceCodeModeToolsPrompt(
+	systemPrompt: string,
+	previousTools: CodeModeToolDefinition[],
+	nextTools: CodeModeToolDefinition[],
+	documentationPath?: string,
+): string {
+	const previous = buildCodeModeToolsPrompt(previousTools, documentationPath);
+	const next = buildCodeModeToolsPrompt(nextTools, documentationPath);
+	if (previous === next) return systemPrompt;
+	if (!previous || !systemPrompt.includes(previous)) {
+		return injectCodeModeToolsPrompt(systemPrompt, nextTools, documentationPath);
+	}
+	return systemPrompt.replace(previous, next);
+}

--- a/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
@@ -14,7 +14,7 @@ export class SharedCodeModeRuntime {
 	readonly providers = new Map<object, CodeModeToolProvider>();
 	private clientPromise: Promise<CodeModeHostClient> | undefined;
 	private clientStartupAbort: AbortController | undefined;
-	private promptToolsSnapshot: CodeModeToolDefinition[] | undefined;
+	private customPromptToolsSnapshot: CodeModeToolDefinition[] | undefined;
 	private promptSectionSnapshot: string | undefined;
 
 	addProvider(provider: CodeModeToolProvider): object {
@@ -35,25 +35,15 @@ export class SharedCodeModeRuntime {
 
 	collectTools(ctx?: unknown): CodeModeToolDefinition[] {
 		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
-		if (!this.promptToolsSnapshot) return tools;
-		const customPromptState = new Map(
-			this.promptToolsSnapshot
-				.filter(isCustomTool)
-				.map((tool) => [tool.name, tool.deferLoading]),
-		);
-		return tools.map((tool) =>
-			isCustomTool(tool)
-				? {
-						...tool,
-						deferLoading: customPromptState.get(tool.name) ?? true,
-					}
-				: tool,
-		);
+		return this.customPromptToolsSnapshot
+			? applyCustomPromptState(tools, this.customPromptToolsSnapshot)
+			: tools;
 	}
 
 	refreshPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
-		this.promptToolsSnapshot = collectUniqueTools(this.activeProviders(ctx), ctx);
-		return this.promptToolsSnapshot;
+		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		this.customPromptToolsSnapshot = tools.filter(isCustomTool);
+		return tools;
 	}
 
 	resetPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
@@ -62,7 +52,12 @@ export class SharedCodeModeRuntime {
 	}
 
 	collectPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
-		return this.promptToolsSnapshot ?? this.refreshPromptTools(ctx);
+		if (!this.customPromptToolsSnapshot) return this.refreshPromptTools(ctx);
+		const liveProgrammaticTools = collectUniqueTools(
+			this.activeProviders(ctx),
+			ctx,
+		).filter((tool) => !isCustomTool(tool));
+		return [...liveProgrammaticTools, ...this.customPromptToolsSnapshot];
 	}
 
 	setPromptSection(section: string): void {
@@ -128,6 +123,23 @@ export class SharedCodeModeRuntime {
 
 function isCustomTool(tool: CodeModeToolDefinition): boolean {
 	return "command" in tool;
+}
+
+function applyCustomPromptState(
+	tools: CodeModeToolDefinition[],
+	customPromptTools: CodeModeToolDefinition[],
+): CodeModeToolDefinition[] {
+	const customPromptState = new Map(
+		customPromptTools.map((tool) => [tool.name, tool.deferLoading]),
+	);
+	return tools.map((tool) =>
+		isCustomTool(tool)
+			? {
+					...tool,
+					deferLoading: customPromptState.get(tool.name) ?? true,
+				}
+			: tool,
+	);
 }
 
 function collectUniqueTools(

--- a/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
@@ -14,6 +14,7 @@ export class SharedCodeModeRuntime {
 	readonly providers = new Map<object, CodeModeToolProvider>();
 	private clientPromise: Promise<CodeModeHostClient> | undefined;
 	private clientStartupAbort: AbortController | undefined;
+	private promptToolsSnapshot: CodeModeToolDefinition[] | undefined;
 
 	addProvider(provider: CodeModeToolProvider): object {
 		const id = {};
@@ -32,7 +33,30 @@ export class SharedCodeModeRuntime {
 	}
 
 	collectTools(ctx?: unknown): CodeModeToolDefinition[] {
-		return collectUniqueTools(this.activeProviders(ctx), ctx);
+		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		if (!this.promptToolsSnapshot) return tools;
+		const customPromptState = new Map(
+			this.promptToolsSnapshot
+				.filter(isCustomTool)
+				.map((tool) => [tool.name, tool.deferLoading]),
+		);
+		return tools.map((tool) =>
+			isCustomTool(tool)
+				? {
+						...tool,
+						deferLoading: customPromptState.get(tool.name) ?? true,
+					}
+				: tool,
+		);
+	}
+
+	refreshPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
+		this.promptToolsSnapshot = collectUniqueTools(this.activeProviders(ctx), ctx);
+		return this.promptToolsSnapshot;
+	}
+
+	collectPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
+		return this.promptToolsSnapshot ?? this.refreshPromptTools(ctx);
 	}
 
 	collectRenderTools(): CodeModeToolDefinition[] {
@@ -86,6 +110,10 @@ export class SharedCodeModeRuntime {
 			}
 		}
 	}
+}
+
+function isCustomTool(tool: CodeModeToolDefinition): boolean {
+	return "command" in tool;
 }
 
 function collectUniqueTools(

--- a/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
@@ -15,6 +15,7 @@ export class SharedCodeModeRuntime {
 	private clientPromise: Promise<CodeModeHostClient> | undefined;
 	private clientStartupAbort: AbortController | undefined;
 	private promptToolsSnapshot: CodeModeToolDefinition[] | undefined;
+	private promptSectionSnapshot: string | undefined;
 
 	addProvider(provider: CodeModeToolProvider): object {
 		const id = {};
@@ -55,8 +56,21 @@ export class SharedCodeModeRuntime {
 		return this.promptToolsSnapshot;
 	}
 
+	resetPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
+		this.promptSectionSnapshot = undefined;
+		return this.refreshPromptTools(ctx);
+	}
+
 	collectPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
 		return this.promptToolsSnapshot ?? this.refreshPromptTools(ctx);
+	}
+
+	setPromptSection(section: string): void {
+		this.promptSectionSnapshot = section;
+	}
+
+	getPromptSection(): string | undefined {
+		return this.promptSectionSnapshot;
 	}
 
 	collectRenderTools(): CodeModeToolDefinition[] {

--- a/packages/pi-codex-conversion/src/tools/code-mode/tool-events.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tool-events.ts
@@ -1,5 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { injectCodeModeToolsPrompt } from "./custom-tool-prompt.js";
+import {
+	buildCodeModeToolsPrompt,
+	injectCodeModeToolsPrompt,
+} from "./custom-tool-prompt.js";
 import type { SharedCodeModeRuntime } from "./shared-runtime.js";
 
 export function registerCodeModeEvents(
@@ -7,10 +10,10 @@ export function registerCodeModeEvents(
 	runtime: SharedCodeModeRuntime,
 ): void {
 	pi.on("session_start", (_event, ctx) => {
-		runtime.refreshPromptTools(ctx);
+		runtime.resetPromptTools(ctx);
 	});
 	pi.on("model_select", (_event, ctx) => {
-		runtime.refreshPromptTools(ctx);
+		runtime.resetPromptTools(ctx);
 	});
 	pi.on("before_agent_start", (event, ctx) => {
 		const activeProviders = runtime.activeProviders(ctx);
@@ -19,9 +22,17 @@ export function registerCodeModeEvents(
 		const documentationPath = activeProviders.find(
 			(provider) => provider.documentationPath,
 		)?.documentationPath;
+		const promptTools = runtime.collectPromptTools(ctx);
+		runtime.setPromptSection(
+			buildCodeModeToolsPrompt(
+				promptTools,
+				documentationPath,
+				event.systemPrompt,
+			),
+		);
 		const systemPrompt = injectCodeModeToolsPrompt(
 			event.systemPrompt,
-			runtime.collectPromptTools(ctx),
+			promptTools,
 			documentationPath,
 		);
 		return systemPrompt === event.systemPrompt ? undefined : { systemPrompt };

--- a/packages/pi-codex-conversion/src/tools/code-mode/tool-events.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tool-events.ts
@@ -6,6 +6,12 @@ export function registerCodeModeEvents(
 	pi: ExtensionAPI,
 	runtime: SharedCodeModeRuntime,
 ): void {
+	pi.on("session_start", (_event, ctx) => {
+		runtime.refreshPromptTools(ctx);
+	});
+	pi.on("model_select", (_event, ctx) => {
+		runtime.refreshPromptTools(ctx);
+	});
 	pi.on("before_agent_start", (event, ctx) => {
 		const activeProviders = runtime.activeProviders(ctx);
 		if (activeProviders.length === 0) return undefined;
@@ -15,7 +21,7 @@ export function registerCodeModeEvents(
 		)?.documentationPath;
 		const systemPrompt = injectCodeModeToolsPrompt(
 			event.systemPrompt,
-			runtime.collectTools(ctx),
+			runtime.collectPromptTools(ctx),
 			documentationPath,
 		);
 		return systemPrompt === event.systemPrompt ? undefined : { systemPrompt };

--- a/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
@@ -116,14 +116,16 @@ export async function registerCodeModeTools(
 			const documentationPath = activeProviders.find(
 				(provider) => provider.documentationPath,
 			)?.documentationPath;
-			const previousTools = runtime.collectPromptTools(ctx);
+			const previousSection = runtime.getPromptSection();
 			const nextTools = runtime.refreshPromptTools(ctx);
-			return replaceCodeModeToolsPrompt(
+			const replacement = replaceCodeModeToolsPrompt(
 				systemPrompt,
-				previousTools,
+				previousSection,
 				nextTools,
 				documentationPath,
 			);
+			runtime.setPromptSection(replacement.section);
+			return replacement.systemPrompt;
 		},
 		shutdownHost: () => runtime.shutdownHost(),
 		async shutdown() {

--- a/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/tools.ts
@@ -10,6 +10,7 @@ import {
 	getCustomToolsDir,
 	getProjectCustomToolsDir,
 } from "./custom-tools.js";
+import { replaceCodeModeToolsPrompt } from "./custom-tool-prompt.js";
 import { registerPublicCodeModeTools } from "./public-tools.js";
 import {
 	SharedCodeModeRuntime,
@@ -30,6 +31,7 @@ export interface RegisterCodeModeToolsOptions extends CodeModeToolProvider {}
 
 export interface CodeModeRegistration {
 	prepare(ctx?: unknown): Promise<void> | undefined;
+	refreshPromptTools(systemPrompt: string, ctx?: unknown): string;
 	shutdownHost(): Promise<void>;
 	shutdown(): Promise<void>;
 }
@@ -109,6 +111,20 @@ export async function registerCodeModeTools(
 	let active = true;
 	return {
 		prepare: (ctx) => runtime.prepare(ctx),
+		refreshPromptTools(systemPrompt, ctx) {
+			const activeProviders = runtime.activeProviders(ctx);
+			const documentationPath = activeProviders.find(
+				(provider) => provider.documentationPath,
+			)?.documentationPath;
+			const previousTools = runtime.collectPromptTools(ctx);
+			const nextTools = runtime.refreshPromptTools(ctx);
+			return replaceCodeModeToolsPrompt(
+				systemPrompt,
+				previousTools,
+				nextTools,
+				documentationPath,
+			);
+		},
 		shutdownHost: () => runtime.shutdownHost(),
 		async shutdown() {
 			if (!active) return;

--- a/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 import {
 	buildCodeModeToolsPrompt,
 	injectCodeModeToolsPrompt,
+	replaceCodeModeToolsPrompt,
 } from "../src/tools/code-mode/custom-tool-prompt.ts";
 import { scopeAllToolsToDeferredCustom } from "../src/tools/code-mode/host-client.ts";
+import { SharedCodeModeRuntime } from "../src/tools/code-mode/shared-runtime.ts";
 import type {
 	CodeModeToolDefinition,
 	CustomToolDefinition,
@@ -86,4 +88,30 @@ test("ALL_TOOLS exposes only deferred configured custom tools", () => {
 	assert.deepEqual(state.ALL_TOOLS, [
 		{ name: "deferred_tool", description: "deferred_tool help" },
 	]);
+});
+
+test("late custom-tool promotion stays deferred until the prompt snapshot refreshes", () => {
+	const initial = customTool("initial_tool", false);
+	const late = customTool("late_tool", false);
+	let discovered: CodeModeToolDefinition[] = [bundled, initial];
+	const runtime = new SharedCodeModeRuntime();
+	runtime.addProvider({ getTools: () => discovered });
+
+	const initialSnapshot = runtime.refreshPromptTools();
+	const initialPrompt = injectCodeModeToolsPrompt("Base", initialSnapshot, "/custom-tools.md");
+	discovered = [bundled, initial, late];
+
+	assert.deepEqual(runtime.collectPromptTools().map((tool) => tool.name), ["exec_command", "initial_tool"]);
+	assert.equal(runtime.collectTools().find((tool) => tool.name === "late_tool")?.deferLoading, true);
+	assert.doesNotMatch(initialPrompt, /late_tool/);
+
+	const refreshedSnapshot = runtime.refreshPromptTools();
+	const refreshedPrompt = replaceCodeModeToolsPrompt(
+		initialPrompt,
+		initialSnapshot,
+		refreshedSnapshot,
+		"/custom-tools.md",
+	);
+	assert.equal(runtime.collectTools().find((tool) => tool.name === "late_tool")?.deferLoading, false);
+	assert.match(refreshedPrompt, /Configured custom tools:\n- await tools\.initial_tool\(input\)\n- await tools\.late_tool\(input\)/);
 });

--- a/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
@@ -93,6 +93,11 @@ test("ALL_TOOLS exposes only deferred configured custom tools", () => {
 test("late custom-tool promotion stays deferred until the prompt snapshot refreshes", () => {
 	const initial = customTool("initial_tool", false);
 	const late = customTool("late_tool", false);
+	const liveBundled = {
+		...bundled,
+		name: "live_programmatic_tool",
+		usage: "await tools.live_programmatic_tool()",
+	};
 	let discovered: CodeModeToolDefinition[] = [bundled, initial];
 	const runtime = new SharedCodeModeRuntime();
 	runtime.addProvider({ getTools: () => discovered });
@@ -101,10 +106,14 @@ test("late custom-tool promotion stays deferred until the prompt snapshot refres
 	const basePrompt = "Tools available in exec:\n- user_owned_tool\n\nBase";
 	const initialSection = buildCodeModeToolsPrompt(initialSnapshot, "/custom-tools.md", basePrompt);
 	const initialPrompt = injectCodeModeToolsPrompt(basePrompt, initialSnapshot, "/custom-tools.md");
-	discovered = [bundled, initial, late];
+	discovered = [bundled, liveBundled, late];
 
-	assert.deepEqual(runtime.collectPromptTools().map((tool) => tool.name), ["exec_command", "initial_tool"]);
+	assert.deepEqual(runtime.collectPromptTools().map((tool) => tool.name), ["exec_command", "live_programmatic_tool", "initial_tool"]);
 	assert.equal(runtime.collectTools().find((tool) => tool.name === "late_tool")?.deferLoading, true);
+	assert.equal(runtime.collectTools().some((tool) => tool.name === "initial_tool"), false);
+	assert.match(buildCodeModeToolsPrompt(runtime.collectPromptTools()), /await tools\.live_programmatic_tool\(\)/);
+	assert.match(buildCodeModeToolsPrompt(runtime.collectPromptTools()), /await tools\.initial_tool\(input\)/);
+	assert.doesNotMatch(buildCodeModeToolsPrompt(runtime.collectPromptTools()), /late_tool/);
 	assert.doesNotMatch(initialPrompt, /late_tool/);
 
 	const refreshedSnapshot = runtime.refreshPromptTools();
@@ -117,5 +126,6 @@ test("late custom-tool promotion stays deferred until the prompt snapshot refres
 	assert.equal(runtime.collectTools().find((tool) => tool.name === "late_tool")?.deferLoading, false);
 	assert.equal(refreshedPrompt.match(/Tools available in exec:/g)?.length, 1);
 	assert.match(refreshedPrompt, /- user_owned_tool/);
-	assert.match(refreshedPrompt, /Configured custom tools:\n- await tools\.initial_tool\(input\)\n- await tools\.late_tool\(input\)/);
+	assert.match(refreshedPrompt, /Configured custom tools:\n- await tools\.late_tool\(input\)/);
+	assert.doesNotMatch(refreshedPrompt, /initial_tool/);
 });

--- a/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-tool-exposition.test.ts
@@ -98,7 +98,9 @@ test("late custom-tool promotion stays deferred until the prompt snapshot refres
 	runtime.addProvider({ getTools: () => discovered });
 
 	const initialSnapshot = runtime.refreshPromptTools();
-	const initialPrompt = injectCodeModeToolsPrompt("Base", initialSnapshot, "/custom-tools.md");
+	const basePrompt = "Tools available in exec:\n- user_owned_tool\n\nBase";
+	const initialSection = buildCodeModeToolsPrompt(initialSnapshot, "/custom-tools.md", basePrompt);
+	const initialPrompt = injectCodeModeToolsPrompt(basePrompt, initialSnapshot, "/custom-tools.md");
 	discovered = [bundled, initial, late];
 
 	assert.deepEqual(runtime.collectPromptTools().map((tool) => tool.name), ["exec_command", "initial_tool"]);
@@ -108,10 +110,12 @@ test("late custom-tool promotion stays deferred until the prompt snapshot refres
 	const refreshedSnapshot = runtime.refreshPromptTools();
 	const refreshedPrompt = replaceCodeModeToolsPrompt(
 		initialPrompt,
-		initialSnapshot,
+		initialSection,
 		refreshedSnapshot,
 		"/custom-tools.md",
-	);
+	).systemPrompt;
 	assert.equal(runtime.collectTools().find((tool) => tool.name === "late_tool")?.deferLoading, false);
+	assert.equal(refreshedPrompt.match(/Tools available in exec:/g)?.length, 1);
+	assert.match(refreshedPrompt, /- user_owned_tool/);
 	assert.match(refreshedPrompt, /Configured custom tools:\n- await tools\.initial_tool\(input\)\n- await tools\.late_tool\(input\)/);
 });

--- a/packages/pi-codex-conversion/tests/websocket-compaction-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-compaction-prewarm.test.ts
@@ -91,15 +91,16 @@ test("post-compaction prewarm opens a fresh socket with the encrypted checkpoint
 			sendUserMessage: () => undefined,
 		} as never);
 		runtime.state.config = config;
-		const activeProviderPrompt = `${runtime.codexSystemPrompt("Stable instructions", extensionContext)}\nACTIVE PROVIDER PROMPT`;
-		runtime.state.activeProviderSystemPrompt = activeProviderPrompt;
+		const preCompactionPrompt = `${runtime.codexSystemPrompt("Stable instructions", extensionContext)}\nPROMOTED: old_tool`;
+		const postCompactionPrompt = preCompactionPrompt.replace("old_tool", "old_tool, late_tool");
+		runtime.state.activeProviderSystemPrompt = postCompactionPrompt;
 		await runtime.startCompactionPrewarm(extensionContext);
 
 		branchEntries = [preEntry, compactionEntry, currentEntry] as SessionEntry[];
 		const postCompactionMessages = convertToLlm(buildSessionContext(branchEntries).messages);
 		await collectStream(registered.provider.streamSimple(
 			model as never,
-			context(postCompactionMessages as never, activeProviderPrompt, activeTools) as never,
+			context(postCompactionMessages as never, postCompactionPrompt, activeTools) as never,
 			{
 				...streamOptions(sessionId),
 				onPayload: (body: unknown) => rewriteCodexProviderRequest(body, extensionContext, runtime.state),
@@ -110,7 +111,8 @@ test("post-compaction prewarm opens a fresh socket with the encrypted checkpoint
 		const prewarmFrame = sentFrames()[1] as ResponseCreateFrame & { generate?: boolean };
 		assert.equal(prewarmFrame.generate, false);
 		assert.equal(JSON.stringify(prewarmFrame.input).match(/sealed-checkpoint/g)?.length, 1);
-		assert.equal(JSON.stringify(prewarmFrame.input).match(/ACTIVE PROVIDER PROMPT/g)?.length, 1);
+		assert.equal(JSON.stringify(prewarmFrame.input).match(/PROMOTED: old_tool, late_tool/g)?.length, 1);
+		assert.doesNotMatch(JSON.stringify(prewarmFrame.input), /PROMOTED: old_tool"/);
 		assert.doesNotMatch(JSON.stringify(prewarmFrame.input), /before compaction/);
 		assert.equal(sentFrames()[2]?.previous_response_id, "resp_ws");
 		assert.deepEqual(sentFrames()[2]?.input, [{ role: "user", content: [{ type: "input_text", text: "after compaction" }] }]);


### PR DESCRIPTION
## Summary
- snapshot prompt-visible Code Mode custom tools at session and model boundaries
- keep additions and renames deferred through `ALL_TOOLS` without changing the active custom-tool prompt
- keep programmatic tools live when their settings change
- refresh promoted custom tools after compaction
- track the exact injected prompt block so user-owned headings remain untouched

Closes #210

## Validation
- `bun run check:changed`
- `bun run changeset:check`

Tests culled: zero complete cases.

## Release
- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
