### PR TITLE
Improve native GitHub stack guidance

### DIFF
--- a/.changeset/patch-msftm78z-b213f7.md
+++ b/.changeset/patch-msftm78z-b213f7.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-skill-gh-stack": patch
+---
+
+Improve the native GitHub stacked-PR skill with tested noninteractive command guidance, lazy-loaded command and recovery references, machine-readable state contracts, and issue-batch stack design.

--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -37,11 +37,11 @@ description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/wor
 
 ### Dispatch a parallel issue batch
 
-Use a native stack when several bounded issues should stay independently reviewable but land as one release unit. This repo runs PR CI for every layer and Changesets/npm release work only on `push` to `main`; directly merging the top lands the stack atomically. A merge queue may split that landing, so use one integration PR instead when one release run is mandatory and direct merge is unavailable.
+Use a native stack as one release-batch PR set: each bounded issue gets a focused layer PR, while the top batch PR is the single requested merge action into `main`. Issues need not depend on each other when they deliberately ship together. This repo runs PR CI for every layer and Changesets/npm release work only on `push` to `main`; directly merging the top lands the stack atomically. A merge queue may split that landing, so use one integration PR instead when one release run is mandatory and direct merge is unavailable.
 
 Dispatch is a handoff, not a supervision loop:
 
-1. Read every issue first. Identify dependencies, shared files/packages, review boundaries, and a stable bottom-to-top order. Exclude work that does not belong in the same release unit.
+1. Read every issue first. Keep all issues in the requested release batch, identify dependencies and overlapping files/packages, then choose a stable bottom-to-top order. Exclude only work that should release separately.
 2. Fetch `origin/main` once and record its SHA. In a dedicated coordinator worktree at that base, run `gh stack init --base main <issue-branch-1> <issue-branch-2> ...` to create and track every worker branch in stack order before implementation starts. Do not create sibling branches and retrofit them later.
 3. Detach the coordinator worktree to free the stack's current branch. Check out each tracked stack branch into its own worker worktree under a sibling root such as `<repo-parent>/.worktrees/<repo>/issue-123`.
 4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per worktree, label it with the issue number and short title, and launch a named Pi session with `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr's JSON; do not guess IDs.
@@ -52,7 +52,7 @@ Dispatch is a handoff, not a supervision loop:
 
 1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready worktrees and commits. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
 2. Stop the ready panels and detach or remove their clean worktrees so Git can rewrite the checked-out branches. In the coordinator worktree, check out a stack branch, run the cascading `gh stack rebase`, resolve integration conflicts in the owning layer, and verify the complete order with `gh stack view --json`.
-3. From the top worker branch, run `gh stack add <batch-release-branch>`. Add patch-autodetected `bun changeset -- "<combined release summary>"` there so the stack carries one release artifact, then apply the verification cull across the complete stack and run the umbrella gate once from the release layer.
+3. From the top worker branch, run `gh stack add <batch-release-branch>`. This top branch is the batch PR. Add patch-autodetected `bun changeset -- "<combined release summary>"` there so the stack carries one release artifact, then apply the verification cull across the complete stack and run the umbrella gate once from the release layer.
 4. Run `gh stack submit --auto` to create draft native PRs and the stack object on GitHub.com. Verify the GitHub stack map, then edit every PR's title, body, issue linkage, base, and order. Use `Closes` only where the layer fully resolves its issue. Invoke configured review systems on each focused layer.
 5. Return the layer → PR map and stop again. Dispatch review-fix workers only when the user asks; each fix wave follows the same launch-and-handoff boundary. After the user declares review converged, rebase and push the affected upstack, run `gh stack submit --auto --open`, and report readiness.
 6. Merge only on explicit user direction. Confirm every layer is approved and green and the target does not require a merge queue, then directly merge the top with `gh stack merge <top-pr> --yes` and the repository's merge method. Verify the atomic `main` landing and release workflow; until one live batch confirms event behavior, do not claim the one-run release property as measured fact.

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -39,8 +39,8 @@ git config rerere.enabled true
 The contracts below target `gh stack` v0.1.0. If the installed version differs, current command
 help wins.
 
-With several remotes, pass `--remote <name>` where supported. Commands without that flag require
-an unambiguous repository-local `remote.pushDefault`.
+With several remotes, pass `--remote <name>` where supported or configure one unambiguous remote
+before noninteractive use.
 
 ## Noninteractive use
 
@@ -84,10 +84,10 @@ gh stack init --base <trunk> <issue-branch-1> <issue-branch-2> <issue-branch-3>
 order. Inspect existing ancestry first. Use ordinary `git add` and `git commit` so each branch owns
 only its concern.
 
-`submit --auto` pushes active branches, creates missing draft PRs with generated metadata, fixes
-their bases, and links them into a GitHub stack. Add `--open` only when they should leave draft
-state; use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic: rerun it after
-repairing a partial failure.
+`submit --auto` pushes active branches, creates missing PRs as drafts, updates existing PRs where
+possible, and links them into a GitHub stack. Read its warnings. Add `--open` only when PRs should
+leave draft state, and use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic;
+rerun it after a partial failure.
 
 ## Edit a lower layer
 

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -1,121 +1,181 @@
 ---
 name: gh-stack
-description: "Native GitHub stacked-PR workflow via gh stack: plan dependent layers; create, submit, inspect, sync, rebase, restructure, and merge stacks. Use for explicit stacked PRs, stacked diffs, or gh stack work; not ordinary or independent PRs."
+description: "Operate native GitHub stacked PRs with gh stack: design layers, create or adopt stacks, submit, inspect, sync, rebase, restructure, and merge. Use for explicit stacks, dependent PRs, or issue batches intended to land as one release unit; not ordinary PR work."
 license: MIT
-compatibility: "Requires authenticated GitHub CLI and the github/gh-stack extension; same-repository branches only"
+compatibility: "Requires authenticated GitHub CLI and the github/gh-stack extension"
 ---
 
-# GitHub stacked PRs
+# gh-stack
 
-## Guardrails
-
-- Repository instructions and explicit user direction override this skill
-- Use a stack only for a linear dependency chain. Keep independent changes in independent PRs; do not manufacture layers merely to shrink a diff
-- Order layers bottom to top: foundations before dependants. Each layer must be cohesive and reviewable against the branch below it
-- Inspect the working tree, remotes, trunk, current branch, existing PRs, and stack state before branch or history operations. Keep unrelated changes out
-- Stacks require branches in one repository. Do not substitute a native stack for fork-based contribution work
-- Cascading rebases rewrite every affected upstack branch. Do not rewrite shared or ambiguously owned branches without agreement
-- Treat `submit`, `link`, `sync`, `push`, `unstack`, and `merge` as external writes. Infer authorization from a requested stacked-PR outcome, but never merge merely because a stack is ready
-
-## Runtime contract
-
-1. Run `gh stack --version`. If unavailable, install with `gh extension install github/gh-stack`, then retry
-2. Use current `gh stack <command> --help` for exact flags when the installed version may differ from this skill
-3. Keep agent calls noninteractive:
-   - name every branch passed to `init` or `add`
-   - use `gh stack submit --auto`; add `--open` only when PRs should leave draft state
-   - inspect with `gh stack view --json` for machine decisions or `--short` for concise display
-   - give `checkout` a stack number, PR number/URL, or branch
-   - do not use interactive `modify` or `switch`
-   - use `gh stack merge ... --yes` with an explicit merge method when merging is authorized
-4. With multiple remotes, pass `--remote <name>` where supported and set repository-local `remote.pushDefault` only when commands without that flag need an unambiguous remote
-5. If `rerere.enabled` is unset before `init`, set it repository-locally to `true` so initialization and repeated conflict resolution stay noninteractive
-
-## Workflow
-
-### Plan
-
-Write the intended chain before creating branches:
+A stack is a trunk-rooted branch chain. Each branch has a PR based on the branch below it, so its
+diff shows only that layer. `gh stack` prints trunk first:
 
 ```text
-trunk <- foundation <- dependent change <- integration
+(main) <- auth <- api <- frontend
 ```
 
-Split at a dependency or review boundary, not by file count. If layer B can land without layer A, it probably belongs in another PR or stack.
+Left is the **bottom** and merges first; right is the **top** and merges last. `up` moves away from
+trunk; `down` moves toward it.
 
-### Create and submit
+## Rules
 
-```sh
+- Repository instructions and explicit user direction override this skill.
+- **Never merge a stack without explicit user approval.** Readiness, green checks, or a prior submit
+  request is not merge authorization.
+- Stacks are linear. A layer may represent a code dependency or one bounded issue in an explicitly
+  shared release batch. Keep work outside that release unit in another stack or PR.
+- Create the chain before implementation. Put each change on the lowest layer that owns it; edit a
+  lower owner, cascade-rebase upstack, then return to the top.
+
+Read `references/stack-design.md` before choosing layers.
+
+## Setup
+
+```bash
+gh stack --version || { gh extension install github/gh-stack && gh stack --version; }
+git config rerere.enabled true
+```
+
+The contracts below target `gh stack` v0.1.0. If the installed version differs, current command
+help wins.
+
+With several remotes, pass `--remote <name>` where supported. Commands without that flag require
+an unambiguous repository-local `remote.pushDefault`.
+
+## Noninteractive use
+
+`gh stack` treats terminal stdout as interactive. Run it **without a PTY**: under a PTY, bare
+commands may prompt or open a full-screen TUI. Still use explicit arguments and flags:
+
+| Run                                       | Never run bare      | Why                              |
+| ----------------------------------------- | ------------------- | -------------------------------- |
+| `gh stack view --json`                    | `gh stack view`     | bare view opens a TUI            |
+| `gh stack submit --auto`                  | `gh stack submit`   | prompts for each new PR title    |
+| `gh stack merge <target> --yes --squash`  | `gh stack merge`    | prompts for scope and method     |
+| `gh stack init <branch>...`               | `gh stack init`     | prompts for branch names         |
+| `gh stack add <branch>`                   | `gh stack add`      | prompts for a name               |
+| `gh stack checkout <target>`              | `gh stack checkout` | opens a selection menu           |
+| `gh stack up` / `down` / `top` / `bottom` | `gh stack switch`   | `switch` is menu-only            |
+| —                                         | `gh stack modify`   | TUI-only; no noninteractive path |
+
+`view --short` is safe but human-formatted; parse `--json`. Use current
+`gh stack <command> --help` for exact flags; `gh stack help <command>` only prints top-level help.
+
+## Create and submit
+
+Create one branch at a time while implementing dependent layers:
+
+```bash
 gh stack init --base <trunk> <bottom-branch>
-# implement, validate, stage deliberately, commit
+# edit, validate, stage deliberately, commit
 gh stack add <next-branch>
-# repeat per dependency layer
+# repeat
 gh stack submit --auto
 gh stack view --json
 ```
 
