### PR TITLE
Improve semantic indexing and apply-patch recovery

### DIFF
--- a/.changeset/patch-msippb77-c92353.md
+++ b/.changeset/patch-msippb77-c92353.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Render delete-and-readd patches as file edits and clarify the required move-file hunk syntax.
+Render delete-and-readd patches as file edits, clarify move-file syntax, and keep failed-patch recovery concise and non-duplicated.

--- a/.changeset/patch-msippb77-c92353.md
+++ b/.changeset/patch-msippb77-c92353.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Render delete-and-readd patches as file edits and clarify the required move-file hunk syntax.

--- a/.changeset/patch-msipv744-bfe3d2.md
+++ b/.changeset/patch-msipv744-bfe3d2.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-semantic-grep": patch
+"@howaboua/pi-codex-conversion": patch
+---
+
+Make semantic indexing single-writer, atomic, resumable, ignore-aware, metadata-fast, batch-embedded, and role-aware while preserving usable prior file indexes across interrupted rebuilds.

--- a/.changeset/patch-msipv744-bfe3d2.md
+++ b/.changeset/patch-msipv744-bfe3d2.md
@@ -3,4 +3,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Make semantic indexing single-writer, atomic, resumable, ignore-aware, metadata-fast, batch-embedded, and role-aware while preserving usable prior file indexes across interrupted rebuilds.
+Make semantic indexing non-blocking at session startup, single-writer, atomic, resumable, ignore-aware, metadata-fast, batch-embedded, and role-aware while preserving usable prior file indexes across interrupted rebuilds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repo publishes through Changesets; every merge to `main` feeds the version 
 - Agent-facing text is behavior: keep tool contracts, skill files, prompt metadata, and subagent prompts compact.
 - Agent-facing prose need not perform grammatical polish; optimize semantic signal per token and omit cosmetic punctuation when it saves tokens. Preserve syntax, structural delimiters, meaning, evidence, caveats, and recovery instructions.
 - Contract spine, not feature museum: feature-existence and regression-tour tests die; retain only independent protocol, routing, migration, or model-visible contracts.
+- Never encode agent tool-call mistakes or prompt-following failures as programmatic tests. Discover them in real use and fix the model-facing contract; tests may cover only deterministic parser, executor, result, or routing boundaries independently of model compliance.
 - Skills and extensions must work for any user. Never ship local paths, personal names, machine assumptions, or private workflow details.
 - Slash commands are for users; agents use tools. Prefer one routed entry command over several command names unless explicitly requested.
 - Treat related package work from one session as one release unit: one PR or one directly, atomically merged stack. Installed users should not absorb serial cleanup releases.

--- a/bun.lock
+++ b/bun.lock
@@ -256,6 +256,8 @@
       "version": "0.1.18",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
+        "ignore": "^7.0.5",
+        "proper-lockfile": "^4.1.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
@@ -263,6 +265,8 @@
         "@earendil-works/pi-tui": "0.82.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^24.0.0",
+        "@types/proper-lockfile": "^4.1.4",
+        "tsx": "^4.20.5",
         "typebox": "1.1.38",
         "typescript": "^5.8.3",
       },
@@ -881,6 +885,8 @@
 
     "@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
+
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -1255,7 +1261,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
@@ -1445,13 +1451,13 @@
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
-    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "protobufjs/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "spawndamnit/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "tree-sitter-bash/node-addon-api": ["node-addon-api@8.8.0", "", {}, "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA=="],
 