-- `init` can adopt existing branches when supplied bottom to top; inspect their ancestry first
-- Use ordinary `git add` and `git commit` so each layer receives only its concern
-- `submit --auto` creates drafts by default. Use `--open` only when validation and repository policy say the PRs are review-ready
-- After submit, verify every layer's branch, base, PR URL, draft state, and stack order; successful pushes alone do not prove correct linkage
+Or create/adopt a planned issue-batch chain upfront, bottom to top, before assigning its branches:
 
-### Continue or repair a stack
-
-When a higher layer reveals a lower-layer change:
-
-```sh
-gh stack checkout <lower-branch-or-pr>
-# edit, validate, commit
-gh stack rebase --upstack
-gh stack push
-gh stack view --json
+```bash
+gh stack init --base <trunk> <issue-branch-1> <issue-branch-2> <issue-branch-3>
 ```
 
-Put the fix in the lowest layer that owns it. Never hide a foundation change in a dependant PR. After any cascading rebase, verify the full upstack and push all rewritten branches together.
+`init` checks out the final branch. Existing branches are adopted; new ones are created in chain
+order. Inspect existing ancestry first. Use ordinary `git add` and `git commit` so each branch owns
+only its concern.
 
-For routine remote reconciliation:
+`submit --auto` pushes active branches, creates missing draft PRs with generated metadata, fixes
+their bases, and links them into a GitHub stack. Add `--open` only when they should leave draft
+state; use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic: rerun it after
+repairing a partial failure.
 
-```sh
+## Edit a lower layer
+
+```bash
+gh stack view --json
+gh stack down                    # or checkout the owning branch or PR
+# edit, validate, commit
+gh stack rebase --upstack
+gh stack top
+gh stack push
+```
+
+`push` updates active branches with per-branch force-with-lease and can partially succeed. Inspect
+remote heads after failure, repair the rejected branch, and rerun.
+
+## Synchronize
+
+```bash
 gh stack sync
 gh stack view --json
 ```
 
-`sync` fetches, reconciles stack membership, rebases, pushes, and updates remote stack state. Its divergence path may print `Sync aborted` while exiting successfully; treat that message as no-op, not success.
+`sync` fetches, reconciles GitHub stack membership, fast-forwards trunk, cascade-rebases, atomically
+pushes active branches, refreshes PR state, and updates the GitHub stack object. Add `--prune` only
+to delete local merged branches. On local/remote topology divergence it can print `Sync aborted`
+while exiting 0; that means no changes were made.
 
-### Link externally managed branches
+## Link externally managed branches
 
-Use `link` when another tool owns branch topology and only GitHub's native stack object is needed:
-
-```sh
+```bash
 gh stack link --base <trunk> <bottom-branch-or-pr> <next> [<top>...]
 ```
 
-Arguments are bottom to top. `link` may push branches, create PRs, correct PR bases, and alter remote stack membership; inspect before and verify after. Do not combine local `gh stack` ownership with jj, Sapling, git-town, or another stack manager accidentally.
+`link` creates or updates only the GitHub stack, with no local tracking state. It may push branch
+arguments, create PRs, and correct bases. Use it when another branch manager or worktree workflow
+owns topology; use `checkout <stack-or-pr>` later if local tracking is needed.
 
-### Merge
+## Merge
 
-GitHub merges a selected PR and every unmerged layer below it, bottom first. Merging the top lands the whole stack; merging a middle PR lands the bottom portion and leaves higher layers open for automatic retargeting.
+After the user explicitly approves the merge, scope it with a PR or stack number and state the
+method:
 
-Before an authorized merge:
+```bash
+gh stack merge <target> --yes --squash  # or --merge / --rebase
+```
 
-1. Inspect `gh stack view --json`
-2. For the selected PR and every unmerged layer below it, run `gh pr view <pr> --json isDraft,reviewDecision,statusCheckRollup,baseRefName,headRefName,mergeStateStatus`
-3. Confirm the intended highest PR, approvals, checks, draft state, merge method, and trunk
-4. Run `gh stack merge <stack-or-pr> --yes` with one of `--squash`, `--rebase`, or `--merge`
-5. Verify landed PRs and remaining layer bases. If a merge queue governs the trunk, report queued state rather than claiming merge completion
+A PR target merges that PR and every unmerged PR below it; a stack target merges the whole stack.
+Direct stack merges are all-or-nothing. A merge queue overrides the method and may land queued PRs
+in separate groups. Do not use `gh pr merge` for a native stack.
 
-Do not use `gh pr merge` for a native stack.
+## Machine-readable state
 
-## Recovery
+`gh stack view --json` writes JSON to stdout; status text goes to stderr. Its stable fields are:
 
-- **Stack support unavailable:** report the repository/rollout failure. Do not silently create ordinary chained PRs
-- **Rebase conflict:** inspect `git status` and conflict markers, resolve and stage only intended files, then `gh stack rebase --continue`. Use `--abort` when ownership or resolution is uncertain; verify every branch afterward
-- **Local/remote divergence:** preserve both states until choosing an authority. If remote wins and the tree is clean, remove only local tracking with `gh stack unstack --local`, then check out the remote stack. If local wins, remote `unstack` and reconstruction alter GitHub state; proceed only when that outcome is authorized
-- **Published restructure:** record PR numbers, branches, bases, and stack order first. `unstack` keeps PRs and branches but removes stack grouping. Rebuild remotely with `link`, or restore local tracking with `init` and then run `submit --auto`; `init` alone does not recreate GitHub's stack object. Verify every base and PR
-- **Checkout wants conflict resolution:** do not blindly discard local tracking. Inspect the mismatch; use `unstack --local` only after deciding GitHub is authoritative
-- **Partial push/submit:** these operations may update some branches before another fails. Inspect remote heads and PRs, repair the rejected branch, then rerun idempotently
-- **Authentication/API failure:** use `gh auth status`, preserve visible error details, and retry only after the permission or transient failure is resolved
+```text
+trunk           string
+currentBranch   string
+branches[]      name, head, base, isCurrent, isMerged, isQueued, needsRebase
+branches[].pr   number, url, state ("OPEN" | "MERGED" | "QUEUED"); absent without a PR
+```
 
-## Finish
+`base` is the saved parent SHA and can lag the parent's tip. `needsRebase` reports that the current
+parent tip is no longer an ancestor of the branch.
 
-Report the stack bottom to top, PR links, current branch, external operations performed, validation, and any conflict, divergence, queued state, or remaining review blocker. Do not narrate routine navigation.
+## Exit codes
+
+| Code | Meaning                  | Recovery                                                  |
+| ---- | ------------------------ | --------------------------------------------------------- |
+| 0    | Success                  | Check output: divergent `sync` can still abort            |
+| 1    | Generic error            | Read stderr                                               |
+| 2    | Not in a stack           | `init`, or `checkout <stack-or-pr>`                       |
+| 3    | Rebase conflict          | Resolve and stage, then `rebase --continue`; or `--abort` |
+| 4    | GitHub API failure       | Check `gh auth status`, then retry                        |
+| 5    | Invalid arguments        | Fix invocation from `<command> --help`                    |
+| 6    | Disambiguation required  | Use a branch unique to the intended stack                 |
+| 7    | Rebase already active    | `rebase --continue` or `--abort`                          |
+| 8    | Stack file locked        | Retry after the other process releases it                 |
+| 9    | Stacked PRs unavailable  | Report repository availability                            |
+| 10   | Modify recovery required | `gh stack modify --abort`                                 |
+
+After a failed `sync`, branches have already been restored; run `gh stack rebase` to recreate a
+conflict before resolving it.
+
+## References
+
+Open only what the task needs:
+
+- `references/stack-design.md` — planning layers, branch names, and release batches
+- `references/commands.md` — command preconditions, side effects, atomicity, and ordering
+- `references/troubleshooting.md` — conflicts, squash merges, divergence, restructuring, and
+  external branch managers

--- a/.pi/skills/gh-stack/references/commands.md
+++ b/.pi/skills/gh-stack/references/commands.md
@@ -1,0 +1,179 @@
+# Command behavior
+
+`gh stack <command> --help` is authoritative for flags and arguments. (`gh stack help <command>` only prints the top-level help.) This file only covers behavior `--help` does not
+explain: preconditions, side effects, atomicity, and failure modes.
+
+## Contents
+
+- [init](#init)
+- [add](#add)
+- [push](#push)
+- [submit](#submit)
+- [link](#link)
+- [sync](#sync)
+- [rebase](#rebase)
+- [view](#view)
+- [checkout](#checkout)
+- [unstack](#unstack)
+- [merge](#merge)
+- [Navigation](#navigation)
+
+## init
+
+Creates the stack and checks out the **last** branch in the list, so a single `init` can lay down
+the whole chain: `gh stack init auth api frontend`.
+
+`init` processes branch arguments from bottom to top. Existing branches are adopted. If the first
+branch does not exist, it is created from the trunk; each later new branch is created from the
+branch immediately before it. There is no separate adopt mode — existence decides. `--base`
+selects a non-default trunk.
+
+`init` also enables `git rerere`. Under a TTY the first run in a repo asks for confirmation; set
+`git config rerere.enabled true` beforehand to skip it.
+
+## add
+
+- **Must run from the top branch** of the stack (or the trunk when the stack is still empty).
+  Anywhere else it exits **5** with `can only add branches on top of the stack`. Run `gh stack top`
+  first.
+- **Uncommitted changes carry over.** Without `-Am`, `add` does not touch the working tree, so
+  staged and unstaged changes follow you onto the new branch. Commit or stash first for a clean start.
+- **`add -Am` commits in place when the current branch has no commits yet** — for example
+  immediately after `init` — instead of creating a branch. This is deliberate: the first layer
+  usually needs its content before a second layer exists.
+- `-A` and `-u` are mutually exclusive, and both require `-m`.
+
+## push
+
+Pushes every active (non-merged, non-queued) branch in one multi-ref push with per-branch
+`--force-with-lease`.
+
+**Not atomic.** Some branches may update while another is rejected. A rejection means that branch
+moved on the remote; fix that branch and rerun — rerunning is safe and skips what already landed.
+
+`push` never creates or updates pull requests. Use `submit` for that.
+
+## submit
+
+Pushes each active branch, then creates a PR for every branch that lacks one, basing it on the
+first non-merged ancestor, then links them into a Stack on GitHub.
+
+- **Not atomic.** Branches are pushed sequentially with per-branch `--force-with-lease`. If a later
+  push is rejected, earlier pushes and PR updates stand. Fix the rejection and rerun the same command.
+- **A fully merged stack cannot be extended.** When every PR in the current stack is already merged,
+  `submit` forks the remaining unmerged branches into a **new** stack rooted at the trunk and creates
+  it on GitHub, leaving the merged stack untouched.
+- **Title generation with `--auto`:** a branch with a single commit uses that commit's subject as
+  the title and its body as the PR body. A branch with multiple commits humanizes the branch name
+  (hyphens and underscores become spaces). There is no flag for a custom title or body; use
+  `gh pr edit` afterwards.
+- `--open` marks new _and existing_ PRs ready for review; without it new PRs are drafts.
+- Requires stacked PRs to be enabled on the repository. If not, `submit` exits **9** when
+  non-interactive (under a TTY it offers to create ordinary unstacked PRs instead).
+
+## link
+
+Creates or updates a stack on GitHub **without any local tracking state**. This is the path for
+branches managed by another tool or living in another worktree — see `troubleshooting.md`.
+
+- Arguments are given bottom to top. Each is a branch name or a PR number; a numeric argument is
+  tried as a PR number first and falls back to a branch name.
+- **A numeric first argument is treated as a stack number only when a stack with that number
+  exists.** In that case the remaining arguments are appended to the top of that stack and you do
+  not re-list its current PRs: `gh stack link 7 feature-c`. Arguments already in the stack are
+  skipped; arguments belonging to a different stack are rejected.
+- Branch arguments are pushed automatically (non-force, atomic). Missing PRs are created with
+  auto-generated titles and correctly chained bases; existing PRs with a wrong base are corrected.
+- Stack membership is **additive only** — `link` never removes a PR from a stack.
+
+## sync
+
+The routine command. Steps, in order:
+
+1. **Fetch** from the remote.
+2. **Reconcile with the GitHub stack.** PRs added to the stack on github.com are pulled down and
+   appended locally. On divergence, aborts when non-interactive (see `troubleshooting.md`).
+3. **Fast-forward the trunk.** Skipped when already current; warns when diverged.
+4. **Cascade rebase when needed.** This runs if the trunk moved, a stack branch was fast-forwarded
+   from its remote, or a branch no longer contains its expected parent. Merged PRs are handled
+   automatically. On conflict, **all branches are restored** to their pre-rebase state and the
+   command exits **3**.
+5. **Push** all active branches, atomically.
+6. **Refresh PR state** from GitHub.
+7. **Sync the stack object** — link open PRs into a stack, additively. Only when two or more PRs
+   exist. `sync` never opens PRs; that is `submit`.
+8. **Prune** local branches for merged PRs, only when `--prune` is passed in a non-interactive
+   environment.
+
+## rebase
+
+Pulls from the remote and cascade-rebases. Use it when `sync` reported a conflict or when you need
+to rebase only part of the stack.
+
+- `--upstack` rebases from the current branch to the top. This is what you run after editing a
+  lower layer.
+- `--downstack` rebases from the trunk to the current branch.
+- `--no-trunk` skips fetching and the trunk rebase entirely, aligning stack branches with each
+  other only.
+- `--continue` after staging resolutions; `--abort` restores every branch.
+- A merged PR is detected automatically and replayed with `--onto` against the correct target, so a
+  squash-merged parent does not produce spurious conflicts.
+- Starting a rebase while one is in progress exits **7**.
+
+## view
+
+- `--json` writes the machine-readable payload to stdout. Its schema is in `SKILL.md`.
+- Bare `view` opens a full-screen TUI when stdout is a TTY, and prints static text when piped.
+- `--short` prints a compact one-line-per-branch summary and never opens the TUI, but it is
+  formatted for humans; parse `--json` instead.
+- `view` refreshes PR state from GitHub as a side effect, best-effort — it does not fail when the
+  API is unreachable.
+
+## checkout
+
+Accepts a stack number, PR number, PR URL, or branch name.
+
+- A bare number resolves as a **stack number first**, then a PR number, then a branch name.
+- Stack numbers, PR numbers, and PR URLs fetch from GitHub, pull the branches down, and set the
+  stack up locally.
+- A **branch name resolves against locally tracked stacks only** and never contacts GitHub. Use a
+  stack or PR number to pull a stack that is not tracked locally.
+- If a local stack already exists over those branches with a different composition, `checkout`
+  cannot be forced past it. Run `gh stack unstack --local` first, then retry.
+- `checkout` has no flags. It relies on `remote.pushDefault` when several remotes exist.
+
+## unstack
+
+Removes the stack **grouping** only. It never deletes pull requests or branches.
+
+- With no argument it targets the active stack — the one containing the current branch — removing
+  it on GitHub and locally.
+- With a stack number it works from anywhere in the repository, tracked locally or not, via the API.
+  Local tracking is also removed when present.
+- `--local` removes local tracking only and never contacts GitHub. Combining `--local` with a stack
+  number that is not tracked locally is an error.
+- An unknown stack number exits **2**.
+
+## merge
+
+- Scope with an argument: pass a PR number to merge that PR and every unmerged PR below it in the
+  stack, or pass a stack number to merge every unmerged PR in that stack.
+- **All-or-nothing.** If any PR in that exact merge set cannot be merged, none are, and the reason
+  is reported.
+- The method comes from `--squash`, `--rebase`, `--merge`, or `--merge-method <method>`. Without
+  one, the last-used method is reused.
+- Only basic PR state is checked before merging: open and not a draft. Bypassing merge requirements
+  is not supported for stacks.
+- **A merge queue on the base branch overrides everything.** The stack is added to the queue rather
+  than merged; the queue chooses the method and any method flag you passed is ignored with a
+  warning. Queued PRs are submitted together but land as the queue processes them, so they may merge
+  in separate groups rather than all at once.
+- `gh pr merge` cannot merge a stack. Always use `gh stack merge`.
+
+## Navigation
+
+`up`, `down`, `top`, `bottom`, and `trunk` are always non-interactive. `up` and `down` accept a
+count (`gh stack up 3`). Movement clamps at the stack bounds, and merged branches are skipped when
+navigating from an active branch, so `bottom` lands on the lowest _unmerged_ branch.
+
+`gh stack switch` is a selection menu with no non-interactive path. Use the commands above instead.

--- a/.pi/skills/gh-stack/references/commands.md
+++ b/.pi/skills/gh-stack/references/commands.md
@@ -33,15 +33,11 @@ selects a non-default trunk.
 
 ## add
 
-- **Must run from the top branch** of the stack (or the trunk when the stack is still empty).
-  Anywhere else it exits **5** with `can only add branches on top of the stack`. Run `gh stack top`
-  first.
-- **Uncommitted changes carry over.** Without `-Am`, `add` does not touch the working tree, so
-  staged and unstaged changes follow you onto the new branch. Commit or stash first for a clean start.
-- **`add -Am` commits in place when the current branch has no commits yet** — for example
-  immediately after `init` — instead of creating a branch. This is deliberate: the first layer
-  usually needs its content before a second layer exists.
-- `-A` and `-u` are mutually exclusive, and both require `-m`.
+- Extend a stack from its top branch; a middle branch exits **5**. Use `gh stack top` first.
+- **Uncommitted changes carry over.** Without `-A`, `-u`, or `-m`, `add` does not touch the working
+  tree, so staged and unstaged changes follow onto the new branch. Commit or stash for a clean start.
+- Avoid the `-A`, `-u`, and `-m` commit shortcuts: they can open an editor or commit in place on an
+  empty current layer. Stage and commit with Git, then run `add <branch>`.
 
 ## push
 
@@ -56,7 +52,7 @@ moved on the remote; fix that branch and rerun — rerunning is safe and skips w
 ## submit
 
 Pushes each active branch, then creates a PR for every branch that lacks one, basing it on the
-first non-merged ancestor, then links them into a Stack on GitHub.
+first active ancestor (skipping merged and queued ancestors), then links them into a Stack on GitHub.
 
 - **Not atomic.** Branches are pushed sequentially with per-branch `--force-with-lease`. If a later
   push is rejected, earlier pushes and PR updates stand. Fix the rejection and rerun the same command.
@@ -68,6 +64,7 @@ first non-merged ancestor, then links them into a Stack on GitHub.
   (hyphens and underscores become spaces). There is no flag for a custom title or body; use
   `gh pr edit` afterwards.
 - `--open` marks new _and existing_ PRs ready for review; without it new PRs are drafts.
+- Read base-mismatch warnings; a remote stack can prevent `submit` from repairing an existing PR.
 - Requires stacked PRs to be enabled on the repository. If not, `submit` exits **9** when
   non-interactive (under a TTY it offers to create ordinary unstacked PRs instead).
 
@@ -140,7 +137,7 @@ Accepts a stack number, PR number, PR URL, or branch name.
   stack or PR number to pull a stack that is not tracked locally.
 - If a local stack already exists over those branches with a different composition, `checkout`
   cannot be forced past it. Run `gh stack unstack --local` first, then retry.
-- `checkout` has no flags. It relies on `remote.pushDefault` when several remotes exist.
+- `checkout` has no flags. Configure one unambiguous remote when several exist.
 
 ## unstack
 
@@ -172,8 +169,8 @@ Removes the stack **grouping** only. It never deletes pull requests or branches.
 
 ## Navigation
 
-`up`, `down`, `top`, `bottom`, and `trunk` are always non-interactive. `up` and `down` accept a
-count (`gh stack up 3`). Movement clamps at the stack bounds, and merged branches are skipped when
-navigating from an active branch, so `bottom` lands on the lowest _unmerged_ branch.
+`up`, `down`, `top`, `bottom`, and `trunk` are always noninteractive. `up` and `down` accept a count
+(`gh stack up 3`) and navigate active layers; `top` means the literal top. Use explicit `checkout`
+when merged or queued layers make the target important.
 
 `gh stack switch` is a selection menu with no non-interactive path. Use the commands above instead.

--- a/.pi/skills/gh-stack/references/stack-design.md
+++ b/.pi/skills/gh-stack/references/stack-design.md
@@ -1,0 +1,99 @@
+# Designing a stack
+
+How to decide what goes in each layer. Read this before running `gh stack init`.
+
+## Contents
+
+- [Plan the layers before writing code](#plan-the-layers-before-writing-code)
+- [Branch naming](#branch-naming)
+- [Staging changes deliberately](#staging-changes-deliberately)
+- [When to add a layer](#when-to-add-a-layer)
+- [One stack, one landing unit](#one-stack-one-landing-unit)
+
+## Plan the layers before writing code
+
+A stack is a linear landing chain. Usually it follows code dependencies; it can also order bounded
+issue PRs that repository policy deliberately ships as one release batch. If code in one layer
+depends on another, the dependency must live in the same branch or a lower one. Plan before writing:
+there is no noninteractive in-place reorder, so fixing the order means `unstack` and `init` again.
+
+Decide the layers first, then write code into them:
+
+```
+(main) <- todo-app/models <- todo-app/api <- todo-app/frontend <- todo-app/integration
+```
+
+- `todo-app/models` — shared types and schema
+- `todo-app/api` — routes that use the models
+- `todo-app/frontend` — components that call the routes
+- `todo-app/integration` — tests exercising the whole feature
+
+This is illustrative. Infer the stack topic and layer names from the actual task; do not reuse
+`todo-app` or these layer names literally.
+
+The failure mode to avoid is writing everything on one branch and trying to split it afterwards.
+If a task is large enough to warrant a stack, create the stack at the start.
+
+## Branch naming
+
+Prefer a shared topic prefix plus the layer's concern:
+`<topic>/<concern>` — for example, `billing/schema`, `billing/api`, `billing/ui`.
+This keeps related branches recognizable without using generic names that could belong to any
+stack. **User and repository branch naming conventions take precedence; follow them instead.**
+
+Names are used exactly as given — nothing is prepended or transformed, and slashes are kept, so
+`gh stack add refactor/foo` creates a branch literally named `refactor/foo`.
+
+If you pass `-m` without a branch name, the name is generated from the commit message in
+date-and-slug form (for example `03-24-add_api_routes`). Prefer naming the branch yourself.
+
+## Staging changes deliberately
+
+Use `git add` and `git commit` directly rather than the `add -Am` shortcut. The point is control
+over which changes land in which branch. With several modified files in the working tree, stage the
+subset that belongs to the current layer, commit it, then create the next branch and stage the rest
+there:
+
+```bash
+git add internal/models/user.go internal/models/session.go
+git commit -m "Add user and session models"
+
+gh stack add api-routes
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+```
+
+Multiple commits per branch are fine. What matters is that every commit in a branch serves the same
+concern, and that a change belonging to a different concern goes in a different branch.
+
+Note that `gh stack add <branch>` without `-Am` does not touch the working tree, so uncommitted
+changes carry over to the new branch. Commit or stash first if you want the new layer to start clean.
+
+## When to add a layer
+
+Add a branch when you start a **different concern that depends on what you have built so far**.
+Signals:
+
+- Moving from backend to frontend, or from core logic to tests or documentation
+- The next changes have a different reviewer audience
+- The current branch's diff is already large enough to review on its own
+
+A layer that cannot be described in one sentence is usually two layers.
+
+## One stack, one landing unit
+
+A stack needs one coherent landing reason. A reviewer should be able to walk its PRs bottom to top
+and understand why they merge together.
+
+**Use a single stack** when every branch serves the same feature or when explicit repository policy
+bundles several bounded issues into one release. In an issue batch, give each issue a focused layer,
+order shared foundations and overlapping surfaces first, and reserve the top layer for any shared
+integration or release artifact. Lack of a code dependency does not disqualify an issue from an
+explicit shared release batch.
+
+**Start a separate stack** when work should land or release independently. Do not mix efforts merely
+because they happened concurrently. Use `gh stack init` for the new effort, or
+`gh stack checkout <target>` to move between existing stacks.
+
+A trivial incidental fix can ride along in the current stack. Once it grows into its own project, it
+deserves its own stack.

--- a/.pi/skills/gh-stack/references/stack-design.md
+++ b/.pi/skills/gh-stack/references/stack-design.md
@@ -66,8 +66,8 @@ git commit -m "Add user API routes"
 Multiple commits per branch are fine. What matters is that every commit in a branch serves the same
 concern, and that a change belonging to a different concern goes in a different branch.
 
-Note that `gh stack add <branch>` without `-Am` does not touch the working tree, so uncommitted
-changes carry over to the new branch. Commit or stash first if you want the new layer to start clean.
+`gh stack add <branch>` does not touch the working tree, so uncommitted changes carry over. Commit
+or stash first if the new layer should start clean.
 
 ## When to add a layer
 

--- a/.pi/skills/gh-stack/references/troubleshooting.md
+++ b/.pi/skills/gh-stack/references/troubleshooting.md
@@ -1,0 +1,159 @@
+# Troubleshooting and recovery
+
+## Contents
+
+- [Rebase conflicts (exit 3)](#rebase-conflicts-exit-3)
+- [After a squash merge](#after-a-squash-merge)
+- [Local and remote stacks have diverged](#local-and-remote-stacks-have-diverged)
+- [Restructuring a stack](#restructuring-a-stack)
+- [Branch belongs to several stacks (exit 6)](#branch-belongs-to-several-stacks-exit-6)
+- [Driving stacks from another tool or worktree](#driving-stacks-from-another-tool-or-worktree)
+- [Stack file is locked (exit 8)](#stack-file-is-locked-exit-8)
+- [An interrupted modify session (exit 10)](#an-interrupted-modify-session-exit-10)
+
+## Rebase conflicts (exit 3)
+
+`rebase` and `sync` both exit 3 on conflict. `sync` restores every branch to its pre-rebase state
+first, so a failed `sync` leaves nothing half-applied; a failed `rebase` stops mid-flight and waits.
+
+```bash
+gh stack rebase
+# exit 3 — conflicted paths are listed on stderr
+git add <resolved paths>
+gh stack rebase --continue     # repeat if the next branch also conflicts
+```
+
+`gh stack rebase --abort` restores every branch in the stack, not just the current one.
+
+Because `init` enables `git rerere`, a conflict you resolve once is replayed automatically the next
+time the same conflict appears — which is common, since a change low in the stack is rebased through
+every branch above it. Without `rerere`, repeated conflicts may need manual resolution on each
+affected layer.
+
+## After a squash merge
+
+A squash merge replaces the branch's commits with one new commit, so the originals no longer exist
+in the trunk's history and an ordinary rebase would try to replay them again.
+
+`gh stack sync` detects this and rebases with `--onto` against the correct target, skipping the
+merged branch:
+
+```bash
+gh stack sync
+gh stack view --json    # merged branch reports "isMerged": true, "state": "MERGED"
+```
+
+No manual action is needed. If the replay conflicts, `sync` restores all branches and exits 3.
+Run `gh stack rebase` to rerun the rebase, which will stop at the conflict and allow you to resolve
+and then `--continue` until complete. Use `gh stack sync --prune` to also delete local branches for
+merged PRs.
+
+## Local and remote stacks have diverged
+
+Divergence means the local stack and the stack on GitHub changed in different ways — for example
+branches were added locally while a PR was added to the stack on github.com.
+
+When non-interactive, `sync` prints both chains, changes nothing, and exits **0** with
+`Sync aborted`. Success here does not mean the sync happened; check for that message, or re-run
+`gh stack view --json` and compare.
+
+Two resolution paths:
+
+- **Keep the remote version.** Drop local tracking and pull the stack back down.
+
+  ```bash
+  gh stack unstack --local          # keeps the stack on GitHub
+  gh stack checkout <stack-number>  # or a PR number
+  ```
+
+- **Keep the local version.** Remove the grouping on GitHub, then recreate it from local state.
+
+  ```bash
+  gh stack unstack                  # removes the grouping; PRs and branches survive
+  gh stack submit --auto
+  ```
+
+Neither path deletes pull requests or branches.
+Remote unstacking leaves PRs that are merging (auto-merge enabled) or are queued (in a merge queue)
+stacked. If needed, clear that state before retrying.
+
+## Restructuring a stack
+
+There is no non-interactive reorder, rename, or removal. `add` run from the wrong branch suggests
+`gh stack modify`, but that is TUI-only. Tear the stack down and rebuild it instead:
+
+```bash
+gh stack unstack                       # removes local tracking and the GitHub grouping
+# Rename or drop branches, and rewrite ancestry as needed.
+gh stack init --base main branch-1 branch-2 branch-3
+gh stack submit --auto                 # re-link on GitHub
+```
+
+`init` adopts branches that already exist, so the rebuild reuses them rather than creating new ones.
+Existing PRs survive. Once Git ancestry is correct, `submit` updates their base branches and
+re-links the stack on GitHub.
+
+Changing metadata does **not** change Git ancestry. Reorder commits first, then rebuild the stack.
+For example, to change `main <- models <- migration <- ui` into
+`main <- migration <- models <- ui`:
+
+```bash
+old_models=$(git rev-parse models)
+old_migration=$(git rev-parse migration)
+git rebase --onto main "$old_models" migration
+git rebase --onto migration main models
+git rebase --onto models "$old_migration" ui
+gh stack unstack
+gh stack init --base main migration models ui
+```
+
+The first rebase moves migration-only commits onto trunk, the second replays model commits above
+them, and the third replays UI-only commits above models. Preserve the old boundary SHAs before
+moving any branch. For a different reorder, identify each layer's range with
+`git log <old-parent>..<branch>`, then replay the ranges bottom to top.
+
+## Branch belongs to several stacks (exit 6)
+
+Commands exit 6 when the current branch cannot identify a single stack — typically because it is the
+trunk of more than one stack. There is no flag to disambiguate.
+
+```bash
+gh stack checkout <a-branch-unique-to-the-intended-stack>
+```
+
+Then rerun. Commands that take an explicit stack number (`merge 7`, `unstack 7`) sidestep the
+problem entirely, since they do not infer the stack from the current branch.
+
+## Driving stacks from another tool or worktree
+
+`gh stack link` creates and updates stacks purely through the API, with no local tracking state.
+Use it when branches are managed by jj, Sapling, git-town, a separate worktree, or any workflow
+where the local `.git/gh-stack` file would be wrong or absent.
+
+```bash
+gh stack link branch-a branch-b branch-c        # bottom to top
+gh stack link --base develop --open a b c       # non-default trunk, ready for review
+gh stack link 10 20 30                          # by PR number
+gh stack link 7 feature-d                       # append to existing stack #7
+```
+
+Because `link` writes no local state, the local navigation commands (`up`, `down`, `top`, `bottom`)
+will not work on the result. Use `gh stack checkout <stack-number>` if you later want local tracking.
+
+## Stack file is locked (exit 8)
+
+Another `gh stack` process holds the exclusive lock on `.git/gh-stack.lock`. The lock times out
+after about five seconds, so wait and retry. A persistent exit 8 means another process still holds
+the lock; identify and stop that process before retrying.
+
+## An interrupted modify session (exit 10)
+
+`gh stack modify` is TUI-only and should never be invoked by an agent. If a repository is left in
+this state by someone else, restore it:
+
+```bash
+gh stack modify --abort
+```
+
+Related: `submit` also detects a pending modify state, and under a TTY asks before overwriting the
+stack on GitHub with local state.

--- a/.pi/skills/gh-stack/references/troubleshooting.md
+++ b/.pi/skills/gh-stack/references/troubleshooting.md
@@ -69,7 +69,9 @@ Two resolution paths:
 - **Keep the local version.** Remove the grouping on GitHub, then recreate it from local state.
 
   ```bash