--- a/docs/pi-execution-modes.md
+++ b/docs/pi-execution-modes.md
@@ -1,0 +1,109 @@
+# Notebook Code Mode plan
+
+## Goal
+
+Add **Notebook Code Mode** to `pi-codex-conversion` alongside normal and existing Code Mode. Preserve the current provider-visible `exec` and `wait` surface and every nested capability, while giving JavaScript and TypeScript cells persistent notebook state, Deno APIs, and npm imports.
+
+The first slice is an internal Linux x64 proof on the canonical development server. It does not promise a cross-platform release.
+
+## Product contract
+
+- Notebook Code Mode extends Code Mode; it does not replace or weaken normal or existing Code Mode.
+- The provider still sees only `exec` and `wait`.
+- Existing nested built-ins, custom tools, deferred discovery, `ALL_TOOLS`, rendering, output handling, and background operations remain available with the same contracts.
+- Users continue choosing their own Pi extensions, memory systems, skills, and custom tools. Do not bundle Prime-style continual harness, prompt-note, memory, skill, or subagent systems.
+- Notebook cells support natural declarations: top-level variables, functions, classes, and imports persist and may be redefined in later cells.
+- Deno APIs and npm imports add a notebook-native computation ecosystem. Prompt the model to keep using Pi/custom tools for project operations where their contracts, rendering, output bounds, or background handles help.
+- Notebook Code Mode initially follows the same model/provider eligibility as existing Code Mode and keeps Responses Lite behavior.
+
+Prime remains the answer for users who want its Python/IPython harness. This feature is the JavaScript/TypeScript counterpart shaped around Pi Code Mode, not a port of Prime's product bundle.
+
+## Runtime architecture
+
+Use a pinned Deno Jupyter kernel rather than modifying the existing V8 host.
+
+- Deno supplies maintained TypeScript compilation, top-level await, natural REPL redeclaration semantics, npm imports, rich MIME output, and isolate interruption.
+- The extension speaks Jupyter over ZeroMQ. `zeromq` 6.1.2 is already proven by Prime's TypeScript client and adds about 11.3 MB unpacked before transitive installation overhead.
+- Lazily download one exact, checksummed Deno release on first Notebook Code Mode use. On Linux x64, Deno 2.9.5 measured 41.6 MB compressed and 95.6 MB installed; this is about 25 MB more download and 49 MB more disk than the current Code Mode host, without inflating the npm package by the binary's full size.
+- Start only with Linux x64. A later release may adopt Deno's official macOS, Windows, and glibc Linux x64/arm64 matrix after the prototype contracts hold. Do not claim musl support without an actual distribution path.
+- Keep Deno/Jupyter ownership outside the pinned upstream V8 source tree. Reuse Pi-owned nested-tool definitions and custom-tool discovery rather than duplicating their policies.
+
+Deno's kernel closes arbitrary Jupyter `comm_open` targets, so Prime's comm bridge is not reusable. Bootstrap an authenticated loopback bridge into the persistent notebook instead:
+
+- `tools` routes calls to the existing nested-tool adapter.
+- `ALL_TOOLS` reflects the current promoted and deferred catalog.
+- `text`, `image`, `generatedImage`, `notify`, `store`, `load`, `yield_control`, and other current globals retain their model-facing behavior.
+- Refresh tool metadata without restarting the kernel or changing the provider tool schema.
+- Bound and validate every bridge request and response; bridge failure is explicit and never falls back to unmediated imitation of a Pi tool.
+
+Deno's ambient filesystem, network, process, and package APIs remain available. This authority is intentional; it does not remove the operational value of Pi's richer tool contracts.
+
+## Cell execution
+
+- One Deno kernel belongs to one active Pi session.
+- Every `exec` remains a distinct cell in that kernel, not one never-ending invocation.
+- Execute one cell at a time. If a cell has yielded, a second `exec` fails with guidance to call `wait` or terminate the active cell.
+- `wait` continues observing the same active cell and preserves its current continuation contract.
+- A normal uncaught exception leaves mutations made before the throw in the live kernel, matching notebook behavior. A failed cell does not advance the durable checkpoint; a later successful checkpoint may include those surviving mutations.
+- Cancellation sends a kernel interrupt. If the kernel remains busy or suffers a fatal runtime failure, terminate it and restore the last completed checkpoint.
+- Runtime recovery only restores notebook data. Never imply that filesystem, network, subprocess, or Pi-tool side effects from an interrupted cell were rolled back.
+- Compaction does not reset the kernel. The model prompt states that notebook state survives turns and compaction while the session remains live.
+
+The internal prototype is session-linear. It need not rewind heap state with Pi conversation-tree navigation. It must detect navigation away from the state-owning branch and reset or restore visibly rather than silently attach mismatched notebook state. Do not share a live kernel between forked sessions.
+
+## Checkpoint and restore
+
+Keep the full JavaScript heap live while the session runs. Add best-effort durable checkpoints for top-level data:
+
+1. Ask Deno's Jupyter `complete_request` for global and lexical-scope names.
+2. Exclude runtime/bootstrap names and serialize each remaining candidate independently with Deno's supported `node:v8` `serialize` API.
+3. Skip functions, closures, promises, imports, weak collections, live resources, and values that fail serialization; retain a concise reason per skipped name.
+4. Write one atomically replaced checkpoint and manifest per session. Include schema, Deno, V8, project, and session identity so incompatible state is rejected rather than guessed at.
+5. Restore compatible values with `node:v8` `deserialize`, then rebind current tool globals and metadata.
+6. Report restored, skipped, failed, or invalidated names visibly to the model.
+
+Use a 256 MiB total prototype cap, with the same cap applied to any single variable. Debounce checkpoints after successful cells and perform a bounded final flush. Replacing one current checkpoint prevents unbounded per-cell history; orphaned session artifacts should be garbage-collected rather than retained indefinitely.
+
+On an orderly mode switch, session switch, reload, or exit, flush the checkpoint and stop Deno. Do not maintain detached daemons or orphan kernels.
+
+## Activation and configuration
+
+Mode precedence is:
+
+1. latest override on the active Pi session branch;
+2. trusted project default from `<cwd>/.pi/pi-codex-conversion.json`;
+3. existing global Code Mode configuration and defaults.
+
+The project field is:
+
+```json
+{
+  "executionMode": "notebook"
+}
+```
+
+Valid values are `normal`, `code`, and `notebook`. Read project configuration only when `ctx.isProjectTrusted()` is true and use Pi's `CONFIG_DIR_NAME` rather than hardcoding `.pi` in implementation.
+
+Add a **Session execution mode** selector to `/codex` with inherited, normal, Code Mode, and Notebook Code Mode values. A session selection writes a non-model-facing custom session entry, not the global configuration file. Existing users with `beta.codeMode` retain their inherited behavior. Changing modes resets provider continuation/prewarm state at the intentional prompt/tool-prefix boundary.
+
+## Compatibility boundary
+
+- Do not modify the working vendored V8 Code Mode host for this feature.
+- Future V8 resync considerations are tracked separately in [issue #238](https://github.com/IgorWarzocha/howaboua-pi-stuff/issues/238). If that work becomes necessary, resync the complete vendored boundary to one upstream commit rather than cherry-picking into upstream-owned source.
+- No V8 sandboxing, resource-limit, or host-transport work belongs in the Notebook Code Mode release.
+- Mode-specific prompt copy may change, but normal and existing Code Mode provider schemas, globals, and behavior must remain stable.
+
+## Prototype acceptance
+
+The Linux x64 proof is successful when it demonstrates:
+
+1. Notebook Code Mode activates through a session override or trusted project default without affecting other modes.
+2. The provider receives only `exec` and `wait`.
+3. TypeScript declarations, functions, imports, npm packages, and top-level await persist and can be reused or redefined across cells.
+4. Existing built-ins and promoted or deferred custom tools remain discoverable and callable from notebook code, including composed and parallel nested calls.
+5. Yield, `wait`, busy rejection, cancellation, ordinary exceptions, and fatal recovery produce actionable model-visible results.
+6. A graceful restart restores serializable variables, reports skipped state, and rebinds current tool metadata.
+7. An interrupted cell restores the last completed checkpoint without claiming to reverse external side effects.
+8. Normal Code Mode still uses fresh V8 isolates and its existing custom-tool behavior unchanged.
+
+After the proof, decide publication and broader platform support from measured startup latency, checkpoint cost, dependency/install reliability, bridge behavior, and real agent use. Shipping package changes require a focused issue/PR, a changeset, and the repository's changed-package gate.

--- a/packages/pi-ask/tests/tool.test.ts
+++ b/packages/pi-ask/tests/tool.test.ts
@@ -4,12 +4,6 @@ import { createAskTool } from "../ask/tool.js";
 const context = { hasUI: false, mode: "print" } as never;
 
 describe("ask tool results", () => {
-	test("keeps the prompt inventory snippet free of the tool name", () => {
-		expect(createAskTool().promptSnippet).toBe(
-			"Request human input or action.",
-		);
-	});
-
 	test("serializes interactive calls", () => {
 		expect(createAskTool().executionMode).toBe("sequential");
 	});

--- a/packages/pi-codex-conversion/examples/custom-tools/browser/browser.test.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/browser/browser.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { basename } from "node:path";
 import test from "node:test";
 import {
-	browserHelp,
 	cliInvocation,
 	formatLocalResult,
 	parseRequest,
@@ -159,14 +158,4 @@ test("abandoned cached results expire", async () => {
 		readCachedResult({ handle: first.result_handle, offset: first.next_offset }),
 		/result handle not found/,
 	);
-});
-
-test("help keeps the preferred loop compact", () => {
-	const help = browserHelp();
-	assert.match(help.call, /tabs\?.*open\?.*find\?.*click\?/);
-	assert.doesNotMatch(help.call, /host/);
-	assert.equal(help.host, undefined);
-	assert.match(help.actions.open, /ref_id/);
-	assert.match(help.actions.click, /id/);
-	assert.ok(JSON.stringify(help).length < 2_000);
 });

--- a/packages/pi-codex-conversion/examples/custom-tools/semantic-grep/semantic-grep.mjs
+++ b/packages/pi-codex-conversion/examples/custom-tools/semantic-grep/semantic-grep.mjs
@@ -121,10 +121,18 @@ async function embed(input, config) {
 	if (config.embeddings.apiKey) {
 		headers.Authorization = `Bearer ${config.embeddings.apiKey}`;
 	}
+	const body = {
+		...(config.embeddings.queryExtraBody ?? {}),
+		model: config.embeddings.model,
+		input: `${config.embeddings.queryPrefix ?? ""}${input}`,
+	};
+	if (config.embeddings.dimensions !== undefined) {
+		body.dimensions = config.embeddings.dimensions;
+	}
 	const response = await fetch(config.embeddings.url, {
 		method: "POST",
 		headers,
-		body: JSON.stringify({ model: config.embeddings.model, input }),
+		body: JSON.stringify(body),
 	});
 	if (!response.ok) {
 		throw new Error(
@@ -133,7 +141,13 @@ async function embed(input, config) {
 	}
 	const json = await response.json();
 	const vector = json.data?.[0]?.embedding;
-	if (!Array.isArray(vector) || vector.length === 0) {
+	if (
+		!Array.isArray(vector) ||
+		vector.length === 0 ||
+		vector.some(
+			(value) => typeof value !== "number" || !Number.isFinite(value),
+		)
+	) {
 		throw new Error("embedding response did not contain data[0].embedding");
 	}
 	return vector;
@@ -143,8 +157,7 @@ function cosine(a, b) {
 	let dot = 0;
 	let aa = 0;
 	let bb = 0;
-	const length = Math.min(a.length, b.length);
-	for (let index = 0; index < length; index += 1) {
+	for (let index = 0; index < a.length; index += 1) {
 		const av = a[index] ?? 0;
 		const bv = b[index] ?? 0;
 		dot += av * bv;
@@ -158,10 +171,28 @@ async function search(db, query, topK, config) {
 	const queryVector = await embed(query, config);
 	const best = [];
 	let minimum = Number.NEGATIVE_INFINITY;
+	let skippedIncompatible = 0;
 	for (const row of db
 		.prepare("select file, start_line, end_line, text, vector from chunks")
 		.iterate()) {
-		const score = cosine(queryVector, JSON.parse(row.vector));
+		let vector;
+		try {
+			vector = JSON.parse(row.vector);
+		} catch {
+			skippedIncompatible += 1;
+			continue;
+		}
+		if (
+			!Array.isArray(vector) ||
+			vector.length !== queryVector.length ||
+			vector.some(
+				(value) => typeof value !== "number" || !Number.isFinite(value),
+			)
+		) {
+			skippedIncompatible += 1;
+			continue;
+		}
+		const score = cosine(queryVector, vector);
 		if (best.length >= topK && score <= minimum) continue;
 		best.push({
 			file: row.file,
@@ -174,11 +205,17 @@ async function search(db, query, topK, config) {
 		if (best.length > topK) best.pop();
 		minimum = best.at(-1)?.score ?? Number.NEGATIVE_INFINITY;
 	}
-	return best;
+	return { matches: best, skippedIncompatible };
 }
 
-function formatMatches(matches) {
-	if (matches.length === 0) return "No semantic grep matches.";
+function formatMatches(results) {
+	const { matches, skippedIncompatible } = results;
+	if (matches.length === 0) {
+		if (skippedIncompatible > 0) {
+			return `No compatible semantic grep vectors. ${skippedIncompatible} stale chunks were omitted; let indexing finish or rebuild the index.`;
+		}
+		return "No semantic grep matches.";
+	}
 	const sections = [];
 	let used = 0;
 	for (const [index, match] of matches.entries()) {
@@ -208,6 +245,11 @@ function formatMatches(matches) {
 			);
 			break;
 		}
+	}
+	if (skippedIncompatible > 0) {
+		sections.push(
+			`${skippedIncompatible} stale chunks were omitted; indexing will replace them.`,
+		);
 	}
 	return sections.join("\n\n");
 }

--- a/packages/pi-codex-conversion/src/adapter/code-mode.ts
+++ b/packages/pi-codex-conversion/src/adapter/code-mode.ts
@@ -67,7 +67,7 @@ function createNestedTools(
 				promptSnippet: false,
 				showDiffWhenCollapsed: !runtime.state.config.ui.compactTools,
 			}),
-			"await tools.apply_patch(patch) // *** Begin Patch / *** End Patch; actions: *** Add File: path | *** Update File: path | *** Delete File: path; *** Move to: path immediately follows the Update File header; Update hunks MUST follow file order; copy exact context; @@ text is context, not a line range; reread a file before patching if it changed since your last read",
+			"await tools.apply_patch(patch) // *** Begin Patch / *** End Patch; actions: *** Add File: path | *** Update File: path | *** Delete File: path; *** Move to: path must immediately follow its Update File header and still needs a nonempty @@ hunk (use one unchanged context line for a pure move); Update hunks MUST follow file order; copy exact context; @@ text is context, not a line range; reread a file before patching if it changed since your last read",
 			{},
 			{
 				kind: "freeform",

--- a/packages/pi-codex-conversion/src/patch/parser.ts
+++ b/packages/pi-codex-conversion/src/patch/parser.ts
@@ -125,7 +125,9 @@ export function parsePatchActions({ text }: { text: string }): ParsedPatchAction
 
 		if (line.startsWith("*** Add File: ")) {
 			const addPath = normalizePatchPath({ path: line.slice("*** Add File: ".length) });
-			if (seenPaths.has(addPath)) {
+			const previous = actions.at(-1);
+			const replacesDeletedPath = previous?.type === "delete" && previous.path === addPath;
+			if (seenPaths.has(addPath) && !replacesDeletedPath) {
 				throw new DiffError(`Add File Error: Duplicate Path: ${addPath}`);
 			}
 			seenPaths.add(addPath);

--- a/packages/pi-codex-conversion/src/tools/apply-patch/rendering.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/rendering.ts
@@ -35,7 +35,7 @@ export function formatApplyPatchSummary(patchText: string, cwd = process.cwd()):
 		return "";
 	}
 
-	const files = actions.map((action) => buildFilePreview(action, cwd));
+	const files = buildFilePreviews(actions, cwd);
 	if (files.length === 0) {
 		return "";
 	}
@@ -80,7 +80,7 @@ export function renderApplyPatchCall(patchText: string, cwd = process.cwd()): st
 		return "";
 	}
 
-	const files = actions.map((action) => buildFilePreview(action, cwd));
+	const files = buildFilePreviews(actions, cwd);
 	if (files.length === 0) {
 		return "";
 	}
@@ -106,6 +106,29 @@ export function renderApplyPatchCall(patchText: string, cwd = process.cwd()): st
 	}
 
 	return lines.join("\n");
+}
+
+function buildFilePreviews(actions: ParsedPatchAction[], cwd: string): FilePreview[] {
+	const files: FilePreview[] = [];
+	for (let index = 0; index < actions.length; index += 1) {
+		const action = actions[index]!;
+		const next = actions[index + 1];
+		if (action.type === "delete" && next?.type === "add" && action.path === next.path) {
+			const deleted = buildFilePreview(action, cwd);
+			const added = buildFilePreview(next, cwd);
+			files.push({
+				verb: "Edited",
+				path: action.path,
+				added: added.added,
+				removed: deleted.removed,
+				lines: [...deleted.lines, ...added.lines],
+			});
+			index += 1;
+			continue;
+		}
+		files.push(buildFilePreview(action, cwd));
+	}
+	return files;
 }
 
 function buildFilePreview(action: ParsedPatchAction, cwd: string): FilePreview {

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -104,9 +104,27 @@ function buildPartialFailureMessage(message: string, failedFiles: string[], appl
 	return lines.join("\n");
 }
 
-function addPatchRetryHint(message: string, cause: string): string {
-	if (!cause.startsWith("Failed to find expected lines")) return message;
-	return `${message}\nRecovery: order each Update File's hunks top-to-bottom and copy exact indentation before retrying`;
+function expectedContextPreview(cause: string): string | undefined {
+	if (!cause.startsWith("Failed to find expected lines")) return undefined;
+	return cause
+		.split("\n")
+		.slice(1)
+		.find((line) => line.trim().length > 0)
+		?.trim();
+}
+
+function summarizePatchCause(cause: string): string {
+	const preview = expectedContextPreview(cause);
+	if (preview === undefined) return cause;
+	return preview
+		? `expected context not found\nExpected near: ${preview}`
+		: "expected context not found";
+}
+
+function addContextRecovery(message: string, cause: string, failedTargets: string[]): string {
+	if (expectedContextPreview(cause) === undefined) return message;
+	const target = failedTargets.join(", ") || "the failed file";
+	return `${message}\nRecovery: MUST read ${target} and retry only the failed edit against current contents`;
 }
 
 function describeFailedActions(error: ExecutePatchError, cwd: string): string[] {
@@ -148,12 +166,12 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 					const failedTargets = describeFailedActions(error, ctx.cwd);
 					const failedTargetSummary = failedTargets.join(", ");
 					const prefix = partial ? `apply_patch partially failed after ${summarizePatchCounts(error.result)}` : "apply_patch failed";
-					const rawMessage = failedTargetSummary ? `${prefix} while patching ${failedTargetSummary}: ${error.message}` : `${prefix}: ${error.message}`;
-					const message = addPatchRetryHint(rawMessage, error.message);
+					const cause = summarizePatchCause(error.message);
+					const rawMessage = failedTargetSummary ? `${prefix} while patching ${failedTargetSummary}: ${cause}` : `${prefix}: ${cause}`;
 					if (partial) {
 						const failedFiles = getFailedPaths(error);
 						const appliedFiles = getAppliedPaths(error.result, failedFiles);
-						const recoveryMessage = buildPartialFailureMessage(message, failedFiles, appliedFiles);
+						const recoveryMessage = buildPartialFailureMessage(rawMessage, failedFiles, appliedFiles);
 						markApplyPatchPartialFailure(toolCallId, failedTargets);
 						return {
 							content: [{ type: "text", text: recoveryMessage }],
@@ -164,6 +182,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 							} satisfies ApplyPatchPartialFailureDetails,
 						};
 					}
+					const message = addContextRecovery(rawMessage, error.message, failedTargets);
 					markApplyPatchFailure(toolCallId, "failed", failedTargets);
 					throw new Error(message);
 				}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -19,7 +19,7 @@ import {
 
 const APPLY_PATCH_PARAMETERS = Type.Object({
 	input: Type.String({
-		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections. Order each file's hunks top-to-bottom; indentation is literal",
+		description: "Full patch text. Use *** Begin Patch / *** End Patch with Add/Update/Delete File sections. *** Move to: path must immediately follow its Update File header and still needs a nonempty @@ hunk; use one unchanged context line for a pure move. Order each file's hunks top-to-bottom; indentation is literal",
 	}),
 });
 

--- a/packages/pi-codex-conversion/src/tools/code-mode/rendering.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/rendering.ts
@@ -126,7 +126,14 @@ export function renderCodeModeResult(
 		.filter((item) => item.type === "text" && typeof item.text === "string")
 		.map((item) => item.text)
 		.join("\n");
-	const status = statusText(details);
+	const scriptErrorRenderedByTrace = Boolean(
+		details.scriptError &&
+			details.traces?.some(
+				(trace) =>
+					trace.status === "error" && trace.error === details.scriptError,
+			),
+	);
+	const status = scriptErrorRenderedByTrace ? "" : statusText(details);
 	const outputText = [text, status].filter(Boolean).join("\n");
 	const tone = context?.isError
 		? "error"
@@ -144,7 +151,7 @@ export function renderCodeModeResult(
 
 	const showOutput =
 		richRendering ||
-		Boolean(details.scriptError) ||
+		Boolean(details.scriptError && !scriptErrorRenderedByTrace) ||
 		details.notification === true ||
 		images.length > 0;
 	const output =

--- a/packages/pi-codex-conversion/tests/apply-patch-rendering.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-rendering.test.ts
@@ -3,10 +3,23 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { renderCodeModeResult } from "../src/tools/code-mode/rendering.ts";
 import {
 	formatApplyPatchSummary,
 	renderApplyPatchCall,
 } from "../src/tools/apply-patch/rendering.ts";
+
+const theme = {
+	fg: (_role: string, text: string) => text,
+	bold: (text: string) => text,
+};
+
+function renderText(component: { render(width: number): string[] }): string {
+	return component
+		.render(120)
+		.map((line) => line.trimEnd())
+		.join("\n");
+}
 
 test("delete-and-readd rewrites render as one edited file", () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-apply-patch-render-"));
@@ -31,4 +44,33 @@ test("delete-and-readd rewrites render as one edited file", () => {
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
+});
+
+test("nested script errors render once", () => {
+	const error = "apply_patch failed: expected context not found";
+	const rendered = renderText(
+		renderCodeModeResult(
+			{
+				content: [{ type: "text", text: `Script error: ${error}` }],
+				details: {
+					cellId: "1",
+					status: "result",
+					scriptError: error,
+					traces: [
+						{
+							id: "tool-1",
+							name: "apply_patch",
+							input: "patch",
+							status: "error",
+							error,
+						},
+					],
+				},
+			},
+			{ expanded: false, isPartial: false },
+			theme,
+		),
+	);
+
+	assert.equal(rendered.match(/expected context not found/g)?.length, 1);
 });

--- a/packages/pi-codex-conversion/tests/apply-patch-rendering.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-rendering.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	formatApplyPatchSummary,
+	renderApplyPatchCall,
+} from "../src/tools/apply-patch/rendering.ts";
+
+test("delete-and-readd rewrites render as one edited file", () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-apply-patch-render-"));
+	try {
+		writeFileSync(join(cwd, "target.txt"), "old one\nold two\n");
+		const patch = [
+			"*** Begin Patch",
+			"*** Delete File: target.txt",
+			"*** Add File: target.txt",
+			"+new one",
+			"+new two",
+			"*** End Patch",
+		].join("\n");
+
+		assert.equal(
+			formatApplyPatchSummary(patch, cwd),
+			"• Edited target.txt (+2 -2)",
+		);
+		const rendered = renderApplyPatchCall(patch, cwd);
+		assert.match(rendered, /old one/);
+		assert.match(rendered, /new one/);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
+++ b/packages/pi-codex-conversion/tests/code-mode-proxy-provider.test.ts
@@ -1,8 +1,5 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
 import { CODE_MODE_EXEC_GRAMMAR } from "../src/tools/code-mode/exec-contract.ts";
@@ -119,28 +116,9 @@ test("the provider-scoped proxy stream delegates ordinary Responses models witho
 
 test("configured Responses models route through the Code Mode stream in Pi's model runtime", async () => {
 	const originalFetch = globalThis.fetch;
-	const agentDir = await mkdtemp(join(tmpdir(), "pi-code-mode-proxy-"));
 	let capturedRequest: RequestInit | undefined;
 	let registration: ReturnType<typeof registerCodeModeProxyProvider> | undefined;
 	try {
-		await writeFile(join(agentDir, "models.json"), JSON.stringify({
-			providers: {
-				MyProxy: {
-					baseUrl: "https://proxy.example/v1",
-					apiKey: "test-key",
-					api: "openai-responses",
-					models: [{
-						id: "gpt-5.6",
-						name: "GPT-5.6 Proxy",
-						reasoning: true,
-						input: ["text"],
-						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-						contextWindow: 100_000,
-						maxTokens: 10_000,
-					}],
-				},
-			},
-		}));
 		globalThis.fetch = (async (_url, init) => {
 			capturedRequest = init;
 			return sseResponse([
@@ -153,10 +131,24 @@ test("configured Responses models route through the Code Mode stream in Pi's mod
 		}) as typeof fetch;
 
 		const runtime = await ModelRuntime.create({
-			modelsPath: join(agentDir, "models.json"),
+			modelsPath: null,
 			allowModelNetwork: false,
 		});
 		const registry = new ModelRegistry(runtime);
+		registry.registerProvider("MyProxy", {
+			baseUrl: "https://proxy.example/v1",
+			apiKey: "test-key",
+			api: "openai-responses",
+			models: [{
+				id: "gpt-5.6",
+				name: "GPT-5.6 Proxy",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 100_000,
+				maxTokens: 10_000,
+			}],
+		});
 		const config = {
 			...DEFAULT_CODEX_CONVERSION_CONFIG,
 			beta: { codeMode: true, responsesLite: true },
@@ -205,6 +197,5 @@ test("configured Responses models route through the Code Mode stream in Pi's mod
 	} finally {
 		registration?.shutdown();
 		globalThis.fetch = originalFetch;
-		await rm(agentDir, { recursive: true, force: true });
 	}
 });

--- a/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
+++ b/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { registerApplyPatchResultEvent } from "../src/tools/apply-patch/tool.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createApplyPatchTool,
+	registerApplyPatchResultEvent,
+} from "../src/tools/apply-patch/tool.ts";
 import { parseViewImageParams } from "../src/tools/view-image/tool.ts";
 
 test("apply_patch partial mutations remain error results", () => {
@@ -16,6 +22,42 @@ test("apply_patch partial mutations remain error results", () => {
 		details: { status: "partial_failure", result: {} },
 	}), { isError: true });
 	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result: {} } }), undefined);
+});
+
+test("apply_patch context failures request a focused reread", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-apply-patch-error-"));
+	try {
+		writeFileSync(join(cwd, "target.txt"), "current line\n");
+		const execution = createApplyPatchTool().execute(
+			"call-context-failure",
+			{
+				input: [
+					"*** Begin Patch",
+					"*** Update File: target.txt",
+					"@@",
+					"-stale line",
+					"+replacement line",
+					"*** End Patch",
+				].join("\n"),
+			},
+			undefined,
+			undefined,
+			{ cwd } as never,
+		);
+
+		await assert.rejects(execution, (error: Error) => {
+			assert.match(error.message, /target\.txt: expected context not found/);
+			assert.match(error.message, /Expected near: stale line/);
+			assert.match(
+				error.message,
+				/Recovery: MUST read target\.txt and retry only the failed edit against current contents/,
+			);
+			assert.doesNotMatch(error.message, /order each Update File's hunks/);
+			return true;
+		});
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
 });
 
 test("view_image accepts model-style path references", () => {

--- a/packages/pi-dynamic-tools/tests/prompt.test.ts
+++ b/packages/pi-dynamic-tools/tests/prompt.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-	buildDynamicToolsDocumentationPrompt,
-	buildPromotedToolsPrompt,
-	EXEC_DESCRIPTION,
-	injectDynamicToolsPrompt,
-	WAIT_DESCRIPTION,
-} from "../src/prompt.js";
+import { EXEC_DESCRIPTION, injectDynamicToolsPrompt } from "../src/prompt.js";
 import type { DynamicToolDefinition } from "../src/types.js";
 
 function tool(
@@ -30,40 +24,6 @@ describe("dynamic tool prompt tiers", () => {
 	test("keeps exec stable regardless of configured tools", () => {
 		expect(EXEC_DESCRIPTION).not.toContain("common_tool");
 		expect(EXEC_DESCRIPTION).toContain("ALL_TOOLS");
-	});
-
-	test("steers long-running cells away from frequent polling", () => {
-		expect(EXEC_DESCRIPTION).toContain(
-			"use 60000 or more for subagents and long commands",
-		);
-		expect(EXEC_DESCRIPTION).toContain("Long waits remain cancellable");
-		expect(WAIT_DESCRIPTION).toContain(
-			"Prefer one long wait over repeated short waits",
-		);
-		expect(WAIT_DESCRIPTION).toContain("notify progress remains visible");
-	});
-
-	test("promotes exact usage without cosmetic markdown", () => {
-		const prompt = buildPromotedToolsPrompt([
-			tool("common_tool", false, "await tools.common_tool({ query: string })"),
-			tool("rare_tool", true),
-		]);
-		expect(prompt).toBe(
-			"Dynamic tools available in exec:\n- common_tool: await tools.common_tool({ query: string })",
-		);
-		expect(prompt).not.toContain("`");
-		expect(prompt).not.toContain("This detail stays on demand.");
-		expect(prompt).not.toContain("Plain text.");
-	});
-
-	test("points to resolved setup help even when no tools exist", () => {
-		expect(
-			buildDynamicToolsDocumentationPrompt(
-				"/packages/pi-dynamic-tools/DYNAMIC-TOOLS.md",
-			),
-		).toBe(
-			"Dynamic tools documentation: read /packages/pi-dynamic-tools/DYNAMIC-TOOLS.md before adding, changing, or answering questions about dynamic tools.\nPrefer a dynamic tool over a Pi extension for a command-backed capability.",
-		);
 	});
 
 	test("injects documentation and promoted forms before runtime context", () => {

--- a/packages/pi-dynamic-tools/tests/spawn-agent.test.ts
+++ b/packages/pi-dynamic-tools/tests/spawn-agent.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -71,35 +71,6 @@ describe("bundled spawn_agent", () => {
 		expect(explorer).not.toContain("--system-prompt");
 		expect(explorer).not.toContain("--no-context-files");
 		expect(explorer).toContain("--no-skills");
-	});
-
-	test("uses the review extension rubric", () => {
-		const bundled = readFileSync(
-			new URL("../examples/spawn-agent/reviewer.prompt.md", import.meta.url),
-			"utf8",
-		);
-		const reviewExtension = readFileSync(
-			new URL("../../pi-subagent-review/review.prompt.md", import.meta.url),
-			"utf8",
-		);
-		expect(bundled).toBe(reviewExtension);
-	});
-
-	test("documents the example as inactive reference material", () => {
-		const documentation = readFileSync(
-			new URL("../DYNAMIC-TOOLS.md", import.meta.url),
-			"utf8",
-		);
-		expect(documentation).toContain(
-			"Installing the package does not register or enable them.",
-		);
-		expect(documentation).toContain(
-			"It does not control, validate, or transform command output.",
-		);
-		expect(documentation).toContain(
-			"Relative entries inside `args` are not rewritten",
-		);
-		expect(documentation).not.toContain("An agent can");
 	});
 
 	test("detects the review base and builds explicit review instructions", () => {

--- a/packages/pi-semantic-grep/AGENTS.md
+++ b/packages/pi-semantic-grep/AGENTS.md
@@ -1,0 +1,5 @@
+- The nearest configured project marker owns the index; nested catalogue indexes are intentional.
+- Acquire the repository writer lock before opening the writable database. Searches remain read-only WAL readers.
+- Embed a complete file before atomically replacing its rows. Failures must preserve the last complete file index.
+- Content-fingerprint generations are resumable; never clear the live index to begin a rebuild.
+- Prefer Git's tracked/untracked `--exclude-standard` discovery. The filesystem fallback stays bounded and churn-tolerant.

--- a/packages/pi-semantic-grep/AGENTS.md
+++ b/packages/pi-semantic-grep/AGENTS.md
@@ -1,4 +1,5 @@
 - The nearest configured project marker owns the index; nested catalogue indexes are intentional.
+- Session startup returns before discovery; background scanning and file loops yield to Pi's event loop while stale searches stay available.
 - Acquire the repository writer lock before opening the writable database. Searches remain read-only WAL readers.
 - Embed a complete file before atomically replacing its rows. Failures must preserve the last complete file index.
 - Content-fingerprint generations are resumable; never clear the live index to begin a rebuild.

--- a/packages/pi-semantic-grep/package.json
+++ b/packages/pi-semantic-grep/package.json
@@ -39,21 +39,26 @@
 	"scripts": {
 		"check": "bun run lint && bun run typecheck",
 		"prepack": "bun run check",
+		"test": "tsx --test tests/**/*.test.ts",
 		"typecheck": "tsgo --noEmit",
 		"lint": "biome check .",
 		"format": "biome check --write ."
 	},
 	"dependencies": {
-		"better-sqlite3": "^12.10.0"
+		"better-sqlite3": "^12.10.0",
+		"ignore": "^7.0.5",
+		"proper-lockfile": "^4.1.2"
 	},
 	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.13",
-		"@types/node": "^24.0.0",
-		"typescript": "^5.8.3",
 		"@biomejs/biome": "^2.4.16",
 		"@earendil-works/pi-coding-agent": "0.82.0",
 		"@earendil-works/pi-tui": "0.82.0",
-		"typebox": "1.1.38"
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/node": "^24.0.0",
+		"@types/proper-lockfile": "^4.1.4",
+		"tsx": "^4.20.5",
+		"typebox": "1.1.38",
+		"typescript": "^5.8.3"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",

--- a/packages/pi-semantic-grep/src/config.ts
+++ b/packages/pi-semantic-grep/src/config.ts
@@ -9,14 +9,22 @@ export interface SemanticGrepConfig {
 		model: string;
 		apiKey?: string;
 		dimensions?: number;
+		batchSize: number;
+		queryPrefix: string;
+		documentPrefix: string;
+		queryExtraBody: Record<string, unknown>;
+		documentExtraBody: Record<string, unknown>;
 	};
 	indexing: {
 		chunkLines: number;
 		chunkOverlap: number;
 		maxFileBytes: number;
 		maxChunkChars: number;
+		maxEmbeddingChars: number;
 		skipOversizedChunks: boolean;
 		followSymlinks: boolean;
+		useGitIgnore: boolean;
+		maxFiles: number;
 		includeExtensions: string[];
 		excludeDirs: string[];
 	};
@@ -42,19 +50,45 @@ export const PROJECT_CONFIG_BASENAME = path.join(
 	"semantic-grep.json",
 );
 
+export const STANDARD_EXCLUDE_DIRS = [
+	".git",
+	".pi",
+	"node_modules",
+	"dist",
+	"build",
+	"target",
+	".venv",
+	"venv",
+	"vendor",
+	".next",
+	".cache",
+	".turbo",
+	".output",
+	"coverage",
+	"out",
+];
+
 export const DEFAULT_CONFIG: SemanticGrepConfig = {
 	toolRegistration: true,
 	embeddings: {
 		url: "http://127.0.0.1:1234/v1/embeddings",
 		model: "text-embedding-embeddinggemma-300m-qat",
+		batchSize: 32,
+		queryPrefix: "",
+		documentPrefix: "",
+		queryExtraBody: {},
+		documentExtraBody: {},
 	},
 	indexing: {
 		chunkLines: 80,
 		chunkOverlap: 20,
 		maxFileBytes: 512_000,
 		maxChunkChars: 12_000,
+		maxEmbeddingChars: 2_000,
 		skipOversizedChunks: false,
 		followSymlinks: false,
+		useGitIgnore: true,
+		maxFiles: 100_000,
 		includeExtensions: [
 			".ts",
 			".tsx",
@@ -83,19 +117,7 @@ export const DEFAULT_CONFIG: SemanticGrepConfig = {
 			".svelte",
 			".vue",
 		],
-		excludeDirs: [
-			".git",
-			".pi",
-			"node_modules",
-			"dist",
-			"build",
-			"target",
-			".venv",
-			"venv",
-			"vendor",
-			".next",
-			".cache",
-		],
+		excludeDirs: STANDARD_EXCLUDE_DIRS,
 	},
 	search: {
 		defaultTopK: 8,

--- a/packages/pi-semantic-grep/src/db.ts
+++ b/packages/pi-semantic-grep/src/db.ts
@@ -17,16 +17,28 @@ export interface FileRow {
 	size: number;
 	mtime_ms: number;
 	indexed_at: string;
+	index_fingerprint: string;
+	index_generation: number;
+	chunk_count: number;
 }
+
+export interface BuildTarget {
+	fingerprint: string;
+	generation: number;
+	fullRebuild: boolean;
+}
+
+const SCHEMA_VERSION = "5";
 
 export function dbPathFor(root: string): string {
 	return path.join(root, ".pi", "semantic-grep.sqlite");
 }
 
-export function openDb(root: string): Database.Database {
-	mkdirSync(path.join(root, ".pi"), { recursive: true });
-	const db = new Database(dbPathFor(root));
-	db.pragma("journal_mode = WAL");
+export function indexLockPathFor(root: string): string {
+	return path.join(root, ".pi", "semantic-grep.index.lock");
+}
+
+function createSchema(db: Database.Database): void {
 	db.exec(`
     create table if not exists meta (key text primary key, value text not null);
     create table if not exists files (
@@ -34,7 +46,10 @@ export function openDb(root: string): Database.Database {
       hash text not null,
       size integer not null,
       mtime_ms real not null,
-      indexed_at text not null
+      indexed_at text not null,
+      index_fingerprint text not null default '',
+      index_generation integer not null default 0,
+      chunk_count integer not null default 0
     );
     create table if not exists chunks (
       id integer primary key,
@@ -44,15 +59,81 @@ export function openDb(root: string): Database.Database {
       text text not null,
       hash text not null,
       vector text not null,
+      chunk_key text,
       foreign key(file) references files(file) on delete cascade
     );
     create index if not exists chunks_file_idx on chunks(file);
   `);
+}
+
+function columnNames(db: Database.Database, table: string): Set<string> {
+	return new Set(
+		(
+			db.prepare(`pragma table_info(${table})`).all() as Array<{ name: string }>
+		).map((row) => row.name),
+	);
+}
+
+function migrateSchema(db: Database.Database): void {
+	const fileColumns = columnNames(db, "files");
+	const chunkColumns = columnNames(db, "chunks");
+	const migrate = db.transaction(() => {
+		if (!fileColumns.has("index_fingerprint"))
+			db.exec(
+				"alter table files add column index_fingerprint text not null default ''",
+			);
+		if (!fileColumns.has("index_generation"))
+			db.exec(
+				"alter table files add column index_generation integer not null default 0",
+			);
+		if (!fileColumns.has("chunk_count"))
+			db.exec(
+				"alter table files add column chunk_count integer not null default -1",
+			);
+		if (!chunkColumns.has("chunk_key"))
+			db.exec("alter table chunks add column chunk_key text");
+
+		const legacyFingerprint = getMeta(db, "index_fingerprint") ?? "";
+		if (legacyFingerprint) {
+			db.prepare(
+				"update files set index_fingerprint = ?, index_generation = 1 where index_fingerprint = ''",
+			).run(legacyFingerprint);
+			if (!getMeta(db, "active_fingerprint")) {
+				setMeta(db, "active_fingerprint", legacyFingerprint);
+				setMeta(db, "active_generation", "1");
+			}
+		}
+		db.exec(`
+      update files
+      set chunk_count = (select count(*) from chunks where chunks.file = files.file)
+      where chunk_count < 0;
+      create unique index if not exists chunks_file_key_uidx
+      on chunks(file, chunk_key) where chunk_key is not null;
+    `);
+		setMeta(db, "schema_version", SCHEMA_VERSION);
+	});
+	migrate();
+}
+
+export function openIndexDb(root: string): Database.Database {
+	mkdirSync(path.join(root, ".pi"), { recursive: true });
+	const db = new Database(dbPathFor(root));
+	db.pragma("journal_mode = WAL");
+	db.pragma("foreign_keys = ON");
+	db.pragma("busy_timeout = 5000");
+	createSchema(db);
+	migrateSchema(db);
 	return db;
 }
 
-export function resetDb(db: Database.Database): void {
-	db.exec("delete from chunks; delete from files; delete from meta;");
+export function openSearchDb(root: string): Database.Database {
+	const db = new Database(dbPathFor(root), {
+		readonly: true,
+		fileMustExist: true,
+	});
+	db.pragma("query_only = ON");
+	db.pragma("busy_timeout = 5000");
+	return db;
 }
 
 export function getMeta(
@@ -74,4 +155,58 @@ export function setMeta(
 	db.prepare(
 		"insert into meta (key, value) values (?, ?) on conflict(key) do update set value = excluded.value",
 	).run(key, value);
+}
+
+function metaGeneration(db: Database.Database, key: string): number {
+	const value = Number.parseInt(getMeta(db, key) ?? "0", 10);
+	return Number.isFinite(value) ? value : 0;
+}
+
+export function prepareBuildTarget(
+	db: Database.Database,
+	fingerprint: string,
+	force: boolean,
+): BuildTarget {
+	const activeFingerprint = getMeta(db, "active_fingerprint") ?? "";
+	const activeGeneration = metaGeneration(db, "active_generation");
+	const pendingFingerprint = getMeta(db, "target_fingerprint") ?? "";
+	const pendingGeneration = metaGeneration(db, "target_generation");
+
+	let generation: number;
+	if (!force && pendingFingerprint === fingerprint && pendingGeneration > 0) {
+		generation = pendingGeneration;
+	} else if (!force && activeFingerprint === fingerprint) {
+		generation = activeGeneration || 1;
+	} else {
+		generation = Math.max(activeGeneration, pendingGeneration) + 1;
+	}
+	setMeta(db, "target_fingerprint", fingerprint);
+	setMeta(db, "target_generation", String(generation));
+	setMeta(db, "build_started_at", new Date().toISOString());
+	return {
+		fingerprint,
+		generation,
+		fullRebuild:
+			force ||
+			activeFingerprint !== fingerprint ||
+			activeGeneration !== generation,
+	};
+}
+
+export function completeBuild(
+	db: Database.Database,
+	target: BuildTarget,
+	model: string,
+): void {
+	const complete = db.transaction(() => {
+		setMeta(db, "active_fingerprint", target.fingerprint);
+		setMeta(db, "active_generation", String(target.generation));
+		setMeta(db, "index_fingerprint", target.fingerprint);
+		setMeta(db, "indexed_at", new Date().toISOString());
+		setMeta(db, "embedding_model", model);
+		db.prepare(
+			"delete from meta where key in ('target_fingerprint', 'target_generation', 'build_started_at')",
+		).run();
+	});
+	complete();
 }

--- a/packages/pi-semantic-grep/src/db.ts
+++ b/packages/pi-semantic-grep/src/db.ts
@@ -203,7 +203,10 @@ export function prepareBuildTarget(
 
 	let generation: number;
 	let resetStaging = false;
-	if (!force && pendingFingerprint === fingerprint && pendingGeneration > 0) {
+	if (
+		pendingFingerprint === fingerprint &&
+		pendingGeneration > activeGeneration
+	) {
 		generation = pendingGeneration;
 	} else if (!force && activeFingerprint === fingerprint) {
 		generation = activeGeneration || 1;

--- a/packages/pi-semantic-grep/src/db.ts
+++ b/packages/pi-semantic-grep/src/db.ts
@@ -16,6 +16,7 @@ export interface FileRow {
 	hash: string;
 	size: number;
 	mtime_ms: number;
+	ctime_ms: number;
 	indexed_at: string;
 	index_fingerprint: string;
 	index_generation: number;
@@ -46,6 +47,7 @@ function createSchema(db: Database.Database): void {
       hash text not null,
       size integer not null,
       mtime_ms real not null,
+      ctime_ms real not null,
       indexed_at text not null,
       index_fingerprint text not null default '',
       index_generation integer not null default 0,
@@ -62,7 +64,32 @@ function createSchema(db: Database.Database): void {
       chunk_key text,
       foreign key(file) references files(file) on delete cascade
     );
+    create table if not exists staged_files (
+      file text primary key,
+      hash text not null,
+      size integer not null,
+      mtime_ms real not null,
+      ctime_ms real not null,
+      indexed_at text not null,
+      index_fingerprint text not null,
+      index_generation integer not null,
+      chunk_count integer not null
+    );
+    create table if not exists staged_chunks (
+      id integer primary key,
+      file text not null,
+      start_line integer not null,
+      end_line integer not null,
+      text text not null,
+      hash text not null,
+      vector text not null,
+      chunk_key text not null,
+      foreign key(file) references staged_files(file) on delete cascade
+    );
     create index if not exists chunks_file_idx on chunks(file);
+    create index if not exists staged_chunks_file_idx on staged_chunks(file);
+    create unique index if not exists staged_chunks_file_key_uidx
+      on staged_chunks(file, chunk_key);
   `);
 }
 
@@ -92,6 +119,8 @@ function migrateSchema(db: Database.Database): void {
 			);
 		if (!chunkColumns.has("chunk_key"))
 			db.exec("alter table chunks add column chunk_key text");
+		if (!fileColumns.has("ctime_ms"))
+			db.exec("alter table files add column ctime_ms real not null default 0");
 
 		const legacyFingerprint = getMeta(db, "index_fingerprint") ?? "";
 		if (legacyFingerprint) {
@@ -173,13 +202,18 @@ export function prepareBuildTarget(
 	const pendingGeneration = metaGeneration(db, "target_generation");
 
 	let generation: number;
+	let resetStaging = false;
 	if (!force && pendingFingerprint === fingerprint && pendingGeneration > 0) {
 		generation = pendingGeneration;
 	} else if (!force && activeFingerprint === fingerprint) {
 		generation = activeGeneration || 1;
+		resetStaging = true;
 	} else {
 		generation = Math.max(activeGeneration, pendingGeneration) + 1;
+		resetStaging = true;
 	}
+	if (resetStaging)
+		db.exec("delete from staged_chunks; delete from staged_files;");
 	setMeta(db, "target_fingerprint", fingerprint);
 	setMeta(db, "target_generation", String(generation));
 	setMeta(db, "build_started_at", new Date().toISOString());
@@ -199,6 +233,26 @@ export function completeBuild(
 	model: string,
 ): void {
 	const complete = db.transaction(() => {
+		if (target.fullRebuild) {
+			db.exec(`
+        delete from chunks;
+        delete from files;
+        insert into files (
+          file, hash, size, mtime_ms, ctime_ms, indexed_at,
+          index_fingerprint, index_generation, chunk_count
+        )
+        select file, hash, size, mtime_ms, ctime_ms, indexed_at,
+               index_fingerprint, index_generation, chunk_count
+        from staged_files;
+        insert into chunks (
+          file, start_line, end_line, text, hash, vector, chunk_key
+        )
+        select file, start_line, end_line, text, hash, vector, chunk_key
+        from staged_chunks;
+        delete from staged_chunks;
+        delete from staged_files;
+      `);
+		}
 		setMeta(db, "active_fingerprint", target.fingerprint);
 		setMeta(db, "active_generation", String(target.generation));
 		setMeta(db, "index_fingerprint", target.fingerprint);

--- a/packages/pi-semantic-grep/src/discovery.ts
+++ b/packages/pi-semantic-grep/src/discovery.ts
@@ -9,15 +9,26 @@ export interface DiscoveryResult {
 	files: FileMetadata[];
 	source: "filesystem" | "git";
 	skipped: number;
-}
-
-function excludedByDirectory(rel: string, excluded: Set<string>): boolean {
-	return rel.split(/[\\/]/).some((part) => excluded.has(part));
+	unavailableDirectories: string[];
+	unavailableFiles: Set<string>;
 }
 
 interface Inspection {
 	metadata?: FileMetadata;
 	unavailable: boolean;
+}
+
+interface IgnoreScope {
+	base: string;
+	matcher: Ignore;
+}
+
+function excludedDirectories(config: SemanticGrepConfig): Set<string> {
+	return new Set([...STANDARD_EXCLUDE_DIRS, ...config.indexing.excludeDirs]);
+}
+
+function excludedByDirectory(rel: string, excluded: Set<string>): boolean {
+	return rel.split(/[\\/]/).some((part) => excluded.has(part));
 }
 
 function inspectFile(
@@ -41,7 +52,12 @@ function inspectFile(
 		if (!stat.isFile() || stat.size > config.indexing.maxFileBytes)
 			return { unavailable: false };
 		return {
-			metadata: { file: rel, size: stat.size, mtimeMs: stat.mtimeMs },
+			metadata: {
+				file: rel,
+				size: stat.size,
+				mtimeMs: stat.mtimeMs,
+				ctimeMs: stat.ctimeMs,
+			},
 			unavailable: false,
 		};
 	} catch (error) {
@@ -72,26 +88,57 @@ function gitCandidates(root: string): string[] | undefined {
 	return result.stdout.split("\0").filter(Boolean);
 }
 
-function rootIgnore(root: string, config: SemanticGrepConfig): Ignore {
-	const matcher = ignore();
-	if (!config.indexing.useGitIgnore) return matcher;
+function loadIgnoreScope(root: string, dir: string): IgnoreScope | undefined {
 	try {
-		matcher.add(readFileSync(path.join(root, ".gitignore"), "utf8"));
+		const rules = readFileSync(path.join(root, dir, ".gitignore"), "utf8");
+		return {
+			base: dir.split(path.sep).join("/"),
+			matcher: ignore().add(rules),
+		};
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
 	}
-	return matcher;
+}
+
+function ignoredByScopes(
+	rel: string,
+	directory: boolean,
+	scopes: IgnoreScope[],
+): boolean {
+	const normalized = rel.split(path.sep).join("/");
+	let ignored = false;
+	for (const scope of scopes) {
+		if (scope.base && !normalized.startsWith(`${scope.base}/`)) continue;
+		const local = scope.base
+			? normalized.slice(scope.base.length + 1)
+			: normalized;
+		if (!local) continue;
+		const result = scope.matcher.checkIgnore(directory ? `${local}/` : local);
+		if (result.rule) ignored = result.ignored;
+	}
+	return ignored;
 }
 
 function filesystemCandidates(
 	root: string,
 	config: SemanticGrepConfig,
-): { files: string[]; skipped: number } {
+): {
+	files: string[];
+	skipped: number;
+	unavailableDirectories: string[];
+} {
 	const excluded = excludedDirectories(config);
-	const matcher = rootIgnore(root, config);
 	const files: string[] = [];
+	const unavailableDirectories: string[] = [];
 	let skipped = 0;
-	const walk = (dir: string): void => {
+	const walk = (dir: string, inheritedScopes: IgnoreScope[]): void => {
+		const localScope = config.indexing.useGitIgnore
+			? loadIgnoreScope(root, dir)
+			: undefined;
+		const scopes = localScope
+			? [...inheritedScopes, localScope]
+			: inheritedScopes;
 		let entries;
 		try {
 			entries = readdirSync(path.join(root, dir), { withFileTypes: true });
@@ -99,33 +146,32 @@ function filesystemCandidates(
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
 				skipped++;
+				unavailableDirectories.push(dir);
 				return;
 			}
 			throw error;
 		}
 		for (const entry of entries) {
 			const rel = dir ? path.join(dir, entry.name) : entry.name;
-			const normalized = rel.split(path.sep).join("/");
 			if (entry.isSymbolicLink()) {
-				if (config.indexing.followSymlinks && !matcher.ignores(normalized))
+				if (
+					config.indexing.followSymlinks &&
+					!ignoredByScopes(rel, false, scopes)
+				)
 					files.push(rel);
 				continue;
 			}
 			if (entry.isDirectory()) {
-				if (excluded.has(entry.name) || matcher.ignores(`${normalized}/`))
+				if (excluded.has(entry.name) || ignoredByScopes(rel, true, scopes))
 					continue;
-				walk(rel);
-			} else if (entry.isFile() && !matcher.ignores(normalized)) {
+				walk(rel, scopes);
+			} else if (entry.isFile() && !ignoredByScopes(rel, false, scopes)) {
 				files.push(rel);
 			}
 		}
 	};
-	walk("");
-	return { files, skipped };
-}
-
-function excludedDirectories(config: SemanticGrepConfig): Set<string> {
-	return new Set([...STANDARD_EXCLUDE_DIRS, ...config.indexing.excludeDirs]);
+	walk("", []);
+	return { files, skipped, unavailableDirectories };
 }
 
 export function discoverFiles(
@@ -138,12 +184,16 @@ export function discoverFiles(
 	const fallback = fromGit ? undefined : filesystemCandidates(root, config);
 	const candidates = fromGit ?? fallback?.files ?? [];
 	const files: FileMetadata[] = [];
+	const unavailableFiles = new Set<string>();
 	const excluded = excludedDirectories(config);
 	let skipped = fallback?.skipped ?? 0;
 	for (const rel of candidates) {
 		const inspection = inspectFile(root, rel, config, excluded);
 		if (inspection.metadata) files.push(inspection.metadata);
-		else if (inspection.unavailable) skipped++;
+		else if (inspection.unavailable) {
+			skipped++;
+			unavailableFiles.add(rel);
+		}
 	}
 	if (files.length > config.indexing.maxFiles) {
 		throw new Error(
@@ -151,5 +201,11 @@ export function discoverFiles(
 		);
 	}
 	files.sort((a, b) => a.file.localeCompare(b.file));
-	return { files, source: fromGit ? "git" : "filesystem", skipped };
+	return {
+		files,
+		source: fromGit ? "git" : "filesystem",
+		skipped,
+		unavailableDirectories: fallback?.unavailableDirectories ?? [],
+		unavailableFiles,
+	};
 }

--- a/packages/pi-semantic-grep/src/discovery.ts
+++ b/packages/pi-semantic-grep/src/discovery.ts
@@ -7,6 +7,7 @@ import { type SemanticGrepConfig, STANDARD_EXCLUDE_DIRS } from "./config.js";
 import type { FileMetadata } from "./files.js";
 
 const execFileAsync = promisify(execFile);
+const METADATA_CONCURRENCY = 32;
 
 export interface DiscoveryResult {
 	files: FileMetadata[];
@@ -39,7 +40,9 @@ async function inspectFile(
 	rel: string,
 	config: SemanticGrepConfig,
 	excluded: Set<string>,
+	signal?: AbortSignal,
 ): Promise<Inspection> {
+	signal?.throwIfAborted();
 	if (
 		excludedByDirectory(rel, excluded) ||
 		!config.indexing.includeExtensions.includes(path.extname(rel).toLowerCase())
@@ -49,6 +52,7 @@ async function inspectFile(
 	const abs = path.join(root, rel);
 	try {
 		const entry = await lstat(abs);
+		signal?.throwIfAborted();
 		if (entry.isSymbolicLink() && !config.indexing.followSymlinks)
 			return { unavailable: false };
 		const fileStat = entry.isSymbolicLink() ? await stat(abs) : entry;
@@ -71,7 +75,10 @@ async function inspectFile(
 	}
 }
 
-async function gitCandidates(root: string): Promise<string[] | undefined> {
+async function gitCandidates(
+	root: string,
+	signal?: AbortSignal,
+): Promise<string[] | undefined> {
 	try {
 		const { stdout } = await execFileAsync(
 			"git",
@@ -86,10 +93,12 @@ async function gitCandidates(root: string): Promise<string[] | undefined> {
 				"--",
 				".",
 			],
-			{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+			{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024, signal },
 		);
+		signal?.throwIfAborted();
 		return stdout.split("\0").filter(Boolean);
 	} catch {
+		signal?.throwIfAborted();
 		return undefined;
 	}
 }
@@ -97,9 +106,12 @@ async function gitCandidates(root: string): Promise<string[] | undefined> {
 async function loadIgnoreScope(
 	root: string,
 	dir: string,
+	signal?: AbortSignal,
 ): Promise<IgnoreScope | undefined> {
+	signal?.throwIfAborted();
 	try {
 		const rules = await readFile(path.join(root, dir, ".gitignore"), "utf8");
+		signal?.throwIfAborted();
 		return {
 			base: dir.split(path.sep).join("/"),
 			matcher: ignore().add(rules),
@@ -132,6 +144,7 @@ function ignoredByScopes(
 async function filesystemCandidates(
 	root: string,
 	config: SemanticGrepConfig,
+	signal?: AbortSignal,
 ): Promise<{
 	files: string[];
 	skipped: number;
@@ -145,8 +158,9 @@ async function filesystemCandidates(
 		dir: string,
 		inheritedScopes: IgnoreScope[],
 	): Promise<void> => {
+		signal?.throwIfAborted();
 		const localScope = config.indexing.useGitIgnore
-			? await loadIgnoreScope(root, dir)
+			? await loadIgnoreScope(root, dir, signal)
 			: undefined;
 		const scopes = localScope
 			? [...inheritedScopes, localScope]
@@ -154,6 +168,7 @@ async function filesystemCandidates(
 		let entries;
 		try {
 			entries = await readdir(path.join(root, dir), { withFileTypes: true });
+			signal?.throwIfAborted();
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
@@ -164,6 +179,7 @@ async function filesystemCandidates(
 			throw error;
 		}
 		for (const entry of entries) {
+			signal?.throwIfAborted();
 			const rel = dir ? path.join(dir, entry.name) : entry.name;
 			if (entry.isSymbolicLink()) {
 				if (
@@ -189,34 +205,54 @@ async function filesystemCandidates(
 export async function discoverFiles(
 	root: string,
 	config: SemanticGrepConfig,
+	signal?: AbortSignal,
 ): Promise<DiscoveryResult> {
+	signal?.throwIfAborted();
 	const fromGit = config.indexing.useGitIgnore
-		? await gitCandidates(root)
+		? await gitCandidates(root, signal)
 		: undefined;
 	const fallback = fromGit
 		? undefined
-		: await filesystemCandidates(root, config);
+		: await filesystemCandidates(root, config, signal);
 	const candidates = fromGit ?? fallback?.files ?? [];
 	const files: FileMetadata[] = [];
 	const unavailableFiles = new Set<string>();
 	const excluded = excludedDirectories(config);
 	let skipped = fallback?.skipped ?? 0;
-	for (let start = 0; start < candidates.length; start += 256) {
-		const batch = candidates.slice(start, start + 256);
-		const inspections = await Promise.all(
-			batch.map((rel) => inspectFile(root, rel, config, excluded)),
-		);
-		for (let index = 0; index < batch.length; index++) {
-			const rel = batch[index];
-			const inspection = inspections[index];
-			if (!rel || !inspection) continue;
-			if (inspection.metadata) files.push(inspection.metadata);
-			else if (inspection.unavailable) {
-				skipped++;
-				unavailableFiles.add(rel);
+	let cursor = 0;
+	let failure: unknown;
+	const worker = async (): Promise<void> => {
+		while (failure === undefined) {
+			try {
+				signal?.throwIfAborted();
+				const index = cursor++;
+				const rel = candidates[index];
+				if (!rel) return;
+				const inspection = await inspectFile(
+					root,
+					rel,
+					config,
+					excluded,
+					signal,
+				);
+				if (inspection.metadata) files.push(inspection.metadata);
+				else if (inspection.unavailable) {
+					skipped++;
+					unavailableFiles.add(rel);
+				}
+			} catch (error) {
+				failure = error;
 			}
 		}
-	}
+	};
+	await Promise.all(
+		Array.from(
+			{ length: Math.min(METADATA_CONCURRENCY, candidates.length) },
+			worker,
+		),
+	);
+	if (failure !== undefined) throw failure;
+	signal?.throwIfAborted();
 	if (files.length > config.indexing.maxFiles) {
 		throw new Error(
 			`semantic grep found ${files.length} indexable files, above indexing.maxFiles=${config.indexing.maxFiles}; narrow the project root or exclusions`,

--- a/packages/pi-semantic-grep/src/discovery.ts
+++ b/packages/pi-semantic-grep/src/discovery.ts
@@ -27,6 +27,12 @@ interface IgnoreScope {
 	matcher: Ignore;
 }
 
+function fileLimitError(config: SemanticGrepConfig): Error {
+	return new Error(
+		`semantic grep found more than indexing.maxFiles=${config.indexing.maxFiles} indexable files; narrow the project root or exclusions`,
+	);
+}
+
 function excludedDirectories(config: SemanticGrepConfig): Set<string> {
 	return new Set([...STANDARD_EXCLUDE_DIRS, ...config.indexing.excludeDirs]);
 }
@@ -80,23 +86,33 @@ async function gitCandidates(
 	signal?: AbortSignal,
 ): Promise<string[] | undefined> {
 	try {
-		const { stdout } = await execFileAsync(
-			"git",
-			[
-				"-C",
-				root,
-				"ls-files",
-				"--cached",
-				"--others",
-				"--exclude-standard",
-				"-z",
-				"--",
-				".",
-			],
-			{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024, signal },
-		);
+		const [listed, removed] = await Promise.all([
+			execFileAsync(
+				"git",
+				[
+					"-C",
+					root,
+					"ls-files",
+					"--cached",
+					"--others",
+					"--exclude-standard",
+					"-z",
+					"--",
+					".",
+				],
+				{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024, signal },
+			),
+			execFileAsync(
+				"git",
+				["-C", root, "ls-files", "--deleted", "-z", "--", "."],
+				{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024, signal },
+			),
+		]);
 		signal?.throwIfAborted();
-		return stdout.split("\0").filter(Boolean);
+		const deleted = new Set(removed.stdout.split("\0").filter(Boolean));
+		return listed.stdout
+			.split("\0")
+			.filter((file) => file && !deleted.has(file));
 	} catch {
 		signal?.throwIfAborted();
 		return undefined;
@@ -146,22 +162,45 @@ async function filesystemCandidates(
 	config: SemanticGrepConfig,
 	signal?: AbortSignal,
 ): Promise<{
-	files: string[];
+	files: FileMetadata[];
 	skipped: number;
 	unavailableDirectories: string[];
+	unavailableFiles: Set<string>;
 }> {
 	const excluded = excludedDirectories(config);
-	const files: string[] = [];
+	const files: FileMetadata[] = [];
 	const unavailableDirectories: string[] = [];
+	const unavailableFiles = new Set<string>();
 	let skipped = 0;
+	const inspect = async (rel: string): Promise<void> => {
+		const inspection = await inspectFile(root, rel, config, excluded, signal);
+		if (inspection.metadata) {
+			files.push(inspection.metadata);
+			if (files.length > config.indexing.maxFiles) throw fileLimitError(config);
+		} else if (inspection.unavailable) {
+			skipped++;
+			unavailableFiles.add(rel);
+		}
+	};
 	const walk = async (
 		dir: string,
 		inheritedScopes: IgnoreScope[],
 	): Promise<void> => {
 		signal?.throwIfAborted();
-		const localScope = config.indexing.useGitIgnore
-			? await loadIgnoreScope(root, dir, signal)
-			: undefined;
+		let localScope: IgnoreScope | undefined;
+		try {
+			localScope = config.indexing.useGitIgnore
+				? await loadIgnoreScope(root, dir, signal)
+				: undefined;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "EACCES" || code === "EPERM") {
+				skipped++;
+				unavailableDirectories.push(dir);
+				return;
+			}
+			throw error;
+		}
 		const scopes = localScope
 			? [...inheritedScopes, localScope]
 			: inheritedScopes;
@@ -186,20 +225,19 @@ async function filesystemCandidates(
 					config.indexing.followSymlinks &&
 					!ignoredByScopes(rel, false, scopes)
 				)
-					files.push(rel);
+					await inspect(rel);
 				continue;
 			}
 			if (entry.isDirectory()) {
 				if (excluded.has(entry.name) || ignoredByScopes(rel, true, scopes))
 					continue;
 				await walk(rel, scopes);
-			} else if (entry.isFile() && !ignoredByScopes(rel, false, scopes)) {
-				files.push(rel);
-			}
+			} else if (entry.isFile() && !ignoredByScopes(rel, false, scopes))
+				await inspect(rel);
 		}
 	};
 	await walk("", []);
-	return { files, skipped, unavailableDirectories };
+	return { files, skipped, unavailableDirectories, unavailableFiles };
 }
 
 export async function discoverFiles(
@@ -214,9 +252,9 @@ export async function discoverFiles(
 	const fallback = fromGit
 		? undefined
 		: await filesystemCandidates(root, config, signal);
-	const candidates = fromGit ?? fallback?.files ?? [];
-	const files: FileMetadata[] = [];
-	const unavailableFiles = new Set<string>();
+	const candidates = fromGit ?? [];
+	const files: FileMetadata[] = fallback?.files ?? [];
+	const unavailableFiles = fallback?.unavailableFiles ?? new Set<string>();
 	const excluded = excludedDirectories(config);
 	let skipped = fallback?.skipped ?? 0;
 	let cursor = 0;
@@ -236,6 +274,8 @@ export async function discoverFiles(
 					signal,
 				);
 				if (inspection.metadata) files.push(inspection.metadata);
+				if (files.length > config.indexing.maxFiles)
+					throw fileLimitError(config);
 				else if (inspection.unavailable) {
 					skipped++;
 					unavailableFiles.add(rel);
@@ -253,11 +293,6 @@ export async function discoverFiles(
 	);
 	if (failure !== undefined) throw failure;
 	signal?.throwIfAborted();
-	if (files.length > config.indexing.maxFiles) {
-		throw new Error(
-			`semantic grep found ${files.length} indexable files, above indexing.maxFiles=${config.indexing.maxFiles}; narrow the project root or exclusions`,
-		);
-	}
 	files.sort((a, b) => a.file.localeCompare(b.file));
 	return {
 		files,

--- a/packages/pi-semantic-grep/src/discovery.ts
+++ b/packages/pi-semantic-grep/src/discovery.ts
@@ -1,0 +1,155 @@
+import { spawnSync } from "node:child_process";
+import { lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import ignore, { type Ignore } from "ignore";
+import { type SemanticGrepConfig, STANDARD_EXCLUDE_DIRS } from "./config.js";
+import type { FileMetadata } from "./files.js";
+
+export interface DiscoveryResult {
+	files: FileMetadata[];
+	source: "filesystem" | "git";
+	skipped: number;
+}
+
+function excludedByDirectory(rel: string, excluded: Set<string>): boolean {
+	return rel.split(/[\\/]/).some((part) => excluded.has(part));
+}
+
+interface Inspection {
+	metadata?: FileMetadata;
+	unavailable: boolean;
+}
+
+function inspectFile(
+	root: string,
+	rel: string,
+	config: SemanticGrepConfig,
+	excluded: Set<string>,
+): Inspection {
+	if (
+		excludedByDirectory(rel, excluded) ||
+		!config.indexing.includeExtensions.includes(path.extname(rel).toLowerCase())
+	)
+		return { unavailable: false };
+
+	const abs = path.join(root, rel);
+	try {
+		const entry = lstatSync(abs);
+		if (entry.isSymbolicLink() && !config.indexing.followSymlinks)
+			return { unavailable: false };
+		const stat = entry.isSymbolicLink() ? statSync(abs) : entry;
+		if (!stat.isFile() || stat.size > config.indexing.maxFileBytes)
+			return { unavailable: false };
+		return {
+			metadata: { file: rel, size: stat.size, mtimeMs: stat.mtimeMs },
+			unavailable: false,
+		};
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "EACCES" || code === "EPERM")
+			return { unavailable: true };
+		throw error;
+	}
+}
+
+function gitCandidates(root: string): string[] | undefined {
+	const result = spawnSync(
+		"git",
+		[
+			"-C",
+			root,
+			"ls-files",
+			"--cached",
+			"--others",
+			"--exclude-standard",
+			"-z",
+			"--",
+			".",
+		],
+		{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+	);
+	if (result.status !== 0) return undefined;
+	return result.stdout.split("\0").filter(Boolean);
+}
+
+function rootIgnore(root: string, config: SemanticGrepConfig): Ignore {
+	const matcher = ignore();
+	if (!config.indexing.useGitIgnore) return matcher;
+	try {
+		matcher.add(readFileSync(path.join(root, ".gitignore"), "utf8"));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return matcher;
+}
+
+function filesystemCandidates(
+	root: string,
+	config: SemanticGrepConfig,
+): { files: string[]; skipped: number } {
+	const excluded = excludedDirectories(config);
+	const matcher = rootIgnore(root, config);
+	const files: string[] = [];
+	let skipped = 0;
+	const walk = (dir: string): void => {
+		let entries;
+		try {
+			entries = readdirSync(path.join(root, dir), { withFileTypes: true });
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
+				skipped++;
+				return;
+			}
+			throw error;
+		}
+		for (const entry of entries) {
+			const rel = dir ? path.join(dir, entry.name) : entry.name;
+			const normalized = rel.split(path.sep).join("/");
+			if (entry.isSymbolicLink()) {
+				if (config.indexing.followSymlinks && !matcher.ignores(normalized))
+					files.push(rel);
+				continue;
+			}
+			if (entry.isDirectory()) {
+				if (excluded.has(entry.name) || matcher.ignores(`${normalized}/`))
+					continue;
+				walk(rel);
+			} else if (entry.isFile() && !matcher.ignores(normalized)) {
+				files.push(rel);
+			}
+		}
+	};
+	walk("");
+	return { files, skipped };
+}
+
+function excludedDirectories(config: SemanticGrepConfig): Set<string> {
+	return new Set([...STANDARD_EXCLUDE_DIRS, ...config.indexing.excludeDirs]);
+}
+
+export function discoverFiles(
+	root: string,
+	config: SemanticGrepConfig,
+): DiscoveryResult {
+	const fromGit = config.indexing.useGitIgnore
+		? gitCandidates(root)
+		: undefined;
+	const fallback = fromGit ? undefined : filesystemCandidates(root, config);
+	const candidates = fromGit ?? fallback?.files ?? [];
+	const files: FileMetadata[] = [];
+	const excluded = excludedDirectories(config);
+	let skipped = fallback?.skipped ?? 0;
+	for (const rel of candidates) {
+		const inspection = inspectFile(root, rel, config, excluded);
+		if (inspection.metadata) files.push(inspection.metadata);
+		else if (inspection.unavailable) skipped++;
+	}
+	if (files.length > config.indexing.maxFiles) {
+		throw new Error(
+			`semantic grep found ${files.length} indexable files, above indexing.maxFiles=${config.indexing.maxFiles}; narrow the project root or exclusions`,
+		);
+	}
+	files.sort((a, b) => a.file.localeCompare(b.file));
+	return { files, source: fromGit ? "git" : "filesystem", skipped };
+}

--- a/packages/pi-semantic-grep/src/discovery.ts
+++ b/packages/pi-semantic-grep/src/discovery.ts
@@ -1,9 +1,12 @@
-import { spawnSync } from "node:child_process";
-import { lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { lstat, readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import ignore, { type Ignore } from "ignore";
 import { type SemanticGrepConfig, STANDARD_EXCLUDE_DIRS } from "./config.js";
 import type { FileMetadata } from "./files.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface DiscoveryResult {
 	files: FileMetadata[];
@@ -31,12 +34,12 @@ function excludedByDirectory(rel: string, excluded: Set<string>): boolean {
 	return rel.split(/[\\/]/).some((part) => excluded.has(part));
 }
 
-function inspectFile(
+async function inspectFile(
 	root: string,
 	rel: string,
 	config: SemanticGrepConfig,
 	excluded: Set<string>,
-): Inspection {
+): Promise<Inspection> {
 	if (
 		excludedByDirectory(rel, excluded) ||
 		!config.indexing.includeExtensions.includes(path.extname(rel).toLowerCase())
@@ -45,18 +48,18 @@ function inspectFile(
 
 	const abs = path.join(root, rel);
 	try {
-		const entry = lstatSync(abs);
+		const entry = await lstat(abs);
 		if (entry.isSymbolicLink() && !config.indexing.followSymlinks)
 			return { unavailable: false };
-		const stat = entry.isSymbolicLink() ? statSync(abs) : entry;
-		if (!stat.isFile() || stat.size > config.indexing.maxFileBytes)
+		const fileStat = entry.isSymbolicLink() ? await stat(abs) : entry;
+		if (!fileStat.isFile() || fileStat.size > config.indexing.maxFileBytes)
 			return { unavailable: false };
 		return {
 			metadata: {
 				file: rel,
-				size: stat.size,
-				mtimeMs: stat.mtimeMs,
-				ctimeMs: stat.ctimeMs,
+				size: fileStat.size,
+				mtimeMs: fileStat.mtimeMs,
+				ctimeMs: fileStat.ctimeMs,
 			},
 			unavailable: false,
 		};
@@ -68,29 +71,35 @@ function inspectFile(
 	}
 }
 
-function gitCandidates(root: string): string[] | undefined {
-	const result = spawnSync(
-		"git",
-		[
-			"-C",
-			root,
-			"ls-files",
-			"--cached",
-			"--others",
-			"--exclude-standard",
-			"-z",
-			"--",
-			".",
-		],
-		{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
-	);
-	if (result.status !== 0) return undefined;
-	return result.stdout.split("\0").filter(Boolean);
+async function gitCandidates(root: string): Promise<string[] | undefined> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			[
+				"-C",
+				root,
+				"ls-files",
+				"--cached",
+				"--others",
+				"--exclude-standard",
+				"-z",
+				"--",
+				".",
+			],
+			{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+		);
+		return stdout.split("\0").filter(Boolean);
+	} catch {
+		return undefined;
+	}
 }
 
-function loadIgnoreScope(root: string, dir: string): IgnoreScope | undefined {
+async function loadIgnoreScope(
+	root: string,
+	dir: string,
+): Promise<IgnoreScope | undefined> {
 	try {
-		const rules = readFileSync(path.join(root, dir, ".gitignore"), "utf8");
+		const rules = await readFile(path.join(root, dir, ".gitignore"), "utf8");
 		return {
 			base: dir.split(path.sep).join("/"),
 			matcher: ignore().add(rules),
@@ -120,28 +129,31 @@ function ignoredByScopes(
 	return ignored;
 }
 
-function filesystemCandidates(
+async function filesystemCandidates(
 	root: string,
 	config: SemanticGrepConfig,
-): {
+): Promise<{
 	files: string[];
 	skipped: number;
 	unavailableDirectories: string[];
-} {
+}> {
 	const excluded = excludedDirectories(config);
 	const files: string[] = [];
 	const unavailableDirectories: string[] = [];
 	let skipped = 0;
-	const walk = (dir: string, inheritedScopes: IgnoreScope[]): void => {
+	const walk = async (
+		dir: string,
+		inheritedScopes: IgnoreScope[],
+	): Promise<void> => {
 		const localScope = config.indexing.useGitIgnore
-			? loadIgnoreScope(root, dir)
+			? await loadIgnoreScope(root, dir)
 			: undefined;
 		const scopes = localScope
 			? [...inheritedScopes, localScope]
 			: inheritedScopes;
 		let entries;
 		try {
-			entries = readdirSync(path.join(root, dir), { withFileTypes: true });
+			entries = await readdir(path.join(root, dir), { withFileTypes: true });
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
@@ -164,35 +176,45 @@ function filesystemCandidates(
 			if (entry.isDirectory()) {
 				if (excluded.has(entry.name) || ignoredByScopes(rel, true, scopes))
 					continue;
-				walk(rel, scopes);
+				await walk(rel, scopes);
 			} else if (entry.isFile() && !ignoredByScopes(rel, false, scopes)) {
 				files.push(rel);
 			}
 		}
 	};
-	walk("", []);
+	await walk("", []);
 	return { files, skipped, unavailableDirectories };
 }
 
-export function discoverFiles(
+export async function discoverFiles(
 	root: string,
 	config: SemanticGrepConfig,
-): DiscoveryResult {
+): Promise<DiscoveryResult> {
 	const fromGit = config.indexing.useGitIgnore
-		? gitCandidates(root)
+		? await gitCandidates(root)
 		: undefined;
-	const fallback = fromGit ? undefined : filesystemCandidates(root, config);
+	const fallback = fromGit
+		? undefined
+		: await filesystemCandidates(root, config);
 	const candidates = fromGit ?? fallback?.files ?? [];
 	const files: FileMetadata[] = [];
 	const unavailableFiles = new Set<string>();
 	const excluded = excludedDirectories(config);
 	let skipped = fallback?.skipped ?? 0;
-	for (const rel of candidates) {
-		const inspection = inspectFile(root, rel, config, excluded);
-		if (inspection.metadata) files.push(inspection.metadata);
-		else if (inspection.unavailable) {
-			skipped++;
-			unavailableFiles.add(rel);
+	for (let start = 0; start < candidates.length; start += 256) {
+		const batch = candidates.slice(start, start + 256);
+		const inspections = await Promise.all(
+			batch.map((rel) => inspectFile(root, rel, config, excluded)),
+		);
+		for (let index = 0; index < batch.length; index++) {
+			const rel = batch[index];
+			const inspection = inspections[index];
+			if (!rel || !inspection) continue;
+			if (inspection.metadata) files.push(inspection.metadata);
+			else if (inspection.unavailable) {
+				skipped++;
+				unavailableFiles.add(rel);
+			}
 		}
 	}
 	if (files.length > config.indexing.maxFiles) {

--- a/packages/pi-semantic-grep/src/embeddings.ts
+++ b/packages/pi-semantic-grep/src/embeddings.ts
@@ -1,33 +1,127 @@
 import type { SemanticGrepConfig } from "./config.js";
 
-interface EmbeddingResponse {
-	data?: Array<{ embedding?: number[] }>;
+interface EmbeddingDatum {
+	embedding?: number[];
+	index?: number;
 }
 
-export async function embed(
+interface EmbeddingResponse {
+	data?: EmbeddingDatum[];
+}
+
+type EmbeddingKind = "document" | "query";
+
+function inputFor(
 	input: string,
+	kind: EmbeddingKind,
+	config: SemanticGrepConfig,
+): string {
+	const prefix =
+		kind === "query"
+			? config.embeddings.queryPrefix
+			: config.embeddings.documentPrefix;
+	return `${prefix}${input}`;
+}
+
+function extraBodyFor(
+	kind: EmbeddingKind,
+	config: SemanticGrepConfig,
+): Record<string, unknown> {
+	return kind === "query"
+		? config.embeddings.queryExtraBody
+		: config.embeddings.documentExtraBody;
+}
+
+async function requestEmbeddings(
+	inputs: string[],
+	kind: EmbeddingKind,
 	config: SemanticGrepConfig,
 	signal?: AbortSignal,
-): Promise<number[]> {
+): Promise<number[][]> {
+	if (inputs.length === 0) return [];
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 	};
 	if (config.embeddings.apiKey)
 		headers["Authorization"] = `Bearer ${config.embeddings.apiKey}`;
 
-	const init: RequestInit = {
+	const prepared = inputs.map((input) => inputFor(input, kind, config));
+	const body: Record<string, unknown> = {
+		...extraBodyFor(kind, config),
+		model: config.embeddings.model,
+		input: prepared.length === 1 ? prepared[0] : prepared,
+	};
+	if (config.embeddings.dimensions !== undefined)
+		body["dimensions"] = config.embeddings.dimensions;
+
+	const res = await fetch(config.embeddings.url, {
 		method: "POST",
 		headers,
-		body: JSON.stringify({ model: config.embeddings.model, input }),
-	};
-	if (signal) init.signal = signal;
-	const res = await fetch(config.embeddings.url, init);
+		body: JSON.stringify(body),
+		...(signal ? { signal } : {}),
+	});
 	if (!res.ok)
 		throw new Error(`embedding endpoint ${res.status}: ${await res.text()}`);
 	const json = (await res.json()) as EmbeddingResponse;
-	const vector = json.data?.[0]?.embedding;
-	if (!Array.isArray(vector) || vector.length === 0)
-		throw new Error("embedding response did not contain data[0].embedding");
+	const data = json.data;
+	if (!Array.isArray(data) || data.length !== prepared.length) {
+		throw new Error(
+			`embedding response contained ${data?.length ?? 0} vectors for ${prepared.length} inputs`,
+		);
+	}
+
+	const ordered = [...data].sort(
+		(a, b) => (a.index ?? data.indexOf(a)) - (b.index ?? data.indexOf(b)),
+	);
+	const vectors = ordered.map((item) => item.embedding);
+	if (
+		vectors.some(
+			(vector) =>
+				!Array.isArray(vector) ||
+				vector.length === 0 ||
+				vector.some(
+					(value) => typeof value !== "number" || !Number.isFinite(value),
+				),
+		)
+	)
+		throw new Error("embedding response did not contain data[].embedding");
+	const dimensions = vectors[0]?.length;
+	if (!dimensions || vectors.some((vector) => vector?.length !== dimensions))
+		throw new Error(
+			"embedding response contained inconsistent vector dimensions",
+		);
+	return vectors as number[][];
+}
+
+export async function embedDocuments(
+	inputs: string[],
+	config: SemanticGrepConfig,
+	signal?: AbortSignal,
+): Promise<number[][]> {
+	const batchSize = Math.max(1, Math.floor(config.embeddings.batchSize));
+	const vectors: number[][] = [];
+	for (let offset = 0; offset < inputs.length; offset += batchSize) {
+		signal?.throwIfAborted();
+		vectors.push(
+			...(await requestEmbeddings(
+				inputs.slice(offset, offset + batchSize),
+				"document",
+				config,
+				signal,
+			)),
+		);
+	}
+	return vectors;
+}
+
+export async function embedQuery(
+	input: string,
+	config: SemanticGrepConfig,
+	signal?: AbortSignal,
+): Promise<number[]> {
+	const [vector] = await requestEmbeddings([input], "query", config, signal);
+	if (!vector)
+		throw new Error("embedding response did not contain a query vector");
 	return vector;
 }
 
@@ -35,8 +129,7 @@ export function cosine(a: number[], b: number[]): number {
 	let dot = 0,
 		aa = 0,
 		bb = 0;
-	const n = Math.min(a.length, b.length);
-	for (let i = 0; i < n; i++) {
+	for (let i = 0; i < a.length; i++) {
 		const av = a[i] ?? 0;
 		const bv = b[i] ?? 0;
 		dot += av * bv;

--- a/packages/pi-semantic-grep/src/event-loop.ts
+++ b/packages/pi-semantic-grep/src/event-loop.ts
@@ -1,0 +1,3 @@
+export function nextEventLoopTurn(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/pi-semantic-grep/src/files.ts
+++ b/packages/pi-semantic-grep/src/files.ts
@@ -16,6 +16,7 @@ export interface FileSnapshot {
 	file: string;
 	size: number;
 	mtimeMs: number;
+	ctimeMs: number;
 	hash: string;
 	text: string;
 }
@@ -24,6 +25,7 @@ export interface FileMetadata {
 	file: string;
 	size: number;
 	mtimeMs: number;
+	ctimeMs: number;
 }
 
 export function hashText(text: string): string {
@@ -42,8 +44,10 @@ export function readFileSnapshot(
 		if (
 			before.size !== after.size ||
 			before.mtimeMs !== after.mtimeMs ||
+			before.ctimeMs !== after.ctimeMs ||
 			after.size !== metadata.size ||
 			after.mtimeMs !== metadata.mtimeMs ||
+			after.ctimeMs !== metadata.ctimeMs ||
 			text.includes("\0")
 		)
 			return undefined;
@@ -51,6 +55,7 @@ export function readFileSnapshot(
 			file: metadata.file,
 			size: after.size,
 			mtimeMs: after.mtimeMs,
+			ctimeMs: after.ctimeMs,
 			hash: hashText(text),
 			text,
 		};
@@ -69,6 +74,7 @@ function pushChunk(
 	endLine: number,
 	text: string,
 	fileHash: string,
+	discriminator = "",
 ): void {
 	const trimmed = text.trim();
 	if (trimmed.length < 20) return;
@@ -78,7 +84,7 @@ function pushChunk(
 		endLine,
 		text: trimmed,
 		hash: fileHash,
-		key: hashText(`${startLine}:${endLine}\0${trimmed}`),
+		key: hashText(`${startLine}:${endLine}:${discriminator}\0${trimmed}`),
 	});
 }
 
@@ -98,6 +104,7 @@ function pushOversizedLine(
 			line,
 			text.slice(offset, offset + maxChars),
 			fileHash,
+			String(offset),
 		);
 }
 

--- a/packages/pi-semantic-grep/src/files.ts
+++ b/packages/pi-semantic-grep/src/files.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import type { SemanticGrepConfig } from "./config.js";
 
@@ -9,58 +9,21 @@ export interface TextChunk {
 	endLine: number;
 	text: string;
 	hash: string;
+	key: string;
 }
 
 export interface FileSnapshot {
 	file: string;
-	abs: string;
 	size: number;
 	mtimeMs: number;
 	hash: string;
+	text: string;
 }
 
-export function findRepoRoot(cwd: string): string {
-	let dir = path.resolve(cwd);
-	while (true) {
-		try {
-			if (statSync(path.join(dir, ".git")).isDirectory()) return dir;
-		} catch {}
-		const parent = path.dirname(dir);
-		if (parent === dir) return path.resolve(cwd);
-		dir = parent;
-	}
-}
-
-function walk(
-	dir: string,
-	root: string,
-	config: SemanticGrepConfig,
-	out: string[],
-): void {
-	for (const ent of readdirSync(dir, { withFileTypes: true })) {
-		if (ent.isSymbolicLink() && !config.indexing.followSymlinks) continue;
-		const abs = path.join(dir, ent.name);
-		if (ent.isDirectory()) {
-			if (!config.indexing.excludeDirs.includes(ent.name))
-				walk(abs, root, config, out);
-			continue;
-		}
-		if (!ent.isFile()) continue;
-		const ext = path.extname(ent.name).toLowerCase();
-		if (!config.indexing.includeExtensions.includes(ext)) continue;
-		const st = statSync(abs);
-		if (st.size > config.indexing.maxFileBytes) continue;
-		out.push(path.relative(root, abs));
-	}
-}
-
-export function listIndexableFiles(
-	root: string,
-	config: SemanticGrepConfig,
-): string[] {
-	const out: string[] = [];
-	walk(root, root, config, out);
-	return out.sort();
+export interface FileMetadata {
+	file: string;
+	size: number;
+	mtimeMs: number;
 }
 
 export function hashText(text: string): string {
@@ -69,74 +32,119 @@ export function hashText(text: string): string {
 
 export function readFileSnapshot(
 	root: string,
-	rel: string,
+	metadata: FileMetadata,
 ): FileSnapshot | undefined {
-	const abs = path.join(root, rel);
-	const st = statSync(abs);
-	const text = readFileSync(abs, "utf8");
-	if (text.includes("\0")) return undefined;
-	return {
-		file: rel,
-		abs,
-		size: st.size,
-		mtimeMs: st.mtimeMs,
-		hash: hashText(text),
-	};
-}
-
-function splitOversizedChunk(text: string, maxChars: number): string[] {
-	const out: string[] = [];
-	for (let i = 0; i < text.length; i += maxChars) {
-		const part = text.slice(i, i + maxChars).trim();
-		if (part.length >= 20) out.push(part);
+	const abs = path.join(root, metadata.file);
+	try {
+		const before = statSync(abs);
+		const text = readFileSync(abs, "utf8");
+		const after = statSync(abs);
+		if (
+			before.size !== after.size ||
+			before.mtimeMs !== after.mtimeMs ||
+			after.size !== metadata.size ||
+			after.mtimeMs !== metadata.mtimeMs ||
+			text.includes("\0")
+		)
+			return undefined;
+		return {
+			file: metadata.file,
+			size: after.size,
+			mtimeMs: after.mtimeMs,
+			hash: hashText(text),
+			text,
+		};
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "EACCES" || code === "EPERM")
+			return undefined;
+		throw error;
 	}
-	return out;
 }
 
-export function chunkFile(
-	root: string,
-	rel: string,
+function pushChunk(
+	out: TextChunk[],
+	file: string,
+	startLine: number,
+	endLine: number,
+	text: string,
+	fileHash: string,
+): void {
+	const trimmed = text.trim();
+	if (trimmed.length < 20) return;
+	out.push({
+		file,
+		startLine,
+		endLine,
+		text: trimmed,
+		hash: fileHash,
+		key: hashText(`${startLine}:${endLine}\0${trimmed}`),
+	});
+}
+
+function pushOversizedLine(
+	out: TextChunk[],
+	file: string,
+	line: number,
+	text: string,
+	fileHash: string,
+	maxChars: number,
+): void {
+	for (let offset = 0; offset < text.length; offset += maxChars)
+		pushChunk(
+			out,
+			file,
+			line,
+			line,
+			text.slice(offset, offset + maxChars),
+			fileHash,
+		);
+}
+
+export function chunkSnapshot(
+	snapshot: FileSnapshot,
 	config: SemanticGrepConfig,
-	knownHash?: string,
 ): TextChunk[] {
-	const abs = path.join(root, rel);
-	const text = readFileSync(abs, "utf8");
-	if (text.includes("\0")) return [];
-	const hash = knownHash ?? hashText(text);
-	const lines = text.split(/\r?\n/);
-	const size = Math.max(1, config.indexing.chunkLines);
-	const overlap = Math.min(config.indexing.chunkOverlap, size - 1);
-	const step = size - overlap;
+	const lines = snapshot.text.split(/\r?\n/);
+	const lineLimit = Math.max(1, config.indexing.chunkLines);
+	const charLimit = Math.max(
+		20,
+		Math.min(config.indexing.maxChunkChars, config.indexing.maxEmbeddingChars),
+	);
+	const configuredOverlap = Math.max(0, config.indexing.chunkOverlap);
 	const chunks: TextChunk[] = [];
-	for (let i = 0; i < lines.length; i += step) {
-		const part = lines.slice(i, i + size);
-		const chunkText = part.join("\n").trim();
-		if (chunkText.length < 20) continue;
-		if (chunkText.length > config.indexing.maxChunkChars) {
-			if (config.indexing.skipOversizedChunks) continue;
-			const subChunks = splitOversizedChunk(
-				chunkText,
-				config.indexing.maxChunkChars,
-			);
-			for (const [j, subText] of subChunks.entries()) {
-				chunks.push({
-					file: rel,
-					startLine: i + 1,
-					endLine: Math.min(i + size, lines.length),
-					text: `[part ${j + 1}/${subChunks.length}]\n${subText}`,
-					hash,
-				});
-			}
-			continue;
+	let start = 0;
+
+	while (start < lines.length) {
+		let end = start;
+		let chars = 0;
+		while (end < lines.length && end - start < lineLimit) {
+			const nextChars = (lines[end]?.length ?? 0) + (end > start ? 1 : 0);
+			if (end > start && chars + nextChars > charLimit) break;
+			chars += nextChars;
+			end++;
 		}
-		chunks.push({
-			file: rel,
-			startLine: i + 1,
-			endLine: Math.min(i + size, lines.length),
-			text: chunkText,
-			hash,
-		});
-		if (i + size >= lines.length) break;
+
+		if (end === start) end++;
+		const text = lines.slice(start, end).join("\n");
+		if (text.length > charLimit) {
+			if (!config.indexing.skipOversizedChunks)
+				pushOversizedLine(
+					chunks,
+					snapshot.file,
+					start + 1,
+					text,
+					snapshot.hash,
+					charLimit,
+				);
+		} else {
+			pushChunk(chunks, snapshot.file, start + 1, end, text, snapshot.hash);
+		}
+
+		if (end >= lines.length) break;
+		const consumed = end - start;
+		const overlap = Math.min(configuredOverlap, Math.max(0, consumed - 1));
+		start = end - overlap;
 	}
 	return chunks;
 }

--- a/packages/pi-semantic-grep/src/files.ts
+++ b/packages/pi-semantic-grep/src/files.ts
@@ -28,6 +28,11 @@ export interface FileMetadata {
 	ctimeMs: number;
 }
 
+export type FileSnapshotRead =
+	| { status: "ready"; snapshot: FileSnapshot }
+	| { status: "unavailable" }
+	| { status: "non-text" };
+
 export function hashText(text: string): string {
 	return crypto.createHash("sha256").update(text).digest("hex");
 }
@@ -35,7 +40,7 @@ export function hashText(text: string): string {
 export function readFileSnapshot(
 	root: string,
 	metadata: FileMetadata,
-): FileSnapshot | undefined {
+): FileSnapshotRead {
 	const abs = path.join(root, metadata.file);
 	try {
 		const before = statSync(abs);
@@ -47,22 +52,25 @@ export function readFileSnapshot(
 			before.ctimeMs !== after.ctimeMs ||
 			after.size !== metadata.size ||
 			after.mtimeMs !== metadata.mtimeMs ||
-			after.ctimeMs !== metadata.ctimeMs ||
-			text.includes("\0")
+			after.ctimeMs !== metadata.ctimeMs
 		)
-			return undefined;
+			return { status: "unavailable" };
+		if (text.includes("\0")) return { status: "non-text" };
 		return {
-			file: metadata.file,
-			size: after.size,
-			mtimeMs: after.mtimeMs,
-			ctimeMs: after.ctimeMs,
-			hash: hashText(text),
-			text,
+			status: "ready",
+			snapshot: {
+				file: metadata.file,
+				size: after.size,
+				mtimeMs: after.mtimeMs,
+				ctimeMs: after.ctimeMs,
+				hash: hashText(text),
+				text,
+			},
 		};
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
 		if (code === "ENOENT" || code === "EACCES" || code === "EPERM")
-			return undefined;
+			return { status: "unavailable" };
 		throw error;
 	}
 }

--- a/packages/pi-semantic-grep/src/index-runner.ts
+++ b/packages/pi-semantic-grep/src/index-runner.ts
@@ -1,6 +1,7 @@
 import type { SemanticGrepConfig } from "./config.js";
 import { openIndexDb } from "./db.js";
 import { discoverFiles } from "./discovery.js";
+import { nextEventLoopTurn } from "./event-loop.js";
 import { type IndexStats, syncIndex } from "./indexer.js";
 import { tryAcquireIndexLock } from "./lock.js";
 
@@ -15,8 +16,10 @@ export async function runIndex(
 	signal?: AbortSignal,
 	onProgress?: (message: string) => void,
 ): Promise<IndexRunResult> {
+	await nextEventLoopTurn();
+	signal?.throwIfAborted();
 	onProgress?.("scanning project files");
-	const discovery = discoverFiles(root, config);
+	const discovery = await discoverFiles(root, config);
 	signal?.throwIfAborted();
 	const release = await tryAcquireIndexLock(root);
 	if (!release) return { status: "busy" };

--- a/packages/pi-semantic-grep/src/index-runner.ts
+++ b/packages/pi-semantic-grep/src/index-runner.ts
@@ -1,0 +1,38 @@
+import type { SemanticGrepConfig } from "./config.js";
+import { openIndexDb } from "./db.js";
+import { type IndexStats, syncIndex } from "./indexer.js";
+import { tryAcquireIndexLock } from "./lock.js";
+
+export type IndexRunResult =
+	| { status: "busy" }
+	| { status: "indexed"; stats: IndexStats };
+
+export async function runIndex(
+	root: string,
+	config: SemanticGrepConfig,
+	forceFullRebuild: boolean,
+	signal?: AbortSignal,
+	onProgress?: (message: string) => void,
+): Promise<IndexRunResult> {
+	const release = await tryAcquireIndexLock(root);
+	if (!release) return { status: "busy" };
+	let db;
+	try {
+		signal?.throwIfAborted();
+		db = openIndexDb(root);
+		return {
+			status: "indexed",
+			stats: await syncIndex(
+				db,
+				root,
+				config,
+				forceFullRebuild,
+				signal,
+				onProgress,
+			),
+		};
+	} finally {
+		db?.close();
+		await release();
+	}
+}

--- a/packages/pi-semantic-grep/src/index-runner.ts
+++ b/packages/pi-semantic-grep/src/index-runner.ts
@@ -19,7 +19,7 @@ export async function runIndex(
 	await nextEventLoopTurn();
 	signal?.throwIfAborted();
 	onProgress?.("scanning project files");
-	const discovery = await discoverFiles(root, config);
+	const discovery = await discoverFiles(root, config, signal);
 	signal?.throwIfAborted();
 	const release = await tryAcquireIndexLock(root);
 	if (!release) return { status: "busy" };

--- a/packages/pi-semantic-grep/src/index-runner.ts
+++ b/packages/pi-semantic-grep/src/index-runner.ts
@@ -1,5 +1,6 @@
 import type { SemanticGrepConfig } from "./config.js";
 import { openIndexDb } from "./db.js";
+import { discoverFiles } from "./discovery.js";
 import { type IndexStats, syncIndex } from "./indexer.js";
 import { tryAcquireIndexLock } from "./lock.js";
 
@@ -14,6 +15,9 @@ export async function runIndex(
 	signal?: AbortSignal,
 	onProgress?: (message: string) => void,
 ): Promise<IndexRunResult> {
+	onProgress?.("scanning project files");
+	const discovery = discoverFiles(root, config);
+	signal?.throwIfAborted();
 	const release = await tryAcquireIndexLock(root);
 	if (!release) return { status: "busy" };
 	let db;
@@ -29,6 +33,7 @@ export async function runIndex(
 				forceFullRebuild,
 				signal,
 				onProgress,
+				discovery,
 			),
 		};
 	} finally {

--- a/packages/pi-semantic-grep/src/index.ts
+++ b/packages/pi-semantic-grep/src/index.ts
@@ -83,6 +83,15 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 				}
 
 				const matches = result.details?.matches ?? [];
+				if (!matches.length && result.details?.skippedIncompatible)
+					return new Text(
+						theme.fg(
+							"warning",
+							`No compatible vectors; ${result.details.skippedIncompatible} stale chunks omitted`,
+						),
+						0,
+						0,
+					);
 				if (!matches.length)
 					return new Text(theme.fg("dim", "No semantic matches"), 0, 0);
 
@@ -205,8 +214,8 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 				}
 				const { stats } = result;
 				ctx.ui.notify(
-					`Semantic grep synced ${stats.files} files: +${stats.added} ~${stats.changed} -${stats.deleted}, ${stats.unchanged} unchanged, ${stats.metadataOnly} metadata-only${stats.skipped ? `, ${stats.skipped} skipped` : ""}${stats.fullRebuild ? " (resumable rebuild)" : ""}`,
-					"info",
+					`Semantic grep synced ${stats.files} files: +${stats.added} ~${stats.changed} -${stats.deleted}, ${stats.unchanged} unchanged, ${stats.metadataOnly} metadata-only${stats.skipped ? `, ${stats.skipped} skipped` : ""}${stats.fullRebuild ? (stats.complete ? " (resumable rebuild complete)" : " (resumable rebuild paused)") : ""}`,
+					stats.complete ? "info" : "warning",
 				);
 			} catch (err) {
 				if (controller.signal.aborted) return;

--- a/packages/pi-semantic-grep/src/index.ts
+++ b/packages/pi-semantic-grep/src/index.ts
@@ -7,26 +7,30 @@ import {
 import { Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import { ensureConfig } from "./config.js";
-import { dbPathFor, openDb } from "./db.js";
-import { syncIndex } from "./indexer.js";
+import { dbPathFor, openSearchDb } from "./db.js";
+import { runIndex } from "./index-runner.js";
 import { denyReason, findProjectRoot } from "./root.js";
 import { formatMatches, type SearchMatch, searchDb } from "./search.js";
 
 const semanticGrepSchema = Type.Object({
-	query: Type.String({ description: "Natural-language search query." }),
+	query: Type.String({ description: "Natural-language search query" }),
 	top_k: Type.Optional(
-		Type.Number({ description: "Maximum matches to return." }),
+		Type.Integer({
+			description: "Maximum matches to return",
+			minimum: 1,
+			maximum: 30,
+		}),
 	),
 });
 
 type SemanticGrepParams = Static<typeof semanticGrepSchema>;
 type SemanticGrepDetails = {
 	error?: string;
-	reason?: string;
 	root?: string;
 	dbFile?: string;
 	query?: string;
 	matches?: SearchMatch[];
+	skippedIncompatible?: number;
 };
 
 function cwdFromCtx(ctx: ExtensionContext): string {
@@ -41,13 +45,13 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 		pi.registerTool<typeof semanticGrepSchema, SemanticGrepDetails>({
 			name: "semantic_grep",
 			label: "Semantic Grep",
-			description: "Search code and docs by meaning.",
-			promptSnippet: "Use semantic_grep for conceptual code/docs discovery.",
+			description: "Search indexed code and docs by meaning",
+			promptSnippet: "Search code and docs by meaning",
 			promptGuidelines: [
-				"semantic_grep: Use early for conceptual or cross-file discovery.",
-				"semantic_grep: Query for behavior, concepts, features, or code paths—not just exact identifiers.",
-				"semantic_grep: Inspect returned locations with file-reading tools before making precise claims or edits.",
-				"semantic_grep: Use exact text search instead when you need literal string occurrences.",
+				"semantic_grep: Use early for conceptual or cross-file discovery",
+				"semantic_grep: Query for behavior, concepts, features, or code paths—not exact identifiers",
+				"semantic_grep: Inspect returned locations before precise claims or edits",
+				"semantic_grep: Use exact text search for literal occurrences",
 			],
 			parameters: semanticGrepSchema,
 			renderCall(args, theme) {
@@ -112,46 +116,27 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 			) {
 				const baseConfig = ensureConfig();
 				const root = findProjectRoot(cwdFromCtx(ctx), baseConfig);
-				if (!root) {
-					return {
-						content: [
-							{
-								type: "text",
-								text: "Semantic grep skipped: no project marker found.",
-							},
-						],
-						details: { error: "no_project_root" },
-					};
-				}
+				if (!root)
+					throw new Error(
+						"Semantic grep needs a project marker in the current directory or an ancestor",
+					);
 				const config = ensureConfig(root);
 				const denied = denyReason(root, config);
-				if (denied) {
-					return {
-						content: [
-							{ type: "text", text: `Semantic grep skipped: ${denied}.` },
-						],
-						details: { error: "denied_root", root, reason: denied },
-					};
-				}
+				if (denied)
+					throw new Error(`Semantic grep refused this root: ${denied}`);
 				const dbFile = dbPathFor(root);
-				if (!existsSync(dbFile)) {
-					return {
-						content: [
-							{
-								type: "text",
-								text: `Semantic grep index not found at ${dbFile}. It should be created automatically at session start; check extension logs/status.`,
-							},
-						],
-						details: { error: "missing_index", dbFile },
-					};
-				}
+				if (!existsSync(dbFile))
+					throw new Error(
+						`Semantic grep index not found at ${dbFile}; indexing starts automatically with the session`,
+					);
 				const topK = Math.min(
 					Math.max(1, params.top_k ?? config.search.defaultTopK),
 					config.search.maxTopK,
+					30,
 				);
-				const db = openDb(root);
+				const db = openSearchDb(root);
 				try {
-					const matches = await searchDb(
+					const results = await searchDb(
 						db,
 						params.query,
 						topK,
@@ -159,8 +144,14 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 						signal,
 					);
 					return {
-						content: [{ type: "text", text: formatMatches(matches) }],
-						details: { root, dbFile, query: params.query, matches },
+						content: [{ type: "text", text: formatMatches(results) }],
+						details: {
+							root,
+							dbFile,
+							query: params.query,
+							matches: results.matches,
+							skippedIncompatible: results.skippedIncompatible,
+						},
 					};
 				} finally {
 					db.close();
@@ -168,7 +159,7 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 			},
 		});
 
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", (_event, ctx) => {
 		const baseConfig = ensureConfig();
 		if (!baseConfig.autoIndex.enabled) return;
 
@@ -195,32 +186,41 @@ export default function semanticGrepExtension(pi: ExtensionAPI) {
 		indexingController?.abort();
 		const controller = new AbortController();
 		indexingController = controller;
-		const db = openDb(root);
 		ctx.ui.setStatus("semantic-grep", "indexing…");
-		try {
-			const stats = await syncIndex(
-				db,
-				root,
-				config,
-				forceFullRebuild,
-				controller.signal,
-				(msg) => ctx.ui.setStatus("semantic-grep", msg),
-			);
-			ctx.ui.notify(
-				`Semantic grep synced ${stats.files} files: +${stats.added} ~${stats.changed} -${stats.deleted}, ${stats.unchanged} unchanged${stats.fullRebuild ? " (full rebuild)" : ""}`,
-				"info",
-			);
-		} catch (err) {
-			if (controller.signal.aborted) return;
-			ctx.ui.notify(
-				`Semantic grep indexing failed: ${err instanceof Error ? err.message : String(err)}`,
-				"error",
-			);
-		} finally {
-			if (indexingController === controller) indexingController = undefined;
-			ctx.ui.setStatus("semantic-grep", undefined);
-			db.close();
-		}
+		void (async () => {
+			try {
+				const result = await runIndex(
+					root,
+					config,
+					forceFullRebuild,
+					controller.signal,
+					(message) => ctx.ui.setStatus("semantic-grep", message),
+				);
+				if (result.status === "busy") {
+					ctx.ui.notify(
+						"Semantic grep indexing is already running for this project",
+						"info",
+					);
+					return;
+				}
+				const { stats } = result;
+				ctx.ui.notify(
+					`Semantic grep synced ${stats.files} files: +${stats.added} ~${stats.changed} -${stats.deleted}, ${stats.unchanged} unchanged, ${stats.metadataOnly} metadata-only${stats.skipped ? `, ${stats.skipped} skipped` : ""}${stats.fullRebuild ? " (resumable rebuild)" : ""}`,
+					"info",
+				);
+			} catch (err) {
+				if (controller.signal.aborted) return;
+				ctx.ui.notify(
+					`Semantic grep indexing failed: ${err instanceof Error ? err.message : String(err)}`,
+					"error",
+				);
+			} finally {
+				if (indexingController === controller) {
+					indexingController = undefined;
+					ctx.ui.setStatus("semantic-grep", undefined);
+				}
+			}
+		})();
 	});
 
 	pi.on("session_shutdown", () => {

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -4,6 +4,7 @@ import type { SemanticGrepConfig } from "./config.js";
 import { completeBuild, type FileRow, prepareBuildTarget } from "./db.js";
 import { type DiscoveryResult, discoverFiles } from "./discovery.js";
 import { embedDocuments } from "./embeddings.js";
+import { nextEventLoopTurn } from "./event-loop.js";
 import {
 	chunkSnapshot,
 	type FileMetadata,
@@ -197,7 +198,7 @@ export async function syncIndex(
 	const fingerprint = indexFingerprint(config);
 	const target = prepareBuildTarget(db, fingerprint, forceFullRebuild);
 	if (!providedDiscovery) onProgress?.("scanning project files");
-	const discovery = providedDiscovery ?? discoverFiles(root, config);
+	const discovery = providedDiscovery ?? (await discoverFiles(root, config));
 	const current = new Set(discovery.files.map((file) => file.file));
 	const filesTable = target.fullRebuild ? "staged_files" : "files";
 	const knownRows = db
@@ -244,6 +245,7 @@ export async function syncIndex(
 	};
 
 	for (let i = 0; i < discovery.files.length; i++) {
+		if (i % 32 === 0) await nextEventLoopTurn();
 		signal?.throwIfAborted();
 		const metadata = discovery.files[i];
 		if (!metadata) continue;

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -198,7 +198,8 @@ export async function syncIndex(
 	const fingerprint = indexFingerprint(config);
 	const target = prepareBuildTarget(db, fingerprint, forceFullRebuild);
 	if (!providedDiscovery) onProgress?.("scanning project files");
-	const discovery = providedDiscovery ?? (await discoverFiles(root, config));
+	const discovery =
+		providedDiscovery ?? (await discoverFiles(root, config, signal));
 	const current = new Set(discovery.files.map((file) => file.file));
 	const filesTable = target.fullRebuild ? "staged_files" : "files";
 	const knownRows = db
@@ -264,6 +265,8 @@ export async function syncIndex(
 			continue;
 		}
 
+		await nextEventLoopTurn();
+		signal?.throwIfAborted();
 		const snapshot = readFileSnapshot(root, metadata);
 		if (!snapshot) {
 			skipped++;
@@ -281,6 +284,8 @@ export async function syncIndex(
 			`[${i + 1}/${discovery.files.length}] indexing ${metadata.file}`,
 		);
 		const fileChunks = chunkSnapshot(snapshot, config);
+		await nextEventLoopTurn();
+		signal?.throwIfAborted();
 		pendingJobs.push({ snapshot, chunks: fileChunks });
 		pendingChunks += fileChunks.length;
 		if (

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -267,11 +267,16 @@ export async function syncIndex(
 
 		await nextEventLoopTurn();
 		signal?.throwIfAborted();
-		const snapshot = readFileSnapshot(root, metadata);
-		if (!snapshot) {
+		const snapshotRead = readFileSnapshot(root, metadata);
+		if (snapshotRead.status === "unavailable") {
 			skipped++;
 			continue;
 		}
+		if (snapshotRead.status === "non-text") {
+			current.delete(metadata.file);
+			continue;
+		}
+		const { snapshot } = snapshotRead;
 		if (currentGeneration && old.hash === snapshot.hash) {
 			updateMetadata(db, metadata, target.fullRebuild);
 			metadataOnly++;

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -1,9 +1,16 @@
 import crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import type { SemanticGrepConfig } from "./config.js";
-import { type FileRow, getMeta, resetDb, setMeta } from "./db.js";
-import { embed } from "./embeddings.js";
-import { chunkFile, listIndexableFiles, readFileSnapshot } from "./files.js";
+import { completeBuild, type FileRow, prepareBuildTarget } from "./db.js";
+import { discoverFiles } from "./discovery.js";
+import { embedDocuments } from "./embeddings.js";
+import {
+	chunkSnapshot,
+	type FileMetadata,
+	type FileSnapshot,
+	readFileSnapshot,
+	type TextChunk,
+} from "./files.js";
 
 export interface IndexStats {
 	files: number;
@@ -11,73 +18,151 @@ export interface IndexStats {
 	added: number;
 	changed: number;
 	unchanged: number;
+	metadataOnly: number;
 	deleted: number;
+	skipped: number;
 	fullRebuild: boolean;
+	discovery: "filesystem" | "git";
 }
 
-function indexFingerprint(config: SemanticGrepConfig): string {
-	const payload = {
-		schema: 4,
+function canonical(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonical);
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, item]) => [key, canonical(item)]),
+	);
+}
+
+export function indexFingerprint(config: SemanticGrepConfig): string {
+	const payload = canonical({
+		schema: 5,
 		model: config.embeddings.model,
 		dimensions: config.embeddings.dimensions ?? null,
+		documentPrefix: config.embeddings.documentPrefix,
+		documentExtraBody: config.embeddings.documentExtraBody,
 		chunkLines: config.indexing.chunkLines,
 		chunkOverlap: config.indexing.chunkOverlap,
-		includeExtensions: config.indexing.includeExtensions,
-		excludeDirs: config.indexing.excludeDirs,
-		maxFileBytes: config.indexing.maxFileBytes,
 		maxChunkChars: config.indexing.maxChunkChars,
+		maxEmbeddingChars: config.indexing.maxEmbeddingChars,
 		skipOversizedChunks: config.indexing.skipOversizedChunks,
-		followSymlinks: config.indexing.followSymlinks,
-	};
+	});
 	return crypto
 		.createHash("sha256")
 		.update(JSON.stringify(payload))
 		.digest("hex");
 }
 
-async function indexOneFile(
+function formattedChunk(chunk: {
+	file: string;
+	startLine: number;
+	endLine: number;
+	text: string;
+}): string {
+	return `File: ${chunk.file}\nLines: ${chunk.startLine}-${chunk.endLine}\n\n${chunk.text}`;
+}
+
+interface FileJob {
+	snapshot: FileSnapshot;
+	chunks: TextChunk[];
+}
+
+function commitFile(
 	db: Database.Database,
-	root: string,
-	file: string,
-	snapshot: NonNullable<ReturnType<typeof readFileSnapshot>>,
+	job: FileJob,
+	vectors: number[][],
+	fingerprint: string,
+	generation: number,
+): void {
+	const { chunks, snapshot } = job;
+	const insertFile = db.prepare(`
+    insert into files (
+      file, hash, size, mtime_ms, indexed_at,
+      index_fingerprint, index_generation, chunk_count
+    ) values (?, ?, ?, ?, ?, ?, ?, ?)
+    on conflict(file) do update set
+      hash = excluded.hash,
+      size = excluded.size,
+      mtime_ms = excluded.mtime_ms,
+      indexed_at = excluded.indexed_at,
+      index_fingerprint = excluded.index_fingerprint,
+      index_generation = excluded.index_generation,
+      chunk_count = excluded.chunk_count
+  `);
+	const insertChunk = db.prepare(`
+    insert into chunks (
+      file, start_line, end_line, text, hash, vector, chunk_key
+    ) values (?, ?, ?, ?, ?, ?, ?)
+  `);
+	const commit = db.transaction(() => {
+		db.prepare("delete from chunks where file = ?").run(snapshot.file);
+		insertFile.run(
+			snapshot.file,
+			snapshot.hash,
+			snapshot.size,
+			snapshot.mtimeMs,
+			new Date().toISOString(),
+			fingerprint,
+			generation,
+			chunks.length,
+		);
+		for (let i = 0; i < chunks.length; i++) {
+			const chunk = chunks[i];
+			const vector = vectors[i];
+			if (!chunk || !vector)
+				throw new Error(`missing embedded chunk ${i} for ${snapshot.file}`);
+			insertChunk.run(
+				chunk.file,
+				chunk.startLine,
+				chunk.endLine,
+				chunk.text,
+				chunk.hash,
+				JSON.stringify(vector),
+				chunk.key,
+			);
+		}
+	});
+	commit();
+}
+
+async function embedAndCommitJobs(
+	db: Database.Database,
+	jobs: FileJob[],
 	config: SemanticGrepConfig,
+	fingerprint: string,
+	generation: number,
 	signal?: AbortSignal,
 ): Promise<number> {
-	db.prepare("delete from chunks where file = ?").run(file);
-	db.prepare("delete from files where file = ?").run(file);
-
-	const chunks = chunkFile(root, file, config, snapshot.hash);
-	const insertChunk = db.prepare(
-		"insert into chunks (file, start_line, end_line, text, hash, vector) values (?, ?, ?, ?, ?, ?)",
+	const chunks = jobs.flatMap((job) => job.chunks);
+	const vectors = await embedDocuments(
+		chunks.map(formattedChunk),
+		config,
+		signal,
 	);
-	const insertFile = db.prepare(
-		"insert into files (file, hash, size, mtime_ms, indexed_at) values (?, ?, ?, ?, ?)",
-	);
-
-	insertFile.run(
-		file,
-		snapshot.hash,
-		snapshot.size,
-		snapshot.mtimeMs,
-		new Date().toISOString(),
-	);
-	for (const chunk of chunks) {
-		signal?.throwIfAborted();
-		const vector = await embed(
-			`File: ${chunk.file}\nLines: ${chunk.startLine}-${chunk.endLine}\n\n${chunk.text}`,
-			config,
-			signal,
+	if (vectors.length !== chunks.length)
+		throw new Error(
+			`embedding response contained ${vectors.length} vectors for ${chunks.length} queued chunks`,
 		);
-		insertChunk.run(
-			chunk.file,
-			chunk.startLine,
-			chunk.endLine,
-			chunk.text,
-			chunk.hash,
-			JSON.stringify(vector),
-		);
+	signal?.throwIfAborted();
+	let offset = 0;
+	for (const job of jobs) {
+		const next = offset + job.chunks.length;
+		commitFile(db, job, vectors.slice(offset, next), fingerprint, generation);
+		offset = next;
 	}
 	return chunks.length;
+}
+
+function updateMetadata(db: Database.Database, metadata: FileMetadata): void {
+	db.prepare(
+		"update files set size = ?, mtime_ms = ?, indexed_at = ? where file = ?",
+	).run(
+		metadata.size,
+		metadata.mtimeMs,
+		new Date().toISOString(),
+		metadata.file,
+	);
 }
 
 export async function syncIndex(
@@ -89,63 +174,108 @@ export async function syncIndex(
 	onProgress?: (msg: string) => void,
 ): Promise<IndexStats> {
 	const fingerprint = indexFingerprint(config);
-	const priorFingerprint = getMeta(db, "index_fingerprint");
-	const fullRebuild = forceFullRebuild || priorFingerprint !== fingerprint;
-	if (fullRebuild) resetDb(db);
-
-	const files = listIndexableFiles(root, config);
-	const current = new Set(files);
+	const target = prepareBuildTarget(db, fingerprint, forceFullRebuild);
+	onProgress?.("scanning project files");
+	const discovery = discoverFiles(root, config);
+	const current = new Set(discovery.files.map((file) => file.file));
 	const knownRows = db
-		.prepare("select file, hash, size, mtime_ms, indexed_at from files")
+		.prepare(`
+      select file, hash, size, mtime_ms, indexed_at,
+             index_fingerprint, index_generation, chunk_count
+      from files
+    `)
 		.all() as FileRow[];
-	const known = new Map(knownRows.map((r) => [r.file, r]));
+	const known = new Map(knownRows.map((row) => [row.file, row]));
 
 	let chunks = 0,
 		added = 0,
 		changed = 0,
 		unchanged = 0,
-		deleted = 0;
+		metadataOnly = 0,
+		deleted = 0,
+		skipped = discovery.skipped;
+	const pendingJobs: FileJob[] = [];
+	let pendingChunks = 0;
+	const flushJobs = async (): Promise<void> => {
+		if (pendingJobs.length === 0) return;
+		chunks += await embedAndCommitJobs(
+			db,
+			pendingJobs,
+			config,
+			target.fingerprint,
+			target.generation,
+			signal,
+		);
+		pendingJobs.length = 0;
+		pendingChunks = 0;
+	};
 
-	for (const row of knownRows) {
-		if (!current.has(row.file)) {
-			db.prepare("delete from chunks where file = ?").run(row.file);
+	const removeDeleted = db.transaction(() => {
+		for (const row of knownRows) {
+			if (current.has(row.file)) continue;
 			db.prepare("delete from files where file = ?").run(row.file);
 			deleted++;
 		}
-	}
+	});
+	removeDeleted();
 
-	for (let i = 0; i < files.length; i++) {
+	for (let i = 0; i < discovery.files.length; i++) {
 		signal?.throwIfAborted();
-		const file = files[i];
-		if (!file) continue;
-		const snapshot = readFileSnapshot(root, file);
-		if (!snapshot) continue;
-		const old = known.get(file);
-		const same =
-			old && old.hash === snapshot.hash && old.size === snapshot.size;
-		if (!fullRebuild && same) {
+		const metadata = discovery.files[i];
+		if (!metadata) continue;
+		const old = known.get(metadata.file);
+		const currentGeneration =
+			old?.index_fingerprint === target.fingerprint &&
+			old.index_generation === target.generation &&
+			old.chunk_count >= 0;
+		if (
+			currentGeneration &&
+			old.size === metadata.size &&
+			old.mtime_ms === metadata.mtimeMs
+		) {
 			unchanged++;
+			continue;
+		}
+
+		const snapshot = readFileSnapshot(root, metadata);
+		if (!snapshot) {
+			skipped++;
+			continue;
+		}
+		if (currentGeneration && old.hash === snapshot.hash) {
+			updateMetadata(db, metadata);
+			metadataOnly++;
 			continue;
 		}
 
 		if (old) changed++;
 		else added++;
-		onProgress?.(`[${i + 1}/${files.length}] indexing ${file}`);
-		chunks += await indexOneFile(db, root, file, snapshot, config, signal);
+		onProgress?.(
+			`[${i + 1}/${discovery.files.length}] indexing ${metadata.file}`,
+		);
+		const fileChunks = chunkSnapshot(snapshot, config);
+		pendingJobs.push({ snapshot, chunks: fileChunks });
+		pendingChunks += fileChunks.length;
+		if (
+			pendingChunks >= Math.max(1, config.embeddings.batchSize) ||
+			pendingJobs.length >= Math.max(1, config.embeddings.batchSize)
+		)
+			await flushJobs();
 	}
+	await flushJobs();
 
-	setMeta(db, "index_fingerprint", fingerprint);
-	setMeta(db, "indexed_at", new Date().toISOString());
-	setMeta(db, "embedding_model", config.embeddings.model);
-
+	completeBuild(db, target, config.embeddings.model);
 	return {
-		files: files.length,
+		files: discovery.files.length,
 		chunks,
 		added,
 		changed,
 		unchanged,
+		metadataOnly,
 		deleted,
-		fullRebuild,
+		skipped,
+		fullRebuild: target.fullRebuild,
+		discovery: discovery.source,
 	};
 }
 

--- a/packages/pi-semantic-grep/src/indexer.ts
+++ b/packages/pi-semantic-grep/src/indexer.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import type { SemanticGrepConfig } from "./config.js";
 import { completeBuild, type FileRow, prepareBuildTarget } from "./db.js";
-import { discoverFiles } from "./discovery.js";
+import { type DiscoveryResult, discoverFiles } from "./discovery.js";
 import { embedDocuments } from "./embeddings.js";
 import {
 	chunkSnapshot,
@@ -22,6 +22,7 @@ export interface IndexStats {
 	deleted: number;
 	skipped: number;
 	fullRebuild: boolean;
+	complete: boolean;
 	discovery: "filesystem" | "git";
 }
 
@@ -74,34 +75,39 @@ function commitFile(
 	vectors: number[][],
 	fingerprint: string,
 	generation: number,
+	staging: boolean,
 ): void {
 	const { chunks, snapshot } = job;
+	const filesTable = staging ? "staged_files" : "files";
+	const chunksTable = staging ? "staged_chunks" : "chunks";
 	const insertFile = db.prepare(`
-    insert into files (
-      file, hash, size, mtime_ms, indexed_at,
+    insert into ${filesTable} (
+      file, hash, size, mtime_ms, ctime_ms, indexed_at,
       index_fingerprint, index_generation, chunk_count
-    ) values (?, ?, ?, ?, ?, ?, ?, ?)
+    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
     on conflict(file) do update set
       hash = excluded.hash,
       size = excluded.size,
       mtime_ms = excluded.mtime_ms,
+      ctime_ms = excluded.ctime_ms,
       indexed_at = excluded.indexed_at,
       index_fingerprint = excluded.index_fingerprint,
       index_generation = excluded.index_generation,
       chunk_count = excluded.chunk_count
   `);
 	const insertChunk = db.prepare(`
-    insert into chunks (
+    insert into ${chunksTable} (
       file, start_line, end_line, text, hash, vector, chunk_key
     ) values (?, ?, ?, ?, ?, ?, ?)
-  `);
+	`);
 	const commit = db.transaction(() => {
-		db.prepare("delete from chunks where file = ?").run(snapshot.file);
+		db.prepare(`delete from ${chunksTable} where file = ?`).run(snapshot.file);
 		insertFile.run(
 			snapshot.file,
 			snapshot.hash,
 			snapshot.size,
 			snapshot.mtimeMs,
+			snapshot.ctimeMs,
 			new Date().toISOString(),
 			fingerprint,
 			generation,
@@ -132,6 +138,7 @@ async function embedAndCommitJobs(
 	config: SemanticGrepConfig,
 	fingerprint: string,
 	generation: number,
+	staging: boolean,
 	signal?: AbortSignal,
 ): Promise<number> {
 	const chunks = jobs.flatMap((job) => job.chunks);
@@ -148,18 +155,31 @@ async function embedAndCommitJobs(
 	let offset = 0;
 	for (const job of jobs) {
 		const next = offset + job.chunks.length;
-		commitFile(db, job, vectors.slice(offset, next), fingerprint, generation);
+		commitFile(
+			db,
+			job,
+			vectors.slice(offset, next),
+			fingerprint,
+			generation,
+			staging,
+		);
 		offset = next;
 	}
 	return chunks.length;
 }
 
-function updateMetadata(db: Database.Database, metadata: FileMetadata): void {
+function updateMetadata(
+	db: Database.Database,
+	metadata: FileMetadata,
+	staging: boolean,
+): void {
+	const table = staging ? "staged_files" : "files";
 	db.prepare(
-		"update files set size = ?, mtime_ms = ?, indexed_at = ? where file = ?",
+		`update ${table} set size = ?, mtime_ms = ?, ctime_ms = ?, indexed_at = ? where file = ?`,
 	).run(
 		metadata.size,
 		metadata.mtimeMs,
+		metadata.ctimeMs,
 		new Date().toISOString(),
 		metadata.file,
 	);
@@ -172,20 +192,32 @@ export async function syncIndex(
 	forceFullRebuild = false,
 	signal?: AbortSignal,
 	onProgress?: (msg: string) => void,
+	providedDiscovery?: DiscoveryResult,
 ): Promise<IndexStats> {
 	const fingerprint = indexFingerprint(config);
 	const target = prepareBuildTarget(db, fingerprint, forceFullRebuild);
-	onProgress?.("scanning project files");
-	const discovery = discoverFiles(root, config);
+	if (!providedDiscovery) onProgress?.("scanning project files");
+	const discovery = providedDiscovery ?? discoverFiles(root, config);
 	const current = new Set(discovery.files.map((file) => file.file));
+	const filesTable = target.fullRebuild ? "staged_files" : "files";
 	const knownRows = db
 		.prepare(`
-      select file, hash, size, mtime_ms, indexed_at,
+      select file, hash, size, mtime_ms, ctime_ms, indexed_at,
              index_fingerprint, index_generation, chunk_count
-      from files
+      from ${filesTable}
     `)
 		.all() as FileRow[];
 	const known = new Map(knownRows.map((row) => [row.file, row]));
+	const activeRows = target.fullRebuild
+		? (db
+				.prepare(`
+            select file, hash, size, mtime_ms, ctime_ms, indexed_at,
+                   index_fingerprint, index_generation, chunk_count
+            from files
+          `)
+				.all() as FileRow[])
+		: knownRows;
+	const active = new Map(activeRows.map((row) => [row.file, row]));
 
 	let chunks = 0,
 		added = 0,
@@ -204,20 +236,12 @@ export async function syncIndex(
 			config,
 			target.fingerprint,
 			target.generation,
+			target.fullRebuild,
 			signal,
 		);
 		pendingJobs.length = 0;
 		pendingChunks = 0;
 	};
-
-	const removeDeleted = db.transaction(() => {
-		for (const row of knownRows) {
-			if (current.has(row.file)) continue;
-			db.prepare("delete from files where file = ?").run(row.file);
-			deleted++;
-		}
-	});
-	removeDeleted();
 
 	for (let i = 0; i < discovery.files.length; i++) {
 		signal?.throwIfAborted();
@@ -231,7 +255,8 @@ export async function syncIndex(
 		if (
 			currentGeneration &&
 			old.size === metadata.size &&
-			old.mtime_ms === metadata.mtimeMs
+			old.mtime_ms === metadata.mtimeMs &&
+			old.ctime_ms === metadata.ctimeMs
 		) {
 			unchanged++;
 			continue;
@@ -243,12 +268,12 @@ export async function syncIndex(
 			continue;
 		}
 		if (currentGeneration && old.hash === snapshot.hash) {
-			updateMetadata(db, metadata);
+			updateMetadata(db, metadata, target.fullRebuild);
 			metadataOnly++;
 			continue;
 		}
 
-		if (old) changed++;
+		if (old || active.has(metadata.file)) changed++;
 		else added++;
 		onProgress?.(
 			`[${i + 1}/${discovery.files.length}] indexing ${metadata.file}`,
@@ -264,7 +289,41 @@ export async function syncIndex(
 	}
 	await flushJobs();
 
-	completeBuild(db, target, config.embeddings.model);
+	const normalizedUnavailableDirectories = discovery.unavailableDirectories.map(
+		(dir) => (dir ? `${dir.split("\\").join("/")}/` : ""),
+	);
+	const preserved = (file: string): boolean => {
+		const normalized = file.split("\\").join("/");
+		return (
+			discovery.unavailableFiles.has(file) ||
+			normalizedUnavailableDirectories.some(
+				(dir) => dir === "" || normalized.startsWith(dir),
+			)
+		);
+	};
+	const deletedFiles = activeRows
+		.filter((row) => !current.has(row.file) && !preserved(row.file))
+		.map((row) => row.file);
+	const complete = !target.fullRebuild || skipped === 0;
+	if (complete) {
+		deleted = deletedFiles.length;
+		if (target.fullRebuild) {
+			const removeStaleStaging = db.transaction(() => {
+				for (const row of knownRows) {
+					if (!current.has(row.file))
+						db.prepare("delete from staged_files where file = ?").run(row.file);
+				}
+			});
+			removeStaleStaging();
+		} else {
+			const removeDeleted = db.transaction(() => {
+				for (const file of deletedFiles)
+					db.prepare("delete from files where file = ?").run(file);
+			});
+			removeDeleted();
+		}
+		completeBuild(db, target, config.embeddings.model);
+	}
 	return {
 		files: discovery.files.length,
 		chunks,
@@ -275,6 +334,7 @@ export async function syncIndex(
 		deleted,
 		skipped,
 		fullRebuild: target.fullRebuild,
+		complete,
 		discovery: discovery.source,
 	};
 }

--- a/packages/pi-semantic-grep/src/lock.ts
+++ b/packages/pi-semantic-grep/src/lock.ts
@@ -1,0 +1,24 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import lockfile from "proper-lockfile";
+import { dbPathFor, indexLockPathFor } from "./db.js";
+
+export type ReleaseIndexLock = () => Promise<void>;
+
+export async function tryAcquireIndexLock(
+	root: string,
+): Promise<ReleaseIndexLock | undefined> {
+	mkdirSync(path.join(root, ".pi"), { recursive: true });
+	try {
+		return await lockfile.lock(dbPathFor(root), {
+			realpath: false,
+			lockfilePath: indexLockPathFor(root),
+			stale: 120_000,
+			update: 30_000,
+			retries: 0,
+		});
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ELOCKED") return undefined;
+		throw error;
+	}
+}

--- a/packages/pi-semantic-grep/src/search.ts
+++ b/packages/pi-semantic-grep/src/search.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SemanticGrepConfig } from "./config.js";
 import type { ChunkRow } from "./db.js";
-import { cosine, embed } from "./embeddings.js";
+import { cosine, embedQuery } from "./embeddings.js";
 
 export interface SearchMatch {
 	file: string;
@@ -11,22 +11,47 @@ export interface SearchMatch {
 	text: string;
 }
 
+export interface SearchResults {
+	matches: SearchMatch[];
+	skippedIncompatible: number;
+}
+
+const MAX_OUTPUT_BYTES = 45_000;
+
 export async function searchDb(
 	db: Database.Database,
 	query: string,
 	topK: number,
 	config: SemanticGrepConfig,
 	signal?: AbortSignal,
-): Promise<SearchMatch[]> {
-	const q = await embed(query, config, signal);
+): Promise<SearchResults> {
+	const q = await embedQuery(query, config, signal);
 	const best: SearchMatch[] = [];
 	let minBestScore = Number.NEGATIVE_INFINITY;
+	let skippedIncompatible = 0;
 
 	for (const row of db
 		.prepare("select file, start_line, end_line, text, vector from chunks")
 		.iterate() as Iterable<ChunkRow>) {
 		signal?.throwIfAborted();
-		const score = cosine(q, JSON.parse(row.vector) as number[]);
+		let vector: number[];
+		try {
+			vector = JSON.parse(row.vector) as number[];
+		} catch {
+			skippedIncompatible++;
+			continue;
+		}
+		if (
+			!Array.isArray(vector) ||
+			vector.length !== q.length ||
+			vector.some(
+				(value) => typeof value !== "number" || !Number.isFinite(value),
+			)
+		) {
+			skippedIncompatible++;
+			continue;
+		}
+		const score = cosine(q, vector);
 		if (best.length >= topK && score <= minBestScore) continue;
 
 		best.push({
@@ -41,15 +66,50 @@ export async function searchDb(
 		minBestScore = best.at(-1)?.score ?? Number.NEGATIVE_INFINITY;
 	}
 
-	return best;
+	return { matches: best, skippedIncompatible };
 }
 
-export function formatMatches(matches: SearchMatch[]): string {
-	if (matches.length === 0)
-		return "No semantic grep matches. Try running /semantic-grep-index first.";
-	return matches
-		.map((m, i) => {
-			return `## ${i + 1}. ${m.file}:${m.startLine}-${m.endLine} score=${m.score.toFixed(4)}\n\n\`\`\`${m.file}\n${m.text}\n\`\`\``;
-		})
-		.join("\n\n");
+function byteLength(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+export function formatMatches(results: SearchResults): string {
+	if (results.matches.length === 0) {
+		if (results.skippedIncompatible > 0)
+			return `No compatible semantic grep vectors. ${results.skippedIncompatible} stale chunks were omitted; let indexing finish or rebuild the index.`;
+		return "No semantic grep matches.";
+	}
+
+	const sections: string[] = [];
+	let used = 0;
+	for (const [index, match] of results.matches.entries()) {
+		const heading = `## ${index + 1}. ${match.file}:${match.startLine}-${match.endLine} score=${match.score.toFixed(4)}\n\n\`\`\`${match.file}\n`;
+		const suffix = "\n```";
+		const remaining =
+			MAX_OUTPUT_BYTES - used - byteLength(heading) - byteLength(suffix);
+		if (remaining <= 200) {
+			sections.push(
+				`… ${results.matches.length - index} additional matches omitted.`,
+			);
+			break;
+		}
+		let text = match.text;
+		while (byteLength(text) > remaining - 24 && text.length > 0)
+			text = text.slice(0, Math.floor(text.length * 0.9));
+		const truncated = text.length < match.text.length;
+		const section = `${heading}${text}${truncated ? "\n… snippet truncated" : ""}${suffix}`;
+		sections.push(section);
+		used += byteLength(section) + 2;
+		if (truncated) {
+			sections.push(
+				`… ${results.matches.length - index - 1} additional matches omitted.`,
+			);
+			break;
+		}
+	}
+	if (results.skippedIncompatible > 0)
+		sections.push(
+			`${results.skippedIncompatible} stale chunks were omitted; indexing will replace them.`,
+		);
+	return sections.join("\n\n");
 }

--- a/packages/pi-semantic-grep/tests/indexing.test.ts
+++ b/packages/pi-semantic-grep/tests/indexing.test.ts
@@ -16,6 +16,7 @@ import { DEFAULT_CONFIG, type SemanticGrepConfig } from "../src/config.js";
 import { dbPathFor, getMeta, openIndexDb } from "../src/db.js";
 import { discoverFiles } from "../src/discovery.js";
 import { chunkSnapshot } from "../src/files.js";
+import { runIndex } from "../src/index-runner.js";
 import { syncIndex } from "../src/indexer.js";
 import { tryAcquireIndexLock } from "../src/lock.js";
 import { searchDb } from "../src/search.js";
@@ -307,7 +308,7 @@ test("legacy databases migrate without discarding indexed chunks", () => {
 	migrated.close();
 });
 
-test("Git discovery includes untracked files and honors standard ignores", () => {
+test("Git discovery includes untracked files and honors standard ignores", async () => {
 	const root = tempProject();
 	execFileSync("git", ["init", "-q", root]);
 	mkdirSync(path.join(root, "ignored"));
@@ -319,7 +320,7 @@ test("Git discovery includes untracked files and honors standard ignores", () =>
 	execFileSync("git", ["-C", root, "add", "-f", "node_modules/forced.ts"]);
 
 	const cfg = config("http://127.0.0.1:1/v1/embeddings");
-	const result = discoverFiles(root, cfg);
+	const result = await discoverFiles(root, cfg);
 	assert.equal(result.source, "git");
 	assert.deepEqual(
 		result.files.map((file) => file.file),
@@ -327,7 +328,7 @@ test("Git discovery includes untracked files and honors standard ignores", () =>
 	);
 });
 
-test("filesystem discovery applies nested gitignore rules", () => {
+test("filesystem discovery applies nested gitignore rules", async () => {
 	const root = tempProject();
 	mkdirSync(path.join(root, "catalogue"));
 	writeFileSync(path.join(root, "catalogue", ".gitignore"), "ignored.ts\n");
@@ -337,7 +338,7 @@ test("filesystem discovery applies nested gitignore rules", () => {
 	);
 	writeFileSync(path.join(root, "catalogue", "ignored.ts"), "ignored\n");
 
-	const result = discoverFiles(
+	const result = await discoverFiles(
 		root,
 		config("http://127.0.0.1:1/v1/embeddings"),
 	);
@@ -346,6 +347,31 @@ test("filesystem discovery applies nested gitignore rules", () => {
 		result.files.map((file) => file.file),
 		[path.join("catalogue", "kept.ts")],
 	);
+});
+
+test("startup indexing yields before project scanning", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		writeFileSync(
+			path.join(root, "background.ts"),
+			"export const ready = true;\n",
+		);
+		let scanning = false;
+		const indexing = runIndex(
+			root,
+			config(endpoint.url),
+			false,
+			undefined,
+			() => {
+				scanning = true;
+			},
+		);
+		assert.equal(scanning, false);
+		assert.equal((await indexing).status, "indexed");
+	} finally {
+		await endpoint.close();
+	}
 });
 
 test("oversized repeated segments receive distinct chunk keys", () => {

--- a/packages/pi-semantic-grep/tests/indexing.test.ts
+++ b/packages/pi-semantic-grep/tests/indexing.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+	chmodSync,
 	mkdirSync,
 	mkdtempSync,
 	unlinkSync,
@@ -211,6 +212,42 @@ test("interrupted configuration rebuilds resume completed files", async () => {
 	}
 });
 
+test("interrupted forced rebuilds resume completed files", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		writeFileSync(path.join(root, "a.ts"), "export const first = 'stable';\n");
+		writeFileSync(path.join(root, "b.ts"), "export const second = 'stable';\n");
+		const db = openIndexDb(root);
+		const cfg = config(endpoint.url);
+		cfg.embeddings.batchSize = 1;
+		await syncIndex(db, root, cfg);
+
+		endpoint.state.failAfterInputs = endpoint.state.inputs + 1;
+		await assert.rejects(syncIndex(db, root, cfg, true), /503/);
+		assert.equal(
+			(
+				db.prepare("select count(*) count from staged_files").get() as {
+					count: number;
+				}
+			).count,
+			1,
+		);
+
+		endpoint.state.failAfterInputs = undefined;
+		const beforeResume = endpoint.state.inputs;
+		await syncIndex(db, root, cfg, true);
+		assert.equal(endpoint.state.inputs - beforeResume, 1);
+		assert.deepEqual(
+			db.prepare("select index_generation from files order by file").all(),
+			[{ index_generation: 2 }, { index_generation: 2 }],
+		);
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
+});
+
 test("query and document requests preserve configured embedding roles", async () => {
 	const endpoint = await embeddingEndpoint();
 	try {
@@ -315,9 +352,12 @@ test("Git discovery includes untracked files and honors standard ignores", async
 	mkdirSync(path.join(root, "node_modules"));
 	writeFileSync(path.join(root, ".gitignore"), "ignored/\n");
 	writeFileSync(path.join(root, "kept.ts"), "export const kept = true;\n");
+	writeFileSync(path.join(root, "deleted.ts"), "export const gone = true;\n");
 	writeFileSync(path.join(root, "ignored", "hidden.ts"), "hidden\n");
 	writeFileSync(path.join(root, "node_modules", "forced.ts"), "forced\n");
 	execFileSync("git", ["-C", root, "add", "-f", "node_modules/forced.ts"]);
+	execFileSync("git", ["-C", root, "add", "deleted.ts"]);
+	unlinkSync(path.join(root, "deleted.ts"));
 
 	const cfg = config("http://127.0.0.1:1/v1/embeddings");
 	const result = await discoverFiles(root, cfg);
@@ -347,6 +387,27 @@ test("filesystem discovery applies nested gitignore rules", async () => {
 		result.files.map((file) => file.file),
 		[path.join("catalogue", "kept.ts")],
 	);
+});
+
+test("filesystem discovery preserves unreadable ignore scopes", {
+	skip: process.platform === "win32",
+}, async () => {
+	const root = tempProject();
+	const protectedDir = path.join(root, "protected");
+	mkdirSync(protectedDir);
+	writeFileSync(path.join(protectedDir, ".gitignore"), "ignored.ts\n");
+	writeFileSync(path.join(protectedDir, "ignored.ts"), "ignored\n");
+	chmodSync(protectedDir, 0);
+	try {
+		const result = await discoverFiles(
+			root,
+			config("http://127.0.0.1:1/v1/embeddings"),
+		);
+		assert.deepEqual(result.unavailableDirectories, ["protected"]);
+		assert.equal(result.skipped, 1);
+	} finally {
+		chmodSync(protectedDir, 0o755);
+	}
 });
 
 test("discovery honors startup cancellation", async () => {
@@ -405,4 +466,25 @@ test("oversized repeated segments receive distinct chunk keys", () => {
 	);
 	assert.equal(chunks.length, 2);
 	assert.equal(new Set(chunks.map((chunk) => chunk.key)).size, 2);
+});
+
+test("text files that become binary are intentionally removed", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		const file = path.join(root, "generated.ts");
+		writeFileSync(file, "export const generated = 'text';\n");
+		const db = openIndexDb(root);
+		const cfg = config(endpoint.url);
+		await syncIndex(db, root, cfg);
+
+		writeFileSync(file, "binary\0content");
+		const rebuilt = await syncIndex(db, root, cfg, true);
+		assert.equal(rebuilt.complete, true);
+		assert.equal(rebuilt.skipped, 0);
+		assert.equal(db.prepare("select file from files").get(), undefined);
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
 });

--- a/packages/pi-semantic-grep/tests/indexing.test.ts
+++ b/packages/pi-semantic-grep/tests/indexing.test.ts
@@ -349,6 +349,20 @@ test("filesystem discovery applies nested gitignore rules", async () => {
 	);
 });
 
+test("discovery honors startup cancellation", async () => {
+	const root = tempProject();
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		discoverFiles(
+			root,
+			config("http://127.0.0.1:1/v1/embeddings"),
+			controller.signal,
+		),
+		(error: Error) => error.name === "AbortError",
+	);
+});
+
 test("startup indexing yields before project scanning", async () => {
 	const endpoint = await embeddingEndpoint();
 	try {

--- a/packages/pi-semantic-grep/tests/indexing.test.ts
+++ b/packages/pi-semantic-grep/tests/indexing.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	unlinkSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,6 +15,7 @@ import Database from "better-sqlite3";
 import { DEFAULT_CONFIG, type SemanticGrepConfig } from "../src/config.js";
 import { dbPathFor, getMeta, openIndexDb } from "../src/db.js";
 import { discoverFiles } from "../src/discovery.js";
+import { chunkSnapshot } from "../src/files.js";
 import { syncIndex } from "../src/indexer.js";
 import { tryAcquireIndexLock } from "../src/lock.js";
 import { searchDb } from "../src/search.js";
@@ -102,6 +109,7 @@ test("unchanged and metadata-only files do not request new embeddings", async ()
 		assert.equal(endpoint.state.inputs, initialInputs);
 
 		writeFileSync(file, "export const durableBehavior = 'second version';\n");
+		utimesSync(file, future, future);
 		const changed = await syncIndex(db, root, cfg);
 		assert.equal(changed.changed, 1);
 		assert.ok(endpoint.state.inputs > initialInputs);
@@ -116,7 +124,9 @@ test("failed embeddings preserve the last complete file index", async () => {
 	try {
 		const root = tempProject();
 		const file = path.join(root, "stable.ts");
+		const removed = path.join(root, "removed.ts");
 		writeFileSync(file, "export function stableResult() { return 'old'; }\n");
+		writeFileSync(removed, "export const removedAfterSuccess = true;\n");
 		const db = openIndexDb(root);
 		const cfg = config(endpoint.url);
 		await syncIndex(db, root, cfg);
@@ -128,6 +138,7 @@ test("failed embeddings preserve the last complete file index", async () => {
 			.all();
 
 		writeFileSync(file, "export function stableResult() { return 'new'; }\n");
+		unlinkSync(removed);
 		endpoint.state.fail = true;
 		await assert.rejects(syncIndex(db, root, cfg), /503/);
 		assert.deepEqual(
@@ -141,6 +152,10 @@ test("failed embeddings preserve the last complete file index", async () => {
 				.prepare("select text, vector from chunks where file = 'stable.ts'")
 				.all(),
 			chunksBefore,
+		);
+		assert.deepEqual(
+			db.prepare("select file from files where file = 'removed.ts'").get(),
+			{ file: "removed.ts" },
 		);
 		db.close();
 	} finally {
@@ -172,7 +187,13 @@ test("interrupted configuration rebuilds resume completed files", async () => {
 		await assert.rejects(syncIndex(db, root, changedConfig), /503/);
 		assert.deepEqual(
 			db.prepare("select index_generation from files order by file").all(),
-			[{ index_generation: 2 }, { index_generation: 1 }],
+			[{ index_generation: 1 }, { index_generation: 1 }],
+		);
+		assert.deepEqual(
+			db
+				.prepare("select index_generation from staged_files order by file")
+				.all(),
+			[{ index_generation: 2 }],
 		);
 
 		endpoint.state.failAfterInputs = undefined;
@@ -304,4 +325,44 @@ test("Git discovery includes untracked files and honors standard ignores", () =>
 		result.files.map((file) => file.file),
 		["kept.ts"],
 	);
+});
+
+test("filesystem discovery applies nested gitignore rules", () => {
+	const root = tempProject();
+	mkdirSync(path.join(root, "catalogue"));
+	writeFileSync(path.join(root, "catalogue", ".gitignore"), "ignored.ts\n");
+	writeFileSync(
+		path.join(root, "catalogue", "kept.ts"),
+		"export const kept = true;\n",
+	);
+	writeFileSync(path.join(root, "catalogue", "ignored.ts"), "ignored\n");
+
+	const result = discoverFiles(
+		root,
+		config("http://127.0.0.1:1/v1/embeddings"),
+	);
+	assert.equal(result.source, "filesystem");
+	assert.deepEqual(
+		result.files.map((file) => file.file),
+		[path.join("catalogue", "kept.ts")],
+	);
+});
+
+test("oversized repeated segments receive distinct chunk keys", () => {
+	const cfg = config("http://127.0.0.1:1/v1/embeddings");
+	cfg.indexing.maxEmbeddingChars = 20;
+	cfg.indexing.maxChunkChars = 20;
+	const chunks = chunkSnapshot(
+		{
+			file: "generated.ts",
+			size: 40,
+			mtimeMs: 1,
+			ctimeMs: 1,
+			hash: "file-hash",
+			text: "abcdefghijklmnopqrstabcdefghijklmnopqrst",
+		},
+		cfg,
+	);
+	assert.equal(chunks.length, 2);
+	assert.equal(new Set(chunks.map((chunk) => chunk.key)).size, 2);
 });

--- a/packages/pi-semantic-grep/tests/indexing.test.ts
+++ b/packages/pi-semantic-grep/tests/indexing.test.ts
@@ -1,0 +1,307 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import Database from "better-sqlite3";
+import { DEFAULT_CONFIG, type SemanticGrepConfig } from "../src/config.js";
+import { dbPathFor, getMeta, openIndexDb } from "../src/db.js";
+import { discoverFiles } from "../src/discovery.js";
+import { syncIndex } from "../src/indexer.js";
+import { tryAcquireIndexLock } from "../src/lock.js";
+import { searchDb } from "../src/search.js";
+
+function tempProject(): string {
+	const root = mkdtempSync(path.join(tmpdir(), "semantic-grep-test-"));
+	writeFileSync(path.join(root, "package.json"), "{}\n");
+	return root;
+}
+
+function config(url: string): SemanticGrepConfig {
+	const value = structuredClone(DEFAULT_CONFIG);
+	value.embeddings.url = url;
+	value.embeddings.model = "test-embedding";
+	value.embeddings.batchSize = 8;
+	value.indexing.includeExtensions = [".ts"];
+	value.indexing.maxEmbeddingChars = 1_000;
+	return value;
+}
+
+interface Endpoint {
+	url: string;
+	state: {
+		bodies: Array<Record<string, unknown>>;
+		fail: boolean;
+		failAfterInputs?: number;
+		inputs: number;
+	};
+	close(): Promise<void>;
+}
+
+async function embeddingEndpoint(): Promise<Endpoint> {
+	const state: Endpoint["state"] = { bodies: [], fail: false, inputs: 0 };
+	const server: Server = createServer(async (request, response) => {
+		let raw = "";
+		for await (const chunk of request) raw += chunk;
+		if (
+			state.fail ||
+			(state.failAfterInputs !== undefined &&
+				state.inputs >= state.failAfterInputs)
+		) {
+			response.writeHead(503).end("deliberate failure");
+			return;
+		}
+		const body = JSON.parse(raw) as { input: string | string[] };
+		state.bodies.push(body);
+		const inputs = Array.isArray(body.input) ? body.input : [body.input];
+		state.inputs += inputs.length;
+		response.writeHead(200, { "Content-Type": "application/json" }).end(
+			JSON.stringify({
+				data: inputs.map((input, index) => ({
+					index,
+					embedding: [input.length, index + 1, 1],
+				})),
+			}),
+		);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string")
+		throw new Error("test embedding endpoint did not bind a TCP port");
+	return {
+		url: `http://127.0.0.1:${address.port}/v1/embeddings`,
+		state,
+		close: () =>
+			new Promise((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			),
+	};
+}
+
+test("unchanged and metadata-only files do not request new embeddings", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		const file = path.join(root, "feature.ts");
+		writeFileSync(file, "export const durableBehavior = 'first version';\n");
+		const db = openIndexDb(root);
+		const cfg = config(endpoint.url);
+		await syncIndex(db, root, cfg);
+		const initialInputs = endpoint.state.inputs;
+
+		const unchanged = await syncIndex(db, root, cfg);
+		assert.equal(unchanged.unchanged, 1);
+		assert.equal(endpoint.state.inputs, initialInputs);
+
+		const future = new Date(Date.now() + 2_000);
+		utimesSync(file, future, future);
+		const touched = await syncIndex(db, root, cfg);
+		assert.equal(touched.metadataOnly, 1);
+		assert.equal(endpoint.state.inputs, initialInputs);
+
+		writeFileSync(file, "export const durableBehavior = 'second version';\n");
+		const changed = await syncIndex(db, root, cfg);
+		assert.equal(changed.changed, 1);
+		assert.ok(endpoint.state.inputs > initialInputs);
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
+});
+
+test("failed embeddings preserve the last complete file index", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		const file = path.join(root, "stable.ts");
+		writeFileSync(file, "export function stableResult() { return 'old'; }\n");
+		const db = openIndexDb(root);
+		const cfg = config(endpoint.url);
+		await syncIndex(db, root, cfg);
+		const before = db
+			.prepare("select hash, chunk_count from files where file = 'stable.ts'")
+			.get();
+		const chunksBefore = db
+			.prepare("select text, vector from chunks where file = 'stable.ts'")
+			.all();
+
+		writeFileSync(file, "export function stableResult() { return 'new'; }\n");
+		endpoint.state.fail = true;
+		await assert.rejects(syncIndex(db, root, cfg), /503/);
+		assert.deepEqual(
+			db
+				.prepare("select hash, chunk_count from files where file = 'stable.ts'")
+				.get(),
+			before,
+		);
+		assert.deepEqual(
+			db
+				.prepare("select text, vector from chunks where file = 'stable.ts'")
+				.all(),
+			chunksBefore,
+		);
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
+});
+
+test("interrupted configuration rebuilds resume completed files", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		writeFileSync(
+			path.join(root, "a.ts"),
+			"export const firstContract = 'stable';\n",
+		);
+		writeFileSync(
+			path.join(root, "b.ts"),
+			"export const secondContract = 'stable';\n",
+		);
+		const db = openIndexDb(root);
+		const initialConfig = config(endpoint.url);
+		await syncIndex(db, root, initialConfig);
+		const initialInputs = endpoint.state.inputs;
+
+		const changedConfig = config(endpoint.url);
+		changedConfig.embeddings.documentPrefix = "document: ";
+		changedConfig.embeddings.batchSize = 1;
+		endpoint.state.failAfterInputs = initialInputs + 1;
+		await assert.rejects(syncIndex(db, root, changedConfig), /503/);
+		assert.deepEqual(
+			db.prepare("select index_generation from files order by file").all(),
+			[{ index_generation: 2 }, { index_generation: 1 }],
+		);
+
+		endpoint.state.failAfterInputs = undefined;
+		const beforeResume = endpoint.state.inputs;
+		await syncIndex(db, root, changedConfig);
+		assert.equal(endpoint.state.inputs - beforeResume, 1);
+		assert.deepEqual(
+			db.prepare("select index_generation from files order by file").all(),
+			[{ index_generation: 2 }, { index_generation: 2 }],
+		);
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
+});
+
+test("query and document requests preserve configured embedding roles", async () => {
+	const endpoint = await embeddingEndpoint();
+	try {
+		const root = tempProject();
+		writeFileSync(
+			path.join(root, "roles.ts"),
+			"export const retrievalRole = 'document';\n",
+		);
+		const db = openIndexDb(root);
+		const cfg = config(endpoint.url);
+		cfg.embeddings.dimensions = 3;
+		cfg.embeddings.documentPrefix = "doc: ";
+		cfg.embeddings.queryPrefix = "query: ";
+		cfg.embeddings.documentExtraBody = { input_type: "document" };
+		cfg.embeddings.queryExtraBody = { input_type: "query" };
+		await syncIndex(db, root, cfg);
+		await searchDb(db, "retrieval role", 1, cfg);
+
+		const documentRequest = endpoint.state.bodies.find(
+			(body) => body["input_type"] === "document",
+		);
+		const queryRequest = endpoint.state.bodies.find(
+			(body) => body["input_type"] === "query",
+		);
+		assert.equal(documentRequest?.["dimensions"], 3);
+		assert.ok(
+			(Array.isArray(documentRequest?.["input"])
+				? documentRequest?.["input"][0]
+				: documentRequest?.["input"]
+			)?.startsWith("doc: File:"),
+		);
+		assert.equal(queryRequest?.["input"], "query: retrieval role");
+		db.close();
+	} finally {
+		await endpoint.close();
+	}
+});
+
+test("writer locks exclude concurrent indexers and recover after release", async () => {
+	const root = tempProject();
+	const release = await tryAcquireIndexLock(root);
+	assert.ok(release);
+	assert.equal(await tryAcquireIndexLock(root), undefined);
+	await release?.();
+	const reacquired = await tryAcquireIndexLock(root);
+	assert.ok(reacquired);
+	await reacquired?.();
+});
+
+test("legacy databases migrate without discarding indexed chunks", () => {
+	const root = tempProject();
+	mkdirSync(path.join(root, ".pi"), { recursive: true });
+	const legacy = new Database(dbPathFor(root));
+	legacy.exec(`
+    create table meta (key text primary key, value text not null);
+    create table files (
+      file text primary key, hash text not null, size integer not null,
+      mtime_ms real not null, indexed_at text not null
+    );
+    create table chunks (
+      id integer primary key, file text not null, start_line integer not null,
+      end_line integer not null, text text not null, hash text not null,
+      vector text not null,
+      foreign key(file) references files(file) on delete cascade
+    );
+    insert into meta values ('index_fingerprint', 'legacy-fingerprint');
+    insert into files values ('legacy.ts', 'hash', 42, 1, 'then');
+    insert into chunks (file, start_line, end_line, text, hash, vector)
+      values ('legacy.ts', 1, 2, 'legacy indexed text', 'hash', '[1,2,3]');
+  `);
+	legacy.close();
+
+	const migrated = openIndexDb(root);
+	const file = migrated
+		.prepare(
+			"select index_fingerprint, index_generation, chunk_count from files where file = 'legacy.ts'",
+		)
+		.get() as {
+		index_fingerprint: string;
+		index_generation: number;
+		chunk_count: number;
+	};
+	assert.deepEqual(file, {
+		index_fingerprint: "legacy-fingerprint",
+		index_generation: 1,
+		chunk_count: 1,
+	});
+	assert.equal(getMeta(migrated, "active_fingerprint"), "legacy-fingerprint");
+	assert.deepEqual(
+		migrated.prepare("select count(*) count from chunks").get(),
+		{
+			count: 1,
+		},
+	);
+	migrated.close();
+});
+
+test("Git discovery includes untracked files and honors standard ignores", () => {
+	const root = tempProject();
+	execFileSync("git", ["init", "-q", root]);
+	mkdirSync(path.join(root, "ignored"));
+	mkdirSync(path.join(root, "node_modules"));
+	writeFileSync(path.join(root, ".gitignore"), "ignored/\n");
+	writeFileSync(path.join(root, "kept.ts"), "export const kept = true;\n");
+	writeFileSync(path.join(root, "ignored", "hidden.ts"), "hidden\n");
+	writeFileSync(path.join(root, "node_modules", "forced.ts"), "forced\n");
+	execFileSync("git", ["-C", root, "add", "-f", "node_modules/forced.ts"]);
+
+	const cfg = config("http://127.0.0.1:1/v1/embeddings");
+	const result = discoverFiles(root, cfg);
+	assert.equal(result.source, "git");
+	assert.deepEqual(
+		result.files.map((file) => file.file),
+		["kept.ts"],
+	);
+});


### PR DESCRIPTION
## Summary

- render delete-and-readd patches as ordinary file edits instead of collapsing the UI to a generic tool-call row
- make failed patch context errors concise, point the agent back to the current file, and suppress duplicate nested error output
- clarify move-file patch syntax
- remove tests that attempted to prove agent prompt compliance, and record the deterministic-test boundary in repository guidance

The branch also includes execution-mode planning documentation.

## Semantic grep

- make indexing single-writer and migration-safe with cross-process locking, schema-v5 migration, atomic per-file replacement, and resumable generation staging that preserves the last usable index after interruption
- discover tracked and untracked files through Git excludes, apply nested gitignore rules in the bounded filesystem fallback, and use size/mtime/ctime metadata to avoid unnecessary file reads and embeddings
- batch role-aware document embeddings, bound oversized chunks, validate vector count, dimensions, ordering, and numeric values, and omit incompatible stale vectors from search with visible recovery guidance
- return from session startup before discovery, keep Git and filesystem scanning asynchronous and cancellable, cooperatively yield during file processing, and leave the stale WAL index searchable while synchronization continues

## Validation

- focused apply-patch rendering and tool-result contract tests
- 11 semantic indexing contracts covering atomic failure recovery, resumable generations, migration, locking, discovery, role routing, startup yielding, cancellation, and chunk identity
- `@howaboua/pi-codex-conversion` and `@howaboua/pi-semantic-grep` package checks
- extension artifact, dependency, changed-package, and changeset checks

## Release

- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-semantic-grep`
- Aggregates: generated by release automation