-  gh stack unstack                  # removes the grouping; PRs and branches survive
+  # First record trunk and every branch bottom to top.
+  gh stack unstack                  # removes remote and local grouping; PRs and branches survive
+  gh stack init --base <trunk> <bottom-branch> <next-branch> [<top-branch>...]
   gh stack submit --auto
   ```
 
@@ -133,7 +135,7 @@ where the local `.git/gh-stack` file would be wrong or absent.
 ```bash
 gh stack link branch-a branch-b branch-c        # bottom to top
 gh stack link --base develop --open a b c       # non-default trunk, ready for review
-gh stack link 10 20 30                          # by PR number
+gh stack link <pr-url-1> <pr-url-2> <pr-url-3>  # explicit PRs, bottom to top
 gh stack link 7 feature-d                       # append to existing stack #7
 ```
 

--- a/packages/pi-skill-gh-stack/LICENSE
+++ b/packages/pi-skill-gh-stack/LICENSE
@@ -1,1 +1,21 @@
-MIT
+MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-skill-gh-stack/skills/gh-stack/SKILL.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/SKILL.md
@@ -39,8 +39,8 @@ git config rerere.enabled true
 The contracts below target `gh stack` v0.1.0. If the installed version differs, current command
 help wins.
 
-With several remotes, pass `--remote <name>` where supported. Commands without that flag require
-an unambiguous repository-local `remote.pushDefault`.
+With several remotes, pass `--remote <name>` where supported or configure one unambiguous remote
+before noninteractive use.
 
 ## Noninteractive use
 
@@ -84,10 +84,10 @@ gh stack init --base <trunk> <issue-branch-1> <issue-branch-2> <issue-branch-3>
 order. Inspect existing ancestry first. Use ordinary `git add` and `git commit` so each branch owns
 only its concern.
 
-`submit --auto` pushes active branches, creates missing draft PRs with generated metadata, fixes
-their bases, and links them into a GitHub stack. Add `--open` only when they should leave draft
-state; use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic: rerun it after
-repairing a partial failure.
+`submit --auto` pushes active branches, creates missing PRs as drafts, updates existing PRs where
+possible, and links them into a GitHub stack. Read its warnings. Add `--open` only when PRs should
+leave draft state, and use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic;
+rerun it after a partial failure.
 
 ## Edit a lower layer
 

--- a/packages/pi-skill-gh-stack/skills/gh-stack/SKILL.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/SKILL.md
@@ -1,121 +1,181 @@
 ---
 name: gh-stack
-description: "Native GitHub stacked-PR workflow via gh stack: plan dependent layers; create, submit, inspect, sync, rebase, restructure, and merge stacks. Use for explicit stacked PRs, stacked diffs, or gh stack work; not ordinary or independent PRs."
+description: "Operate native GitHub stacked PRs with gh stack: design layers, create or adopt stacks, submit, inspect, sync, rebase, restructure, and merge. Use for explicit stacks, dependent PRs, or issue batches intended to land as one release unit; not ordinary PR work."
 license: MIT
-compatibility: "Requires authenticated GitHub CLI and the github/gh-stack extension; same-repository branches only"
+compatibility: "Requires authenticated GitHub CLI and the github/gh-stack extension"
 ---
 
-# GitHub stacked PRs
+# gh-stack
 
-## Guardrails
-
-- Repository instructions and explicit user direction override this skill
-- Use a stack only for a linear dependency chain. Keep independent changes in independent PRs; do not manufacture layers merely to shrink a diff
-- Order layers bottom to top: foundations before dependants. Each layer must be cohesive and reviewable against the branch below it
-- Inspect the working tree, remotes, trunk, current branch, existing PRs, and stack state before branch or history operations. Keep unrelated changes out
-- Stacks require branches in one repository. Do not substitute a native stack for fork-based contribution work
-- Cascading rebases rewrite every affected upstack branch. Do not rewrite shared or ambiguously owned branches without agreement
-- Treat `submit`, `link`, `sync`, `push`, `unstack`, and `merge` as external writes. Infer authorization from a requested stacked-PR outcome, but never merge merely because a stack is ready
-
-## Runtime contract
-
-1. Run `gh stack --version`. If unavailable, install with `gh extension install github/gh-stack`, then retry
-2. Use current `gh stack <command> --help` for exact flags when the installed version may differ from this skill
-3. Keep agent calls noninteractive:
-   - name every branch passed to `init` or `add`
-   - use `gh stack submit --auto`; add `--open` only when PRs should leave draft state
-   - inspect with `gh stack view --json` for machine decisions or `--short` for concise display
-   - give `checkout` a stack number, PR number/URL, or branch
-   - do not use interactive `modify` or `switch`
-   - use `gh stack merge ... --yes` with an explicit merge method when merging is authorized
-4. With multiple remotes, pass `--remote <name>` where supported and set repository-local `remote.pushDefault` only when commands without that flag need an unambiguous remote
-5. If `rerere.enabled` is unset before `init`, set it repository-locally to `true` so initialization and repeated conflict resolution stay noninteractive
-
-## Workflow
-
-### Plan
-
-Write the intended chain before creating branches:
+A stack is a trunk-rooted branch chain. Each branch has a PR based on the branch below it, so its
+diff shows only that layer. `gh stack` prints trunk first:
 
 ```text
-trunk <- foundation <- dependent change <- integration
+(main) <- auth <- api <- frontend
 ```
 
-Split at a dependency or review boundary, not by file count. If layer B can land without layer A, it probably belongs in another PR or stack.
+Left is the **bottom** and merges first; right is the **top** and merges last. `up` moves away from
+trunk; `down` moves toward it.
 
-### Create and submit
+## Rules
 
-```sh
+- Repository instructions and explicit user direction override this skill.
+- **Never merge a stack without explicit user approval.** Readiness, green checks, or a prior submit
+  request is not merge authorization.
+- Stacks are linear. A layer may represent a code dependency or one bounded issue in an explicitly
+  shared release batch. Keep work outside that release unit in another stack or PR.
+- Create the chain before implementation. Put each change on the lowest layer that owns it; edit a
+  lower owner, cascade-rebase upstack, then return to the top.
+
+Read `references/stack-design.md` before choosing layers.
+
+## Setup
+
+```bash
+gh stack --version || { gh extension install github/gh-stack && gh stack --version; }
+git config rerere.enabled true
+```
+
+The contracts below target `gh stack` v0.1.0. If the installed version differs, current command
+help wins.
+
+With several remotes, pass `--remote <name>` where supported. Commands without that flag require
+an unambiguous repository-local `remote.pushDefault`.
+
+## Noninteractive use
+
+`gh stack` treats terminal stdout as interactive. Run it **without a PTY**: under a PTY, bare
+commands may prompt or open a full-screen TUI. Still use explicit arguments and flags:
+
+| Run                                       | Never run bare      | Why                              |
+| ----------------------------------------- | ------------------- | -------------------------------- |
+| `gh stack view --json`                    | `gh stack view`     | bare view opens a TUI            |
+| `gh stack submit --auto`                  | `gh stack submit`   | prompts for each new PR title    |
+| `gh stack merge <target> --yes --squash`  | `gh stack merge`    | prompts for scope and method     |
+| `gh stack init <branch>...`               | `gh stack init`     | prompts for branch names         |
+| `gh stack add <branch>`                   | `gh stack add`      | prompts for a name               |
+| `gh stack checkout <target>`              | `gh stack checkout` | opens a selection menu           |
+| `gh stack up` / `down` / `top` / `bottom` | `gh stack switch`   | `switch` is menu-only            |
+| —                                         | `gh stack modify`   | TUI-only; no noninteractive path |
+
+`view --short` is safe but human-formatted; parse `--json`. Use current
+`gh stack <command> --help` for exact flags; `gh stack help <command>` only prints top-level help.
+
+## Create and submit
+
+Create one branch at a time while implementing dependent layers:
+
+```bash
 gh stack init --base <trunk> <bottom-branch>
-# implement, validate, stage deliberately, commit
+# edit, validate, stage deliberately, commit
 gh stack add <next-branch>
-# repeat per dependency layer
+# repeat
 gh stack submit --auto
 gh stack view --json
 ```
 
-- `init` can adopt existing branches when supplied bottom to top; inspect their ancestry first
-- Use ordinary `git add` and `git commit` so each layer receives only its concern
-- `submit --auto` creates drafts by default. Use `--open` only when validation and repository policy say the PRs are review-ready
-- After submit, verify every layer's branch, base, PR URL, draft state, and stack order; successful pushes alone do not prove correct linkage
+Or create/adopt a planned issue-batch chain upfront, bottom to top, before assigning its branches:
 
-### Continue or repair a stack
-
-When a higher layer reveals a lower-layer change:
-
-```sh
-gh stack checkout <lower-branch-or-pr>
-# edit, validate, commit
-gh stack rebase --upstack
-gh stack push
-gh stack view --json
+```bash
+gh stack init --base <trunk> <issue-branch-1> <issue-branch-2> <issue-branch-3>
 ```
 
-Put the fix in the lowest layer that owns it. Never hide a foundation change in a dependant PR. After any cascading rebase, verify the full upstack and push all rewritten branches together.
+`init` checks out the final branch. Existing branches are adopted; new ones are created in chain
+order. Inspect existing ancestry first. Use ordinary `git add` and `git commit` so each branch owns
+only its concern.
 
-For routine remote reconciliation:
+`submit --auto` pushes active branches, creates missing draft PRs with generated metadata, fixes
+their bases, and links them into a GitHub stack. Add `--open` only when they should leave draft
+state; use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic: rerun it after
+repairing a partial failure.
 
-```sh
+## Edit a lower layer
+
+```bash
+gh stack view --json
+gh stack down                    # or checkout the owning branch or PR
+# edit, validate, commit
+gh stack rebase --upstack
+gh stack top
+gh stack push
+```
+
+`push` updates active branches with per-branch force-with-lease and can partially succeed. Inspect
+remote heads after failure, repair the rejected branch, and rerun.
+
+## Synchronize
+
+```bash
 gh stack sync
 gh stack view --json
 ```
 
-`sync` fetches, reconciles stack membership, rebases, pushes, and updates remote stack state. Its divergence path may print `Sync aborted` while exiting successfully; treat that message as no-op, not success.
+`sync` fetches, reconciles GitHub stack membership, fast-forwards trunk, cascade-rebases, atomically
+pushes active branches, refreshes PR state, and updates the GitHub stack object. Add `--prune` only
+to delete local merged branches. On local/remote topology divergence it can print `Sync aborted`
+while exiting 0; that means no changes were made.
 
-### Link externally managed branches
+## Link externally managed branches
 
-Use `link` when another tool owns branch topology and only GitHub's native stack object is needed:
-
-```sh
+```bash
 gh stack link --base <trunk> <bottom-branch-or-pr> <next> [<top>...]
 ```
 
-Arguments are bottom to top. `link` may push branches, create PRs, correct PR bases, and alter remote stack membership; inspect before and verify after. Do not combine local `gh stack` ownership with jj, Sapling, git-town, or another stack manager accidentally.
+`link` creates or updates only the GitHub stack, with no local tracking state. It may push branch
+arguments, create PRs, and correct bases. Use it when another branch manager or worktree workflow
+owns topology; use `checkout <stack-or-pr>` later if local tracking is needed.
 
-### Merge
+## Merge
 
-GitHub merges a selected PR and every unmerged layer below it, bottom first. Merging the top lands the whole stack; merging a middle PR lands the bottom portion and leaves higher layers open for automatic retargeting.
+After the user explicitly approves the merge, scope it with a PR or stack number and state the
+method:
 
-Before an authorized merge:
+```bash
+gh stack merge <target> --yes --squash  # or --merge / --rebase
+```
 
-1. Inspect `gh stack view --json`
-2. For the selected PR and every unmerged layer below it, run `gh pr view <pr> --json isDraft,reviewDecision,statusCheckRollup,baseRefName,headRefName,mergeStateStatus`
-3. Confirm the intended highest PR, approvals, checks, draft state, merge method, and trunk
-4. Run `gh stack merge <stack-or-pr> --yes` with one of `--squash`, `--rebase`, or `--merge`
-5. Verify landed PRs and remaining layer bases. If a merge queue governs the trunk, report queued state rather than claiming merge completion
+A PR target merges that PR and every unmerged PR below it; a stack target merges the whole stack.
+Direct stack merges are all-or-nothing. A merge queue overrides the method and may land queued PRs
+in separate groups. Do not use `gh pr merge` for a native stack.
 
-Do not use `gh pr merge` for a native stack.
+## Machine-readable state
 
-## Recovery
+`gh stack view --json` writes JSON to stdout; status text goes to stderr. Its stable fields are:
 
-- **Stack support unavailable:** report the repository/rollout failure. Do not silently create ordinary chained PRs
-- **Rebase conflict:** inspect `git status` and conflict markers, resolve and stage only intended files, then `gh stack rebase --continue`. Use `--abort` when ownership or resolution is uncertain; verify every branch afterward
-- **Local/remote divergence:** preserve both states until choosing an authority. If remote wins and the tree is clean, remove only local tracking with `gh stack unstack --local`, then check out the remote stack. If local wins, remote `unstack` and reconstruction alter GitHub state; proceed only when that outcome is authorized
-- **Published restructure:** record PR numbers, branches, bases, and stack order first. `unstack` keeps PRs and branches but removes stack grouping. Rebuild remotely with `link`, or restore local tracking with `init` and then run `submit --auto`; `init` alone does not recreate GitHub's stack object. Verify every base and PR
-- **Checkout wants conflict resolution:** do not blindly discard local tracking. Inspect the mismatch; use `unstack --local` only after deciding GitHub is authoritative
-- **Partial push/submit:** these operations may update some branches before another fails. Inspect remote heads and PRs, repair the rejected branch, then rerun idempotently
-- **Authentication/API failure:** use `gh auth status`, preserve visible error details, and retry only after the permission or transient failure is resolved
+```text
+trunk           string
+currentBranch   string
+branches[]      name, head, base, isCurrent, isMerged, isQueued, needsRebase
+branches[].pr   number, url, state ("OPEN" | "MERGED" | "QUEUED"); absent without a PR
+```
 
-## Finish
+`base` is the saved parent SHA and can lag the parent's tip. `needsRebase` reports that the current
+parent tip is no longer an ancestor of the branch.
 
-Report the stack bottom to top, PR links, current branch, external operations performed, validation, and any conflict, divergence, queued state, or remaining review blocker. Do not narrate routine navigation.
+## Exit codes
+
+| Code | Meaning                  | Recovery                                                  |
+| ---- | ------------------------ | --------------------------------------------------------- |
+| 0    | Success                  | Check output: divergent `sync` can still abort            |
+| 1    | Generic error            | Read stderr                                               |
+| 2    | Not in a stack           | `init`, or `checkout <stack-or-pr>`                       |
+| 3    | Rebase conflict          | Resolve and stage, then `rebase --continue`; or `--abort` |
+| 4    | GitHub API failure       | Check `gh auth status`, then retry                        |
+| 5    | Invalid arguments        | Fix invocation from `<command> --help`                    |
+| 6    | Disambiguation required  | Use a branch unique to the intended stack                 |
+| 7    | Rebase already active    | `rebase --continue` or `--abort`                          |
+| 8    | Stack file locked        | Retry after the other process releases it                 |
+| 9    | Stacked PRs unavailable  | Report repository availability                            |
+| 10   | Modify recovery required | `gh stack modify --abort`                                 |
+
+After a failed `sync`, branches have already been restored; run `gh stack rebase` to recreate a
+conflict before resolving it.
+
+## References
+
+Open only what the task needs:
+
+- `references/stack-design.md` — planning layers, branch names, and release batches
+- `references/commands.md` — command preconditions, side effects, atomicity, and ordering
+- `references/troubleshooting.md` — conflicts, squash merges, divergence, restructuring, and
+  external branch managers

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/commands.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/commands.md
@@ -1,0 +1,179 @@
+# Command behavior
+
+`gh stack <command> --help` is authoritative for flags and arguments. (`gh stack help <command>` only prints the top-level help.) This file only covers behavior `--help` does not
+explain: preconditions, side effects, atomicity, and failure modes.
+
+## Contents
+
+- [init](#init)
+- [add](#add)
+- [push](#push)
+- [submit](#submit)
+- [link](#link)
+- [sync](#sync)
+- [rebase](#rebase)
+- [view](#view)
+- [checkout](#checkout)
+- [unstack](#unstack)
+- [merge](#merge)
+- [Navigation](#navigation)
+
+## init
+
+Creates the stack and checks out the **last** branch in the list, so a single `init` can lay down
+the whole chain: `gh stack init auth api frontend`.
+
+`init` processes branch arguments from bottom to top. Existing branches are adopted. If the first
+branch does not exist, it is created from the trunk; each later new branch is created from the
+branch immediately before it. There is no separate adopt mode — existence decides. `--base`
+selects a non-default trunk.
+
+`init` also enables `git rerere`. Under a TTY the first run in a repo asks for confirmation; set
+`git config rerere.enabled true` beforehand to skip it.
+
+## add
+
+- **Must run from the top branch** of the stack (or the trunk when the stack is still empty).
+  Anywhere else it exits **5** with `can only add branches on top of the stack`. Run `gh stack top`
+  first.
+- **Uncommitted changes carry over.** Without `-Am`, `add` does not touch the working tree, so
+  staged and unstaged changes follow you onto the new branch. Commit or stash first for a clean start.
+- **`add -Am` commits in place when the current branch has no commits yet** — for example
+  immediately after `init` — instead of creating a branch. This is deliberate: the first layer
+  usually needs its content before a second layer exists.
+- `-A` and `-u` are mutually exclusive, and both require `-m`.
+
+## push
+
+Pushes every active (non-merged, non-queued) branch in one multi-ref push with per-branch
+`--force-with-lease`.
+
+**Not atomic.** Some branches may update while another is rejected. A rejection means that branch
+moved on the remote; fix that branch and rerun — rerunning is safe and skips what already landed.
+
+`push` never creates or updates pull requests. Use `submit` for that.
+
+## submit
+
+Pushes each active branch, then creates a PR for every branch that lacks one, basing it on the
+first non-merged ancestor, then links them into a Stack on GitHub.
+
+- **Not atomic.** Branches are pushed sequentially with per-branch `--force-with-lease`. If a later
+  push is rejected, earlier pushes and PR updates stand. Fix the rejection and rerun the same command.
+- **A fully merged stack cannot be extended.** When every PR in the current stack is already merged,
+  `submit` forks the remaining unmerged branches into a **new** stack rooted at the trunk and creates
+  it on GitHub, leaving the merged stack untouched.
+- **Title generation with `--auto`:** a branch with a single commit uses that commit's subject as
+  the title and its body as the PR body. A branch with multiple commits humanizes the branch name
+  (hyphens and underscores become spaces). There is no flag for a custom title or body; use
+  `gh pr edit` afterwards.
+- `--open` marks new _and existing_ PRs ready for review; without it new PRs are drafts.
+- Requires stacked PRs to be enabled on the repository. If not, `submit` exits **9** when
+  non-interactive (under a TTY it offers to create ordinary unstacked PRs instead).
+
+## link
+
+Creates or updates a stack on GitHub **without any local tracking state**. This is the path for
+branches managed by another tool or living in another worktree — see `troubleshooting.md`.
+
+- Arguments are given bottom to top. Each is a branch name or a PR number; a numeric argument is
+  tried as a PR number first and falls back to a branch name.
+- **A numeric first argument is treated as a stack number only when a stack with that number
+  exists.** In that case the remaining arguments are appended to the top of that stack and you do
+  not re-list its current PRs: `gh stack link 7 feature-c`. Arguments already in the stack are
+  skipped; arguments belonging to a different stack are rejected.
+- Branch arguments are pushed automatically (non-force, atomic). Missing PRs are created with
+  auto-generated titles and correctly chained bases; existing PRs with a wrong base are corrected.
+- Stack membership is **additive only** — `link` never removes a PR from a stack.
+
+## sync
+
+The routine command. Steps, in order:
+
+1. **Fetch** from the remote.
+2. **Reconcile with the GitHub stack.** PRs added to the stack on github.com are pulled down and
+   appended locally. On divergence, aborts when non-interactive (see `troubleshooting.md`).
+3. **Fast-forward the trunk.** Skipped when already current; warns when diverged.
+4. **Cascade rebase when needed.** This runs if the trunk moved, a stack branch was fast-forwarded
+   from its remote, or a branch no longer contains its expected parent. Merged PRs are handled
+   automatically. On conflict, **all branches are restored** to their pre-rebase state and the
+   command exits **3**.
+5. **Push** all active branches, atomically.
+6. **Refresh PR state** from GitHub.
+7. **Sync the stack object** — link open PRs into a stack, additively. Only when two or more PRs
+   exist. `sync` never opens PRs; that is `submit`.
+8. **Prune** local branches for merged PRs, only when `--prune` is passed in a non-interactive
+   environment.
+
+## rebase
+
+Pulls from the remote and cascade-rebases. Use it when `sync` reported a conflict or when you need
+to rebase only part of the stack.
+
+- `--upstack` rebases from the current branch to the top. This is what you run after editing a
+  lower layer.
+- `--downstack` rebases from the trunk to the current branch.
+- `--no-trunk` skips fetching and the trunk rebase entirely, aligning stack branches with each
+  other only.
+- `--continue` after staging resolutions; `--abort` restores every branch.
+- A merged PR is detected automatically and replayed with `--onto` against the correct target, so a
+  squash-merged parent does not produce spurious conflicts.
+- Starting a rebase while one is in progress exits **7**.
+
+## view
+
+- `--json` writes the machine-readable payload to stdout. Its schema is in `SKILL.md`.
+- Bare `view` opens a full-screen TUI when stdout is a TTY, and prints static text when piped.
+- `--short` prints a compact one-line-per-branch summary and never opens the TUI, but it is
+  formatted for humans; parse `--json` instead.
+- `view` refreshes PR state from GitHub as a side effect, best-effort — it does not fail when the
+  API is unreachable.
+
+## checkout
+
+Accepts a stack number, PR number, PR URL, or branch name.
+
+- A bare number resolves as a **stack number first**, then a PR number, then a branch name.
+- Stack numbers, PR numbers, and PR URLs fetch from GitHub, pull the branches down, and set the
+  stack up locally.
+- A **branch name resolves against locally tracked stacks only** and never contacts GitHub. Use a
+  stack or PR number to pull a stack that is not tracked locally.
+- If a local stack already exists over those branches with a different composition, `checkout`
+  cannot be forced past it. Run `gh stack unstack --local` first, then retry.
+- `checkout` has no flags. It relies on `remote.pushDefault` when several remotes exist.
+
+## unstack
+
+Removes the stack **grouping** only. It never deletes pull requests or branches.
+
+- With no argument it targets the active stack — the one containing the current branch — removing
+  it on GitHub and locally.
+- With a stack number it works from anywhere in the repository, tracked locally or not, via the API.
+  Local tracking is also removed when present.
+- `--local` removes local tracking only and never contacts GitHub. Combining `--local` with a stack
+  number that is not tracked locally is an error.
+- An unknown stack number exits **2**.
+
+## merge
+
+- Scope with an argument: pass a PR number to merge that PR and every unmerged PR below it in the
+  stack, or pass a stack number to merge every unmerged PR in that stack.
+- **All-or-nothing.** If any PR in that exact merge set cannot be merged, none are, and the reason
+  is reported.
+- The method comes from `--squash`, `--rebase`, `--merge`, or `--merge-method <method>`. Without
+  one, the last-used method is reused.
+- Only basic PR state is checked before merging: open and not a draft. Bypassing merge requirements
+  is not supported for stacks.
+- **A merge queue on the base branch overrides everything.** The stack is added to the queue rather
+  than merged; the queue chooses the method and any method flag you passed is ignored with a
+  warning. Queued PRs are submitted together but land as the queue processes them, so they may merge
+  in separate groups rather than all at once.
+- `gh pr merge` cannot merge a stack. Always use `gh stack merge`.
+
+## Navigation
+
+`up`, `down`, `top`, `bottom`, and `trunk` are always non-interactive. `up` and `down` accept a
+count (`gh stack up 3`). Movement clamps at the stack bounds, and merged branches are skipped when
+navigating from an active branch, so `bottom` lands on the lowest _unmerged_ branch.
+
+`gh stack switch` is a selection menu with no non-interactive path. Use the commands above instead.

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/commands.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/commands.md
@@ -33,15 +33,11 @@ selects a non-default trunk.
 
 ## add
 
-- **Must run from the top branch** of the stack (or the trunk when the stack is still empty).
-  Anywhere else it exits **5** with `can only add branches on top of the stack`. Run `gh stack top`
-  first.
-- **Uncommitted changes carry over.** Without `-Am`, `add` does not touch the working tree, so
-  staged and unstaged changes follow you onto the new branch. Commit or stash first for a clean start.
-- **`add -Am` commits in place when the current branch has no commits yet** — for example
-  immediately after `init` — instead of creating a branch. This is deliberate: the first layer
-  usually needs its content before a second layer exists.
-- `-A` and `-u` are mutually exclusive, and both require `-m`.
+- Extend a stack from its top branch; a middle branch exits **5**. Use `gh stack top` first.
+- **Uncommitted changes carry over.** Without `-A`, `-u`, or `-m`, `add` does not touch the working
+  tree, so staged and unstaged changes follow onto the new branch. Commit or stash for a clean start.
+- Avoid the `-A`, `-u`, and `-m` commit shortcuts: they can open an editor or commit in place on an
+  empty current layer. Stage and commit with Git, then run `add <branch>`.
 
 ## push
 
@@ -56,7 +52,7 @@ moved on the remote; fix that branch and rerun — rerunning is safe and skips w
 ## submit
 
 Pushes each active branch, then creates a PR for every branch that lacks one, basing it on the
-first non-merged ancestor, then links them into a Stack on GitHub.
+first active ancestor (skipping merged and queued ancestors), then links them into a Stack on GitHub.
 
 - **Not atomic.** Branches are pushed sequentially with per-branch `--force-with-lease`. If a later
   push is rejected, earlier pushes and PR updates stand. Fix the rejection and rerun the same command.
@@ -68,6 +64,7 @@ first non-merged ancestor, then links them into a Stack on GitHub.
   (hyphens and underscores become spaces). There is no flag for a custom title or body; use
   `gh pr edit` afterwards.
 - `--open` marks new _and existing_ PRs ready for review; without it new PRs are drafts.
+- Read base-mismatch warnings; a remote stack can prevent `submit` from repairing an existing PR.
 - Requires stacked PRs to be enabled on the repository. If not, `submit` exits **9** when
   non-interactive (under a TTY it offers to create ordinary unstacked PRs instead).
 
@@ -140,7 +137,7 @@ Accepts a stack number, PR number, PR URL, or branch name.
   stack or PR number to pull a stack that is not tracked locally.
 - If a local stack already exists over those branches with a different composition, `checkout`
   cannot be forced past it. Run `gh stack unstack --local` first, then retry.
-- `checkout` has no flags. It relies on `remote.pushDefault` when several remotes exist.
+- `checkout` has no flags. Configure one unambiguous remote when several exist.
 
 ## unstack
 
@@ -172,8 +169,8 @@ Removes the stack **grouping** only. It never deletes pull requests or branches.
 
 ## Navigation
 
-`up`, `down`, `top`, `bottom`, and `trunk` are always non-interactive. `up` and `down` accept a
-count (`gh stack up 3`). Movement clamps at the stack bounds, and merged branches are skipped when
-navigating from an active branch, so `bottom` lands on the lowest _unmerged_ branch.
+`up`, `down`, `top`, `bottom`, and `trunk` are always noninteractive. `up` and `down` accept a count
+(`gh stack up 3`) and navigate active layers; `top` means the literal top. Use explicit `checkout`
+when merged or queued layers make the target important.
 
 `gh stack switch` is a selection menu with no non-interactive path. Use the commands above instead.

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/stack-design.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/stack-design.md
@@ -1,0 +1,99 @@
+# Designing a stack
+
+How to decide what goes in each layer. Read this before running `gh stack init`.
+
+## Contents
+
+- [Plan the layers before writing code](#plan-the-layers-before-writing-code)
+- [Branch naming](#branch-naming)
+- [Staging changes deliberately](#staging-changes-deliberately)
+- [When to add a layer](#when-to-add-a-layer)
+- [One stack, one landing unit](#one-stack-one-landing-unit)
+
+## Plan the layers before writing code
+
+A stack is a linear landing chain. Usually it follows code dependencies; it can also order bounded
+issue PRs that repository policy deliberately ships as one release batch. If code in one layer
+depends on another, the dependency must live in the same branch or a lower one. Plan before writing:
+there is no noninteractive in-place reorder, so fixing the order means `unstack` and `init` again.
+
+Decide the layers first, then write code into them:
+
+```
+(main) <- todo-app/models <- todo-app/api <- todo-app/frontend <- todo-app/integration
+```
+
+- `todo-app/models` — shared types and schema
+- `todo-app/api` — routes that use the models
+- `todo-app/frontend` — components that call the routes
+- `todo-app/integration` — tests exercising the whole feature
+
+This is illustrative. Infer the stack topic and layer names from the actual task; do not reuse
+`todo-app` or these layer names literally.
+
+The failure mode to avoid is writing everything on one branch and trying to split it afterwards.
+If a task is large enough to warrant a stack, create the stack at the start.
+
+## Branch naming
+
+Prefer a shared topic prefix plus the layer's concern:
+`<topic>/<concern>` — for example, `billing/schema`, `billing/api`, `billing/ui`.
+This keeps related branches recognizable without using generic names that could belong to any
+stack. **User and repository branch naming conventions take precedence; follow them instead.**
+
+Names are used exactly as given — nothing is prepended or transformed, and slashes are kept, so
+`gh stack add refactor/foo` creates a branch literally named `refactor/foo`.
+
+If you pass `-m` without a branch name, the name is generated from the commit message in
+date-and-slug form (for example `03-24-add_api_routes`). Prefer naming the branch yourself.
+
+## Staging changes deliberately
+
+Use `git add` and `git commit` directly rather than the `add -Am` shortcut. The point is control
+over which changes land in which branch. With several modified files in the working tree, stage the
+subset that belongs to the current layer, commit it, then create the next branch and stage the rest
+there:
+
+```bash
+git add internal/models/user.go internal/models/session.go
+git commit -m "Add user and session models"
+
+gh stack add api-routes
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+```
+
+Multiple commits per branch are fine. What matters is that every commit in a branch serves the same
+concern, and that a change belonging to a different concern goes in a different branch.
+
+Note that `gh stack add <branch>` without `-Am` does not touch the working tree, so uncommitted
+changes carry over to the new branch. Commit or stash first if you want the new layer to start clean.
+
+## When to add a layer
+
+Add a branch when you start a **different concern that depends on what you have built so far**.
+Signals:
+
+- Moving from backend to frontend, or from core logic to tests or documentation
+- The next changes have a different reviewer audience
+- The current branch's diff is already large enough to review on its own
+
+A layer that cannot be described in one sentence is usually two layers.
+
+## One stack, one landing unit
+
+A stack needs one coherent landing reason. A reviewer should be able to walk its PRs bottom to top
+and understand why they merge together.
+
+**Use a single stack** when every branch serves the same feature or when explicit repository policy
+bundles several bounded issues into one release. In an issue batch, give each issue a focused layer,
+order shared foundations and overlapping surfaces first, and reserve the top layer for any shared
+integration or release artifact. Lack of a code dependency does not disqualify an issue from an
+explicit shared release batch.
+
+**Start a separate stack** when work should land or release independently. Do not mix efforts merely
+because they happened concurrently. Use `gh stack init` for the new effort, or
+`gh stack checkout <target>` to move between existing stacks.
+
+A trivial incidental fix can ride along in the current stack. Once it grows into its own project, it
+deserves its own stack.

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/stack-design.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/stack-design.md
@@ -66,8 +66,8 @@ git commit -m "Add user API routes"
 Multiple commits per branch are fine. What matters is that every commit in a branch serves the same
 concern, and that a change belonging to a different concern goes in a different branch.
 
-Note that `gh stack add <branch>` without `-Am` does not touch the working tree, so uncommitted
-changes carry over to the new branch. Commit or stash first if you want the new layer to start clean.
+`gh stack add <branch>` does not touch the working tree, so uncommitted changes carry over. Commit
+or stash first if the new layer should start clean.
 
 ## When to add a layer
 

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/troubleshooting.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/troubleshooting.md
@@ -1,0 +1,159 @@
+# Troubleshooting and recovery
+
+## Contents
+
+- [Rebase conflicts (exit 3)](#rebase-conflicts-exit-3)
+- [After a squash merge](#after-a-squash-merge)
+- [Local and remote stacks have diverged](#local-and-remote-stacks-have-diverged)
+- [Restructuring a stack](#restructuring-a-stack)
+- [Branch belongs to several stacks (exit 6)](#branch-belongs-to-several-stacks-exit-6)
+- [Driving stacks from another tool or worktree](#driving-stacks-from-another-tool-or-worktree)
+- [Stack file is locked (exit 8)](#stack-file-is-locked-exit-8)
+- [An interrupted modify session (exit 10)](#an-interrupted-modify-session-exit-10)
+
+## Rebase conflicts (exit 3)
+
+`rebase` and `sync` both exit 3 on conflict. `sync` restores every branch to its pre-rebase state
+first, so a failed `sync` leaves nothing half-applied; a failed `rebase` stops mid-flight and waits.
+
+```bash
+gh stack rebase
+# exit 3 — conflicted paths are listed on stderr
+git add <resolved paths>
+gh stack rebase --continue     # repeat if the next branch also conflicts
+```
+
+`gh stack rebase --abort` restores every branch in the stack, not just the current one.
+
+Because `init` enables `git rerere`, a conflict you resolve once is replayed automatically the next
+time the same conflict appears — which is common, since a change low in the stack is rebased through
+every branch above it. Without `rerere`, repeated conflicts may need manual resolution on each
+affected layer.
+
+## After a squash merge
+
+A squash merge replaces the branch's commits with one new commit, so the originals no longer exist
+in the trunk's history and an ordinary rebase would try to replay them again.
+
+`gh stack sync` detects this and rebases with `--onto` against the correct target, skipping the
+merged branch:
+
+```bash
+gh stack sync
+gh stack view --json    # merged branch reports "isMerged": true, "state": "MERGED"
+```
+
+No manual action is needed. If the replay conflicts, `sync` restores all branches and exits 3.
+Run `gh stack rebase` to rerun the rebase, which will stop at the conflict and allow you to resolve
+and then `--continue` until complete. Use `gh stack sync --prune` to also delete local branches for
+merged PRs.
+
+## Local and remote stacks have diverged
+
+Divergence means the local stack and the stack on GitHub changed in different ways — for example
+branches were added locally while a PR was added to the stack on github.com.
+
+When non-interactive, `sync` prints both chains, changes nothing, and exits **0** with
+`Sync aborted`. Success here does not mean the sync happened; check for that message, or re-run
+`gh stack view --json` and compare.
+
+Two resolution paths:
+
+- **Keep the remote version.** Drop local tracking and pull the stack back down.
+
+  ```bash
+  gh stack unstack --local          # keeps the stack on GitHub
+  gh stack checkout <stack-number>  # or a PR number
+  ```
+
+- **Keep the local version.** Remove the grouping on GitHub, then recreate it from local state.
+
+  ```bash
+  gh stack unstack                  # removes the grouping; PRs and branches survive
+  gh stack submit --auto
+  ```
+
+Neither path deletes pull requests or branches.
+Remote unstacking leaves PRs that are merging (auto-merge enabled) or are queued (in a merge queue)
+stacked. If needed, clear that state before retrying.
+
+## Restructuring a stack
+
+There is no non-interactive reorder, rename, or removal. `add` run from the wrong branch suggests
+`gh stack modify`, but that is TUI-only. Tear the stack down and rebuild it instead:
+
+```bash
+gh stack unstack                       # removes local tracking and the GitHub grouping
+# Rename or drop branches, and rewrite ancestry as needed.
+gh stack init --base main branch-1 branch-2 branch-3
+gh stack submit --auto                 # re-link on GitHub
+```
+
+`init` adopts branches that already exist, so the rebuild reuses them rather than creating new ones.
+Existing PRs survive. Once Git ancestry is correct, `submit` updates their base branches and
+re-links the stack on GitHub.
+
+Changing metadata does **not** change Git ancestry. Reorder commits first, then rebuild the stack.
+For example, to change `main <- models <- migration <- ui` into
+`main <- migration <- models <- ui`:
+
+```bash
+old_models=$(git rev-parse models)
+old_migration=$(git rev-parse migration)
+git rebase --onto main "$old_models" migration
+git rebase --onto migration main models
+git rebase --onto models "$old_migration" ui
+gh stack unstack
+gh stack init --base main migration models ui
+```
+
+The first rebase moves migration-only commits onto trunk, the second replays model commits above
+them, and the third replays UI-only commits above models. Preserve the old boundary SHAs before
+moving any branch. For a different reorder, identify each layer's range with
+`git log <old-parent>..<branch>`, then replay the ranges bottom to top.
+
+## Branch belongs to several stacks (exit 6)
+
+Commands exit 6 when the current branch cannot identify a single stack — typically because it is the
+trunk of more than one stack. There is no flag to disambiguate.
+
+```bash
+gh stack checkout <a-branch-unique-to-the-intended-stack>
+```
+
+Then rerun. Commands that take an explicit stack number (`merge 7`, `unstack 7`) sidestep the
+problem entirely, since they do not infer the stack from the current branch.
+
+## Driving stacks from another tool or worktree
+
+`gh stack link` creates and updates stacks purely through the API, with no local tracking state.
+Use it when branches are managed by jj, Sapling, git-town, a separate worktree, or any workflow
+where the local `.git/gh-stack` file would be wrong or absent.
+
+```bash
+gh stack link branch-a branch-b branch-c        # bottom to top
+gh stack link --base develop --open a b c       # non-default trunk, ready for review
+gh stack link 10 20 30                          # by PR number
+gh stack link 7 feature-d                       # append to existing stack #7
+```
+
+Because `link` writes no local state, the local navigation commands (`up`, `down`, `top`, `bottom`)
+will not work on the result. Use `gh stack checkout <stack-number>` if you later want local tracking.
+
+## Stack file is locked (exit 8)
+
+Another `gh stack` process holds the exclusive lock on `.git/gh-stack.lock`. The lock times out
+after about five seconds, so wait and retry. A persistent exit 8 means another process still holds
+the lock; identify and stop that process before retrying.
+
+## An interrupted modify session (exit 10)
+
+`gh stack modify` is TUI-only and should never be invoked by an agent. If a repository is left in
+this state by someone else, restore it:
+
+```bash
+gh stack modify --abort
+```
+
+Related: `submit` also detects a pending modify state, and under a TTY asks before overwriting the
+stack on GitHub with local state.

--- a/packages/pi-skill-gh-stack/skills/gh-stack/references/troubleshooting.md
+++ b/packages/pi-skill-gh-stack/skills/gh-stack/references/troubleshooting.md
@@ -69,7 +69,9 @@ Two resolution paths:
 - **Keep the local version.** Remove the grouping on GitHub, then recreate it from local state.
 
   ```bash
-  gh stack unstack                  # removes the grouping; PRs and branches survive
+  # First record trunk and every branch bottom to top.
+  gh stack unstack                  # removes remote and local grouping; PRs and branches survive
+  gh stack init --base <trunk> <bottom-branch> <next-branch> [<top-branch>...]
   gh stack submit --auto
   ```
 
@@ -133,7 +135,7 @@ where the local `.git/gh-stack` file would be wrong or absent.
 ```bash
 gh stack link branch-a branch-b branch-c        # bottom to top
 gh stack link --base develop --open a b c       # non-default trunk, ready for review
-gh stack link 10 20 30                          # by PR number
+gh stack link <pr-url-1> <pr-url-2> <pr-url-3>  # explicit PRs, bottom to top
 gh stack link 7 feature-d                       # append to existing stack #7
 ```
 


### PR DESCRIPTION
## Summary

- curate GitHub's improved `gh-stack` skill into a compact mechanics-first core with lazy command, design, and troubleshooting references
- add explicit no-PTY guidance, machine-readable state and exit contracts, and source-checked recovery behavior
- make one release-batch stack the repository workflow: one focused PR per issue, one top batch PR, no worker supervision, and no merge without explicit user approval

## Validation

- `python packages/pi-skill-skill-creator/skills/skill-creator/scripts/skill-efficiency-check.py .pi/skills/gh-stack`
- `gh skill publish packages/pi-skill-gh-stack --dry-run`
- `bunx oxfmt --check ...`
- `bun pm pack --dry-run`
- `bun run check:changed`
- `bun run changeset:check`
- command claims checked against `github/gh-stack` v0.1.0 source at `14fc42e`

## Release

- Changeset: yes
- Packages: `@howaboua/pi-skill-gh-stack`
- Aggregates: generated by release automation
