### PR TITLE
feat: auto-resume dropped realtime voice sessions

### DIFF
--- a/.changeset/patch-msoc7pyw-487d1b.md
+++ b/.changeset/patch-msoc7pyw-487d1b.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Auto-resume dropped realtime voice calls when enabled and update Undici to its patched release.

--- a/.changeset/patch-msocleu5-cd4c51.md
+++ b/.changeset/patch-msocleu5-cd4c51.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-gippity-control": patch
+---
+
+Add opt-in dropped realtime voice call auto-resume to GipPity Control and update Undici to its patched release.

--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -97,6 +97,7 @@ Verification does not imply a permanent test. Use the cheapest fitting evidence:
 ## GitHub writing
 
 - Write issue and PR bodies for the next human: goal, material context, actual change, validation, and unresolved risk without routine command narration.
+- Begin every PR body with one plain-language sentence stating what it is trying to do, before headings or bullets. Add more opening prose only when truly needed or when multiple affected packages need separate explanation.
 - Use `Closes #123` only when the PR fully resolves the issue; otherwise use `Refs #123`.
 - For multiline bodies and comments, write Markdown to a temporary file and pass `--body-file`. Do not pass shell strings containing `\n`.
 - Follow repository templates, removing placeholders that do not apply.
@@ -105,6 +106,8 @@ Verification does not imply a permanent test. Use the cheapest fitting evidence:
 Use this concise PR body when no more specific template applies:
 
 ```markdown
+This PR ...
+
 ## Summary
 
 - ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repo publishes through Changesets; every merge to `main` feeds the version 
 - Agent-facing text is behavior: keep tool contracts, skill files, prompt metadata, and subagent prompts compact.
 - Agent-facing prose need not perform grammatical polish; optimize semantic signal per token and omit cosmetic punctuation when it saves tokens. Preserve syntax, structural delimiters, meaning, evidence, caveats, and recovery instructions.
 - Contract spine, not feature museum: feature-existence and regression-tour tests die; retain only independent protocol, routing, migration, or model-visible contracts.
+- When review questions test scope, cull first: delete whole cases or narrow to the minimum independent contract. Never increase permanent test count unless the user explicitly requests more coverage.
 - Never encode agent tool-call mistakes or prompt-following failures as programmatic tests. Discover them in real use and fix the model-facing contract; tests may cover only deterministic parser, executor, result, or routing boundaries independently of model compliance.
 - Skills and extensions must work for any user. Never ship local paths, personal names, machine assumptions, or private workflow details.
 - Slash commands are for users; agents use tools. Prefer one routed entry command over several command names unless explicitly requested.

--- a/bun.lock
+++ b/bun.lock
@@ -187,7 +187,7 @@
       "dependencies": {
         "proxy-from-env": "1.1.0",
         "selfsigned": "^3.0.1",
-        "undici": "8.5.0",
+        "undici": "8.10.0",
         "ws": "^8.21.0",
       },
       "devDependencies": {
@@ -1392,8 +1392,6 @@
     "@howaboua/pi-extensions/@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
 
     "@howaboua/pi-gippity-control/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
-
-    "@howaboua/pi-gippity-control/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@howaboua/pi-gpt-switcher/@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
         "selfsigned": "^3.0.1",
         "smol-toml": "^1.6.0",
         "tree-sitter-bash": "^0.25.1",
-        "undici": "8.5.0",
+        "undici": "8.10.0",
         "web-tree-sitter": "^0.26.7",
         "ws": "^8.21.0",
       },
@@ -1315,7 +1315,7 @@
 
     "unbash": ["unbash@4.0.3", "", {}, "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w=="],
 
-    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1393,6 +1393,8 @@
 
     "@howaboua/pi-gippity-control/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "@howaboua/pi-gippity-control/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-gpt-switcher/@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
 
     "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
@@ -1467,6 +1469,8 @@
 
     "@howaboua/pi-ask/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
+    "@howaboua/pi-ask/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-auto-reasoning-tool/@earendil-works/pi-ai/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "@howaboua/pi-auto-reasoning-tool/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
@@ -1476,6 +1480,8 @@
     "@howaboua/pi-auto-reasoning-tool/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "@howaboua/pi-auto-reasoning-tool/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "@howaboua/pi-auto-reasoning-tool/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@howaboua/pi-cache-hit-predictor/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
@@ -1487,17 +1493,23 @@
 
     "@howaboua/pi-cache-hit-predictor/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
+    "@howaboua/pi-cache-hit-predictor/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-dynamic-tools/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
     "@howaboua/pi-dynamic-tools/@earendil-works/pi-coding-agent/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
 
     "@howaboua/pi-dynamic-tools/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
+    "@howaboua/pi-dynamic-tools/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-dynamic-tools/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@howaboua/pi-explore-subagents/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
     "@howaboua/pi-explore-subagents/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@howaboua/pi-explore-subagents/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@howaboua/pi-explore-subagents/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -1511,6 +1523,8 @@
 
     "@howaboua/pi-extensions/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
+    "@howaboua/pi-extensions/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-gippity-control/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@howaboua/pi-gpt-switcher/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
@@ -1523,6 +1537,8 @@
 
     "@howaboua/pi-gpt-switcher/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
+    "@howaboua/pi-gpt-switcher/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
     "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
@@ -1530,6 +1546,8 @@
     "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent/@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ=="],
 
     "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@howaboua/pi-markdown-workflows/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@howaboua/pi-memories/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
@@ -1539,6 +1557,8 @@
 
     "@howaboua/pi-memories/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
+    "@howaboua/pi-memories/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-memories/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@howaboua/pi-semantic-grep/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
@@ -1546,6 +1566,8 @@
     "@howaboua/pi-semantic-grep/@earendil-works/pi-coding-agent/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
 
     "@howaboua/pi-semantic-grep/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@howaboua/pi-semantic-grep/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@howaboua/pi-stuff/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
@@ -1557,11 +1579,15 @@
 
     "@howaboua/pi-stuff/@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
+    "@howaboua/pi-stuff/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
     "@howaboua/pi-vent/@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
     "@howaboua/pi-vent/@earendil-works/pi-coding-agent/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
 
     "@howaboua/pi-vent/@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@howaboua/pi-vent/@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/packages/pi-codex-conversion/package.json
+++ b/packages/pi-codex-conversion/package.json
@@ -111,7 +111,7 @@
     "selfsigned": "^3.0.1",
     "smol-toml": "^1.6.0",
     "tree-sitter-bash": "^0.25.1",
-    "undici": "8.5.0",
+    "undici": "8.10.0",
     "web-tree-sitter": "^0.26.7",
     "ws": "^8.21.0"
   },

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -82,6 +82,7 @@ export interface CodexConversionConfig {
 	};
 	voice: {
 		v3Voice: RealtimeV3Voice;
+		autoResumeRealtime: boolean;
 		dictationShortcut: string;
 		realtimeShortcut: string;
 		muteShortcut: string;
@@ -131,6 +132,7 @@ export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	beta: { codeMode: false, responsesLite: false, v2UserMessageRetention: 64 },
 	voice: {
 		v3Voice: "cove",
+		autoResumeRealtime: false,
 		dictationShortcut: "ctrl+alt+d",
 		realtimeShortcut: "ctrl+alt+space",
 		muteShortcut: "ctrl+alt+m",
@@ -390,6 +392,10 @@ export function normalizeCodexConversionConfig(
 			v3Voice:
 				normalizeRealtimeV3Voice(voice["v3Voice"]) ??
 				DEFAULT_CODEX_CONVERSION_CONFIG.voice.v3Voice,
+			autoResumeRealtime: bool(
+				voice["autoResumeRealtime"],
+				DEFAULT_CODEX_CONVERSION_CONFIG.voice.autoResumeRealtime,
+			),
 			dictationShortcut: stringValue(
 				voice["dictationShortcut"],
 				DEFAULT_CODEX_CONVERSION_CONFIG.voice.dictationShortcut,

--- a/packages/pi-codex-conversion/src/ui/settings/config-items-voice.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-items-voice.ts
@@ -39,6 +39,21 @@ export function buildVoiceSettings(
 		),
 		setting(
 			{
+				id: "autoResumeRealtime",
+				label: "Auto-resume realtime voice",
+				currentValue: config.voice.autoResumeRealtime ? "on" : "off",
+				values: ["off", "on"],
+			},
+			(value, current) => ({
+				...current,
+				voice: {
+					...current.voice,
+					autoResumeRealtime: value === "on",
+				},
+			}),
+		),
+		setting(
+			{
 				id: "voiceContextModel",
 				label: "Voice context model",
 				currentValue: currentContextModel,

--- a/packages/pi-codex-conversion/src/voice/AGENTS.md
+++ b/packages/pi-codex-conversion/src/voice/AGENTS.md
@@ -14,6 +14,7 @@
 - On finalized user `turn.done`, immediately show one display-only `You said` entry before routing any hidden canonical delegation. Never render partial recognition.
 - Buffer Pi worker text to its assistant-message boundary. Route tool-use messages to V3 commentary and terminal messages to speakable without changing visible Pi text. Never forward raw thinking deltas.
 - Each mode owns its helper process and idempotent cleanup; the controller owns replacement/reload/shutdown ordering.
+- Opt-in auto-resume replaces only established host-to-OpenAI V3 calls after terminal transport drops. Preserve LAN browser ownership, rerun normal context startup, omit lifecycle end/start, and leave failed replacement startup terminal.
 - LAN voice is host-owned: one helper WebRTC V3 call owns authenticated setup and delegation; browser disconnect/takeover preserves it, explicit Stop closes it so the next Start snapshots fresh Pi context. Never replace supported V3 WebRTC with standalone ChatGPT OAuth WebSocket.
 - Realtime mic mute keeps V3 warm. Gate browser tracks, discard captured samples, send silence RTP, and reset mute when input ownership ends.
 - Native `v3.rs` owns WebRTC signaling/session state; `v3_media.rs` owns audio tracks, playout, encoding, and silence RTP.

--- a/packages/pi-codex-conversion/src/voice/controller-sessions.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-sessions.ts
@@ -31,6 +31,7 @@ export async function startControllerConversation(options: {
 	config: CodexConversionConfig;
 	instructions: string;
 	initialItems?: RealtimeInitialMessageItem[] | undefined;
+	inputMuted?: boolean | undefined;
 	peer?: CodexRealtimePeer | undefined;
 	signal?: AbortSignal | undefined;
 	lifecycle: RealtimeSessionLifecycle;
@@ -54,7 +55,13 @@ export async function startControllerConversation(options: {
 	const closeOnAbort = () => { void session.close(); };
 	options.signal?.addEventListener("abort", closeOnAbort, { once: true });
 	try {
-		await session.start(options.auth, options.config, options.instructions, options.initialItems);
+		await session.start(
+			options.auth,
+			options.config,
+			options.instructions,
+			options.initialItems,
+			options.inputMuted,
+		);
 	} finally {
 		options.signal?.removeEventListener("abort", closeOnAbort);
 	}

--- a/packages/pi-codex-conversion/src/voice/controller-sessions.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-sessions.ts
@@ -16,6 +16,7 @@ interface SessionLifecycle<T> {
 }
 
 interface RealtimeSessionLifecycle extends SessionLifecycle<CodexRealtimeConversation> {
+	onDrop(session: CodexRealtimeConversation, error: Error): void;
 	onTurn(turn: RealtimeVoiceTurn): void;
 	onUserTranscript(transcript: string): void;
 	onTranscriptTail(transcript: string): void;
@@ -42,6 +43,7 @@ export async function startControllerConversation(options: {
 	let session!: CodexRealtimeConversation;
 	session = new CodexRealtimeConversation({
 		onError: (error) => options.lifecycle.onError(session, error),
+		onDrop: (error) => options.lifecycle.onDrop(session, error),
 		onStatus: options.lifecycle.onStatus,
 		onTurn: options.lifecycle.onTurn,
 		onUserTranscript: options.lifecycle.onUserTranscript,
@@ -56,7 +58,10 @@ export async function startControllerConversation(options: {
 	} finally {
 		options.signal?.removeEventListener("abort", closeOnAbort);
 	}
-	if (options.lifecycle.isCurrent(session)) options.lifecycle.onActive(session);
+	if (options.lifecycle.isCurrent(session)) {
+		session.markEstablished();
+		options.lifecycle.onActive(session);
+	}
 	else await session.close();
 }
 

--- a/packages/pi-codex-conversion/src/voice/controller-start.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-start.ts
@@ -45,6 +45,7 @@ export async function startControllerMode(options: {
 	mode: CodexVoiceMode;
 	realtimePeerPlan?: RealtimePeerPlan | undefined;
 	resume?: boolean | undefined;
+	inputMuted?: boolean | undefined;
 	signal?: AbortSignal | undefined;
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined;
 	stopCurrent(): Promise<void>;
@@ -171,6 +172,7 @@ async function startConversation(
 		config: options.config,
 		instructions,
 		initialItems,
+		inputMuted: options.inputMuted,
 		peer,
 		signal,
 		lifecycle: {

--- a/packages/pi-codex-conversion/src/voice/controller-start.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-start.ts
@@ -20,6 +20,12 @@ import type { CodexRealtimeConversation } from "./conversation/session.ts";
 import type { CodexVoiceSessionMessages } from "./session-messages.ts";
 import type { CodexVoiceMode } from "./ui.ts";
 
+export interface RealtimePeerPlan {
+	createPeer(): CodexRealtimePeer;
+	onActive?(session: CodexRealtimeConversation, peer: CodexRealtimePeer): void;
+	onInactive?(session: CodexRealtimeConversation, error: Error, resuming: boolean): void;
+}
+
 export interface VoiceControllerRuntime {
 	state: VoiceState;
 	context?: ExtensionContext | undefined;
@@ -28,6 +34,7 @@ export interface VoiceControllerRuntime {
 	startGeneration: number;
 	startAbortController?: AbortController | undefined;
 	voiceStatus: string;
+	realtimePeerPlan?: RealtimePeerPlan | undefined;
 }
 
 export async function startControllerMode(options: {
@@ -36,31 +43,29 @@ export async function startControllerMode(options: {
 	ctx: ExtensionContext;
 	config: CodexConversionConfig;
 	mode: CodexVoiceMode;
-	peer?: CodexRealtimePeer | undefined;
+	realtimePeerPlan?: RealtimePeerPlan | undefined;
+	resume?: boolean | undefined;
 	signal?: AbortSignal | undefined;
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined;
 	stopCurrent(): Promise<void>;
 	finishCurrentDictation(): Promise<void>;
-	onError(error: Error): void;
+	onError(error: Error, session?: CodexRealtimeConversation | undefined): void;
+	onDrop(session: CodexRealtimeConversation, error: Error): void;
 	onStatus(status: string): void;
 }): Promise<CodexRealtimeConversation | undefined> {
-	const { runtime, peer, signal } = options;
-	if (signal?.aborted) {
-		await peer?.close();
-		return;
-	}
+	const { runtime, signal } = options;
+	if (signal?.aborted) return;
 	const realtimePrompt =
 		options.mode === "realtime"
 			? options.prepareRealtimePrompt(options.ctx)
 			: undefined;
 	if (options.mode === "realtime" && realtimePrompt === undefined) return;
-	if (runtime.state.type === "dictation")
-		await options.finishCurrentDictation();
-	else await options.stopCurrent();
-	if (signal?.aborted) {
-		await peer?.close();
-		return;
-	}
+	if (!options.resume) {
+		if (runtime.state.type === "dictation")
+			await options.finishCurrentDictation();
+		else await options.stopCurrent();
+	} else if (runtime.state.type !== "reconnecting") return;
+	if (signal?.aborted) return;
 	const startAbortController = new AbortController();
 	runtime.startAbortController = startAbortController;
 	const startSignal = signal
@@ -69,6 +74,7 @@ export async function startControllerMode(options: {
 	const startGeneration = ++runtime.startGeneration;
 	runtime.context = options.ctx;
 	runtime.config = options.config;
+	runtime.realtimePeerPlan = options.mode === "realtime" ? options.realtimePeerPlan : undefined;
 	options.messages.setContext(options.ctx);
 	runtime.state =
 		options.mode === "realtime"
@@ -94,7 +100,6 @@ export async function startControllerMode(options: {
 			startSignal,
 		);
 		if (startup === CANCELLED) {
-			await peer?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
@@ -102,10 +107,7 @@ export async function startControllerMode(options: {
 		if (
 			startGeneration !== runtime.startGeneration ||
 			runtime.state.type !== "connecting"
-		) {
-			await peer?.close();
-			return;
-		}
+		) return;
 		if (options.mode === "dictation") await startDictation(options, auth);
 		else
 			await startConversation(
@@ -116,19 +118,20 @@ export async function startControllerMode(options: {
 				startSignal,
 			);
 		if (startSignal.aborted) {
-			await peer?.close();
+			await currentVoiceSession(runtime.state)?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
 		const activeState = snapshotState(runtime);
 		if (options.mode === "realtime") {
 			if (activeState.type !== "conversation") {
-				await peer?.close();
 				return;
 			}
 			if (realtimeSummary) options.messages.contextSummary(realtimeSummary);
-			runtime.announcedMode = options.mode;
-			options.messages.modeStarted(options.mode);
+			if (runtime.announcedMode !== options.mode) {
+				runtime.announcedMode = options.mode;
+				options.messages.modeStarted(options.mode);
+			}
 			return activeState.session;
 		}
 		if (activeState.type !== "dictation") return;
@@ -137,14 +140,11 @@ export async function startControllerMode(options: {
 		return undefined;
 	} catch (error) {
 		if (startSignal.aborted) {
-			await peer?.close();
+			await currentVoiceSession(runtime.state)?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
-		if (startGeneration !== runtime.startGeneration) {
-			await peer?.close();
-			return;
-		}
+		if (startGeneration !== runtime.startGeneration) return;
 		options.onError(error instanceof Error ? error : new Error(String(error)));
 		return undefined;
 	}
@@ -165,12 +165,13 @@ async function startConversation(
 		connecting.phase !== "authorizing"
 	)
 		return;
+	const peer = options.realtimePeerPlan?.createPeer();
 	await startControllerConversation({
 		auth,
 		config: options.config,
 		instructions,
 		initialItems,
-		peer: options.peer,
+		peer,
 		signal,
 		lifecycle: {
 			stillAuthorizing: () => runtime.state === connecting,
@@ -185,10 +186,15 @@ async function startConversation(
 			isCurrent: (session) => currentVoiceSession(runtime.state) === session,
 			onActive: (session) => {
 				runtime.state = { type: "conversation", session };
+				if (peer) options.realtimePeerPlan?.onActive?.(session, peer);
 			},
 			onError: (session, error) => {
 				if (currentVoiceSession(runtime.state) === session)
-					options.onError(error);
+					options.onError(error, session);
+			},
+			onDrop: (session, error) => {
+				if (currentVoiceSession(runtime.state) === session)
+					options.onDrop(session, error);
 			},
 			onStatus: options.onStatus,
 			onTurn: (turn) => { void options.messages.voiceTurn(turn); },
@@ -247,6 +253,7 @@ function cancelStart(
 	if (startGeneration !== runtime.startGeneration) return;
 	runtime.state = { type: "idle" };
 	runtime.config = undefined;
+	runtime.realtimePeerPlan = undefined;
 	runtime.voiceStatus = "";
 	runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 }

--- a/packages/pi-codex-conversion/src/voice/controller-support.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-support.ts
@@ -14,6 +14,7 @@ export const VOICE_STATUS_KEY = "codex-voice";
 export type VoiceSession = CodexRealtimeConversation | CodexDictationSession;
 export type VoiceState =
 	| { type: "idle" }
+	| { type: "reconnecting" }
 	| { type: "connecting"; mode: "realtime"; phase: "authorizing" }
 	| { type: "connecting"; mode: "realtime"; phase: "starting"; session: CodexRealtimeConversation }
 	| { type: "connecting"; mode: "dictation"; phase: "authorizing" }

--- a/packages/pi-codex-conversion/src/voice/controller-support.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-support.ts
@@ -14,7 +14,7 @@ export const VOICE_STATUS_KEY = "codex-voice";
 export type VoiceSession = CodexRealtimeConversation | CodexDictationSession;
 export type VoiceState =
 	| { type: "idle" }
-	| { type: "reconnecting" }
+	| { type: "reconnecting"; session: CodexRealtimeConversation }
 	| { type: "connecting"; mode: "realtime"; phase: "authorizing" }
 	| { type: "connecting"; mode: "realtime"; phase: "starting"; session: CodexRealtimeConversation }
 	| { type: "connecting"; mode: "dictation"; phase: "authorizing" }
@@ -24,7 +24,7 @@ export type VoiceState =
 	| { type: "failed"; message: string };
 
 export function currentVoiceSession(state: VoiceState): VoiceSession | undefined {
-	if (state.type === "conversation" || state.type === "dictation") return state.session;
+	if (state.type === "conversation" || state.type === "dictation" || state.type === "reconnecting") return state.session;
 	return state.type === "connecting" && state.phase === "starting" ? state.session : undefined;
 }
 

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -328,7 +328,7 @@ export class CodexVoiceController {
 		this.runtime.startAbortController = undefined;
 		const resumeGeneration = ++this.runtime.startGeneration;
 		const wasMuted = this.inputMuted;
-		this.runtime.state = { type: "reconnecting" };
+		this.runtime.state = { type: "reconnecting", session };
 		this.renderStatus("reconnecting…");
 		void (async () => {
 			await Promise.allSettled([

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -160,6 +160,7 @@ export class CodexVoiceController {
 		realtimePeerPlan?: RealtimePeerPlan,
 		signal?: AbortSignal,
 		resume = false,
+		inputMuted = false,
 	): Promise<CodexRealtimeConversation | undefined> {
 		return startControllerMode({
 			runtime: this.runtime,
@@ -170,6 +171,7 @@ export class CodexVoiceController {
 			realtimePeerPlan,
 			signal,
 			resume,
+			inputMuted,
 			prepareRealtimePrompt: (current) => this.prepareRealtimePrompt(current),
 			stopCurrent: () => this.stop({ announce: true }),
 			finishCurrentDictation: () => this.finishDictation({ announce: true }),
@@ -346,6 +348,7 @@ export class CodexVoiceController {
 				realtimePeerPlan,
 				undefined,
 				true,
+				wasMuted,
 			);
 			const replacementGeneration = this.runtime.startGeneration;
 			let resumed: CodexRealtimeConversation | undefined;
@@ -373,7 +376,7 @@ export class CodexVoiceController {
 				return;
 			}
 			if (resumed && wasMuted && this.currentSession() === resumed)
-				this.setInputMuted(true);
+				this.renderCurrentStatus();
 		})();
 	}
 

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -339,7 +339,7 @@ export class CodexVoiceController {
 				this.runtime.startGeneration !== resumeGeneration ||
 				this.runtime.state.type !== "reconnecting"
 			) return;
-			const resumed = await this.startMode(
+			const resumePromise = this.startMode(
 				ctx,
 				config,
 				"realtime",
@@ -347,6 +347,19 @@ export class CodexVoiceController {
 				undefined,
 				true,
 			);
+			const replacementGeneration = this.runtime.startGeneration;
+			let resumed: CodexRealtimeConversation | undefined;
+			try {
+				resumed = await resumePromise;
+			} catch (resumeError) {
+				if (this.runtime.startGeneration === replacementGeneration)
+					this.fail(
+						resumeError instanceof Error
+							? resumeError
+							: new Error(String(resumeError)),
+					);
+				return;
+			}
 			if (!resumed) {
 				const resumeError = new Error("Codex realtime voice could not resume");
 				this.markRealtimePeerInactive(

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -7,6 +7,7 @@ import type {
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import {
 	startControllerMode,
+	type RealtimePeerPlan,
 	type VoiceControllerRuntime,
 } from "./controller-start.ts";
 import {
@@ -18,7 +19,6 @@ import {
 	voiceModeForState,
 } from "./controller-support.ts";
 import { realtimeHandoffChannel } from "./conversation/handoff.ts";
-import type { CodexRealtimePeer } from "./conversation/peer.ts";
 import type { CodexRealtimeConversation } from "./conversation/session.ts";
 import { CodexVoiceSessionMessages, type PreparedVoiceDelegation } from "./session-messages.ts";
 import { formatVoiceAudioError } from "./setup.ts";
@@ -110,13 +110,13 @@ export class CodexVoiceController {
 		await this.startMode(ctx, config, mode);
 	}
 
-	async startRealtimeWithPeer(
+	async startRealtimeWithPeerPlan(
 		ctx: ExtensionContext,
 		config: CodexConversionConfig,
-		peer: CodexRealtimePeer,
+		plan: RealtimePeerPlan,
 		signal?: AbortSignal,
 	): Promise<CodexRealtimeConversation | undefined> {
-		return this.startMode(ctx, config, "realtime", peer, signal);
+		return this.startMode(ctx, config, "realtime", plan, signal);
 	}
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined {
 		return prepareRealtimeVoicePrompt(ctx);
@@ -127,6 +127,13 @@ export class CodexVoiceController {
 		options?: { announce?: boolean },
 	): Promise<void> {
 		if (this.currentSession() === session) await this.stop(options);
+	}
+
+	async stopRealtimeWithPeerPlan(
+		plan: RealtimePeerPlan,
+		options?: { announce?: boolean },
+	): Promise<void> {
+		if (this.runtime.realtimePeerPlan === plan) await this.stop(options);
 	}
 
 	setConversationInputActive(
@@ -150,8 +157,9 @@ export class CodexVoiceController {
 		ctx: ExtensionContext,
 		config: CodexConversionConfig,
 		mode: CodexVoiceMode,
-		peer?: CodexRealtimePeer,
+		realtimePeerPlan?: RealtimePeerPlan,
 		signal?: AbortSignal,
+		resume = false,
 	): Promise<CodexRealtimeConversation | undefined> {
 		return startControllerMode({
 			runtime: this.runtime,
@@ -159,12 +167,14 @@ export class CodexVoiceController {
 			ctx,
 			config,
 			mode,
-			peer,
+			realtimePeerPlan,
 			signal,
+			resume,
 			prepareRealtimePrompt: (current) => this.prepareRealtimePrompt(current),
 			stopCurrent: () => this.stop({ announce: true }),
 			finishCurrentDictation: () => this.finishDictation({ announce: true }),
-			onError: (error) => this.fail(error),
+			onError: (error, session) => this.fail(error, session),
+			onDrop: (session, error) => this.drop(session, error),
 			onStatus: (status) => this.renderStatus(status),
 		});
 	}
@@ -183,6 +193,7 @@ export class CodexVoiceController {
 		this.runtime.state = { type: "idle" };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		await closePromise;
@@ -216,6 +227,7 @@ export class CodexVoiceController {
 		this.runtime.state = { type: "idle" };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.messages.voiceStopped(endedMode);
@@ -258,7 +270,10 @@ export class CodexVoiceController {
 		return currentVoiceSession(this.runtime.state);
 	}
 
-	private fail(error: Error): void {
+	private fail(
+		error: Error,
+		failedSession?: CodexRealtimeConversation | undefined,
+	): void {
 		if (
 			this.runtime.state.type === "idle" ||
 			this.runtime.state.type === "failed"
@@ -274,10 +289,13 @@ export class CodexVoiceController {
 		const endedMode = this.runtime.announcedMode;
 		const wasMuted = this.inputMuted;
 		const session = this.currentSession();
+		if (failedSession)
+			this.markRealtimePeerInactive(failedSession, error, false);
 		const closePromise = session?.close();
 		this.runtime.state = { type: "failed", message };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.runtime.context?.ui.notify(message, "error");
@@ -293,6 +311,73 @@ export class CodexVoiceController {
 				this.runtime.state.message === message
 			) this.messages.voiceStopped(endedMode);
 		})();
+	}
+
+	private drop(session: CodexRealtimeConversation, error: Error): void {
+		if (this.currentSession() !== session) return;
+		const config = this.runtime.config;
+		const ctx = this.runtime.context;
+		if (!config?.voice.autoResumeRealtime || !ctx) {
+			this.markRealtimePeerInactive(session, error, false);
+			this.fail(error);
+			return;
+		}
+		const realtimePeerPlan = this.runtime.realtimePeerPlan;
+		this.markRealtimePeerInactive(session, error, true);
+		this.runtime.startAbortController?.abort();
+		this.runtime.startAbortController = undefined;
+		const resumeGeneration = ++this.runtime.startGeneration;
+		const wasMuted = this.inputMuted;
+		this.runtime.state = { type: "reconnecting" };
+		this.renderStatus("reconnecting…");
+		void (async () => {
+			await Promise.allSettled([
+				session.close(),
+				this.messages.waitForDelegations(),
+			]);
+			if (
+				this.runtime.startGeneration !== resumeGeneration ||
+				this.runtime.state.type !== "reconnecting"
+			) return;
+			const resumed = await this.startMode(
+				ctx,
+				config,
+				"realtime",
+				realtimePeerPlan,
+				undefined,
+				true,
+			);
+			if (!resumed) {
+				const resumeError = new Error("Codex realtime voice could not resume");
+				this.markRealtimePeerInactive(
+					session,
+					resumeError,
+					false,
+					realtimePeerPlan,
+				);
+				if (this.runtime.state.type === "reconnecting")
+					this.fail(resumeError);
+				return;
+			}
+			if (resumed && wasMuted && this.currentSession() === resumed)
+				this.setInputMuted(true);
+		})();
+	}
+
+	private markRealtimePeerInactive(
+		session: CodexRealtimeConversation,
+		error: Error,
+		resuming: boolean,
+		plan = this.runtime.realtimePeerPlan,
+	): void {
+		try {
+			plan?.onInactive?.(session, error, resuming);
+		} catch (ownerError) {
+			this.runtime.context?.ui.notify(
+				`Could not update realtime voice owner: ${ownerError instanceof Error ? ownerError.message : String(ownerError)}`,
+				"error",
+			);
+		}
 	}
 
 	private renderStatus(status: string): void {

--- a/packages/pi-codex-conversion/src/voice/conversation/session.ts
+++ b/packages/pi-codex-conversion/src/voice/conversation/session.ts
@@ -31,6 +31,7 @@ export class CodexRealtimeConversation {
 	private state: ConversationState = "idle";
 	private setupAbortController: AbortController | undefined;
 	private peerReady: ReturnType<typeof Promise.withResolvers<void>> | undefined;
+	private closePromise: Promise<void> | undefined;
 	private callSetup: RealtimeCallSetup = setupRealtimeCall;
 	private inputMuted = false;
 	private established = false;
@@ -126,7 +127,11 @@ export class CodexRealtimeConversation {
 	}
 
 	async close(): Promise<void> {
-		if (this.state === "closed") return;
+		this.closePromise ??= this.closeSession();
+		return this.closePromise;
+	}
+
+	private async closeSession(): Promise<void> {
 		this.state = "closed";
 		this.established = false;
 		this.abortSetup();
@@ -239,6 +244,6 @@ export class CodexRealtimeConversation {
 		this.peerReady = undefined;
 		if (dropped) this.callbacks.onDrop(error);
 		else this.callbacks.onError(error);
-		void this.peer.close();
+		void this.close();
 	}
 }

--- a/packages/pi-codex-conversion/src/voice/conversation/session.ts
+++ b/packages/pi-codex-conversion/src/voice/conversation/session.ts
@@ -49,7 +49,7 @@ export class CodexRealtimeConversation {
 		this.peer.onExit((error) => this.drop(error));
 	}
 
-	async start(auth: CodexVoiceAuth, config: CodexConversionConfig, instructions: string, initialItems?: RealtimeInitialMessageItem[]): Promise<void> {
+	async start(auth: CodexVoiceAuth, config: CodexConversionConfig, instructions: string, initialItems?: RealtimeInitialMessageItem[], inputMuted = false): Promise<void> {
 		this.state = "starting";
 		const sdp = await this.peer.start(config);
 		if (this.state !== "starting") return;
@@ -76,6 +76,7 @@ export class CodexRealtimeConversation {
 		if (this.state !== "starting") return;
 		if (status !== 201) throw new Error(`Codex voice call failed (${status}): ${answer.slice(0, 1_000)}`);
 		this.state = "active";
+		if (inputMuted) this.setInputMuted(true);
 		const peerReady = Promise.withResolvers<void>();
 		this.peerReady = peerReady;
 		this.callbacks.onStatus("connecting…");
@@ -145,7 +146,12 @@ export class CodexRealtimeConversation {
 
 	private handlePeerEvent(event: CodexRealtimePeerEvent): void {
 		if (this.state === "idle" || this.state === "closed" || this.state === "failed") return;
-		if (event.type === "error") { this.fail(new Error(event.message)); return; }
+		if (event.type === "error") {
+			const error = new Error(event.message);
+			if (terminalTransportError(event.message)) this.drop(error);
+			else this.fail(error);
+			return;
+		}
 		if (event.type === "data") this.handleServerEvent(event.message);
 		if (event.type === "state") this.handleHelperState(event.state);
 	}
@@ -246,4 +252,9 @@ export class CodexRealtimeConversation {
 		else this.callbacks.onError(error);
 		void this.close();
 	}
+}
+
+function terminalTransportError(message: string): boolean {
+	return message.startsWith("realtime speaker stream ended:")
+		|| message.startsWith("realtime microphone stream failed:");
 }

--- a/packages/pi-codex-conversion/src/voice/conversation/session.ts
+++ b/packages/pi-codex-conversion/src/voice/conversation/session.ts
@@ -16,6 +16,7 @@ type ConversationState = "idle" | "starting" | "active" | "failed" | "closed";
 
 export interface CodexConversationCallbacks {
 	onError(error: Error): void;
+	onDrop(error: Error): void;
 	onStatus(status: string): void;
 	onTurn(turn: RealtimeVoiceTurn): void;
 	onUserTranscript(transcript: string): void;
@@ -32,6 +33,7 @@ export class CodexRealtimeConversation {
 	private peerReady: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 	private callSetup: RealtimeCallSetup = setupRealtimeCall;
 	private inputMuted = false;
+	private established = false;
 
 	constructor(callbacks: CodexConversationCallbacks, peer: CodexRealtimePeer) {
 		this.callbacks = callbacks;
@@ -43,7 +45,7 @@ export class CodexRealtimeConversation {
 			onStatus: (status) => this.callbacks.onStatus(status),
 		});
 		this.peer.onEvent((event) => this.handlePeerEvent(event));
-		this.peer.onExit((error) => this.fail(error));
+		this.peer.onExit((error) => this.drop(error));
 	}
 
 	async start(auth: CodexVoiceAuth, config: CodexConversionConfig, instructions: string, initialItems?: RealtimeInitialMessageItem[]): Promise<void> {
@@ -91,6 +93,10 @@ export class CodexRealtimeConversation {
 		}
 	}
 
+	markEstablished(): void {
+		if (this.state === "active") this.established = true;
+	}
+
 	activateDelegation(id: string): void {
 		this.handoff.activate(id);
 	}
@@ -122,6 +128,7 @@ export class CodexRealtimeConversation {
 	async close(): Promise<void> {
 		if (this.state === "closed") return;
 		this.state = "closed";
+		this.established = false;
 		this.abortSetup();
 		this.handoff.clear();
 		this.drainConversation();
@@ -140,7 +147,7 @@ export class CodexRealtimeConversation {
 
 	private handleHelperState(state: string): void {
 		const failure = realtimePeerStateFailure(state);
-		if (failure) { this.fail(new Error(failure)); return; }
+		if (failure) { this.drop(new Error(failure)); return; }
 		if (state === "ready" || state === "listening") {
 			this.peerReady?.resolve();
 			this.callbacks.onStatus("listening");
@@ -214,14 +221,24 @@ export class CodexRealtimeConversation {
 	}
 
 	private fail(error: Error): void {
+		this.finishFailure(error, false);
+	}
+
+	private drop(error: Error): void {
+		this.finishFailure(error, this.established);
+	}
+
+	private finishFailure(error: Error, dropped: boolean): void {
 		if (this.state === "idle" || this.state === "closed" || this.state === "failed") return;
 		this.state = "failed";
+		this.established = false;
 		this.abortSetup();
 		this.handoff.clear();
 		this.drainConversation();
 		this.peerReady?.resolve();
 		this.peerReady = undefined;
-		this.callbacks.onError(error);
+		if (dropped) this.callbacks.onDrop(error);
+		else this.callbacks.onError(error);
 		void this.peer.close();
 	}
 }

--- a/packages/pi-codex-conversion/src/voice/lan/browser-peer.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-peer.ts
@@ -8,13 +8,9 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
 	private readonly helper = new VoiceHelperClient();
 	private readonly onAudio: (pcm: Buffer) => void;
-	private readonly onFailure: (error: Error) => void;
-	private failed = false;
-	private closing = false;
 
-	constructor(options: { onAudio(pcm: Buffer): void; onFailure(error: Error): void }) {
+	constructor(options: { onAudio(pcm: Buffer): void }) {
 		this.onAudio = options.onAudio;
-		this.onFailure = options.onFailure;
 	}
 
 	onEvent(listener: (event: CodexRealtimePeerEvent) => void): () => void {
@@ -25,14 +21,11 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 			}
 			const peerEvent = toPeerEvent(event);
 			if (peerEvent) listener(peerEvent);
-			if (event.type === "error") this.fail(new Error(event.message));
 		});
 	}
 
 	onExit(listener: (error: Error) => void): () => void {
-		const remove = this.helper.onExit(listener);
-		const removeFailure = this.helper.onExit((error) => { if (!this.closing) this.fail(error); });
-		return () => { remove(); removeFailure(); };
+		return this.helper.onExit(listener);
 	}
 
 	async start(config: CodexConversionConfig): Promise<string> {
@@ -74,14 +67,7 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 	}
 
 	close(): Promise<void> {
-		this.closing = true;
 		return this.helper.close();
-	}
-
-	private fail(error: Error): void {
-		if (this.failed) return;
-		this.failed = true;
-		this.onFailure(error);
 	}
 }
 

--- a/packages/pi-codex-conversion/src/voice/lan/server.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer } from "ws";
 import type { CodexConversionConfig } from "../../adapter/activation/config.ts";
 import type { CodexVoiceAuth } from "../auth.ts";
 import type { CodexVoiceController } from "../controller.ts";
+import type { RealtimePeerPlan } from "../controller-start.ts";
 import type { CodexRealtimeConversation } from "../conversation/session.ts";
 import { LanVoiceActivity } from "./activity.ts";
 import { createLanVoiceWebManifest } from "./app-assets.ts";
@@ -41,7 +42,8 @@ export async function startCodexLanVoiceServer(options: {
 	const certificate = resolveLanVoiceCertificate(options.certificateAgentDir);
 	const ownerIsActive = () => options.ctx.sessionManager.getSessionId() === options.ownerSessionId;
 	let activeConversation: { peer: LanHostRealtimePeer; conversation: CodexRealtimeConversation } | undefined;
-	let conversationStart: { peer: LanHostRealtimePeer; abort: AbortController; promise: Promise<void> } | undefined;
+	let conversationStart: { abort: AbortController; promise: Promise<void> } | undefined;
+	let realtimePlan: RealtimePeerPlan | undefined;
 	let closing = false;
 	let clients!: LanVoiceBrowserClients;
 	const activity = new LanVoiceActivity({
@@ -57,36 +59,55 @@ export async function startCodexLanVoiceServer(options: {
 		onError: (clientId, error) => clients.sendControl(clientId, { type: "error", message: error.message }),
 	});
 
-	const conversationFailed = (peer: LanHostRealtimePeer, error: Error): void => {
-		if (activeConversation?.peer !== peer) return;
-		activeConversation = undefined;
-		clients.broadcastControl({ type: "error", message: error.message });
-	};
 	const ensureConversation = async (): Promise<void> => {
 		if (activeConversation) return;
 		if (conversationStart) return conversationStart.promise;
-		const peer = new LanHostRealtimePeer({
-			onAudio: (pcm) => clients.sendConversationAudio(pcm),
-			onFailure: (error) => conversationFailed(peer, error),
-		});
+		if (realtimePlan) return;
 		const abort = new AbortController();
+		let activated = false;
+		const plan: RealtimePeerPlan = {
+			createPeer: () => {
+				let peer!: LanHostRealtimePeer;
+				peer = new LanHostRealtimePeer({
+					onAudio: (pcm) => {
+						if (activeConversation?.peer === peer)
+							clients.sendConversationAudio(pcm);
+					},
+				});
+				return peer;
+			},
+			onActive: (conversation, peer) => {
+				activated = true;
+				activeConversation = {
+					peer: peer as LanHostRealtimePeer,
+					conversation,
+				};
+			},
+			onInactive: (conversation, error, resuming) => {
+				const ownedActive = activeConversation?.conversation === conversation;
+				if (!ownedActive && realtimePlan !== plan) return;
+				if (ownedActive)
+					activeConversation = undefined;
+				if (resuming) return;
+				if (realtimePlan === plan) realtimePlan = undefined;
+				if (activated)
+					clients.broadcastControl({ type: "error", message: error.message });
+			},
+		};
+		realtimePlan = plan;
 		const promise = (async () => {
-			let started: CodexRealtimeConversation | undefined;
-			try {
-				started = await options.voice.startRealtimeWithPeer(options.ctx, options.getConfig(), peer, abort.signal);
-			} catch (error) {
-				await peer.close();
-				throw error;
-			}
-			if (!started) {
-				await peer.close();
-				throw new Error("Codex voice could not start");
-			}
-			activeConversation = { peer, conversation: started };
+			const started = await options.voice.startRealtimeWithPeerPlan(
+				options.ctx,
+				options.getConfig(),
+				plan,
+				abort.signal,
+			);
+			if (!started) throw new Error("Codex voice could not start");
 		})().finally(() => {
-			if (conversationStart?.peer === peer) conversationStart = undefined;
+			if (conversationStart?.abort === abort) conversationStart = undefined;
+			if (!activated && realtimePlan === plan) realtimePlan = undefined;
 		});
-		conversationStart = { peer, abort, promise };
+		conversationStart = { abort, promise };
 		return promise;
 	};
 	clients = new LanVoiceBrowserClients({
@@ -111,13 +132,16 @@ export async function startCodexLanVoiceServer(options: {
 		cancelDictation: (clientId) => dictation.cancel(clientId),
 		async onConversationActivity(active) {
 			const current = activeConversation;
-			if (!current) return;
 			if (active) {
-				options.voice.setConversationInputActive(current.conversation, true);
+				if (current)
+					options.voice.setConversationInputActive(current.conversation, true);
 				return;
 			}
+			const plan = realtimePlan;
+			realtimePlan = undefined;
 			activeConversation = undefined;
-			await options.voice.stopConversation(current.conversation, { announce: true });
+			if (plan)
+				await options.voice.stopRealtimeWithPeerPlan(plan, { announce: true });
 		},
 		conversationMuted: () => options.voice.inputMuted,
 		onConversationMute(muted) {
@@ -181,11 +205,13 @@ export async function startCodexLanVoiceServer(options: {
 		const clientsClosing = clients.close();
 		const failures: unknown[] = [];
 		await collectFailures([clientsClosing, dictation.close()], failures);
-		const remainingConversation = activeConversation;
-		if (remainingConversation) {
-			activeConversation = undefined;
-			await collectFailures([options.voice.stopConversation(remainingConversation.conversation, { announce: true })], failures);
-		}
+		const remainingPlan = realtimePlan;
+		realtimePlan = undefined;
+		activeConversation = undefined;
+		if (remainingPlan)
+			await collectFailures([
+				options.voice.stopRealtimeWithPeerPlan(remainingPlan, { announce: true }),
+			], failures);
 		await collectFailures([
 			new Promise<void>((resolve) => webSockets.close(() => resolve())),
 			new Promise<void>((resolve) => { server.close(() => resolve()); server.closeAllConnections(); }),

--- a/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
 import type { CodexVoiceAuth } from "../src/voice/auth.ts";
+import { currentVoiceSession } from "../src/voice/controller-support.ts";
 import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
 import type {
 	CodexRealtimePeerEvent,
@@ -35,9 +36,25 @@ test("only an established realtime transport failure is a resumable drop", async
 		"instructions",
 	);
 	active.session.markEstablished();
+	active.peer.holdClose();
 	active.peer.emit({ type: "state", state: "closed" });
 	assert.deepEqual(active.failures, []);
 	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
+	assert.equal(
+		currentVoiceSession({ type: "reconnecting", session: active.session }),
+		active.session,
+	);
+	const firstClose = active.session.close();
+	const repeatedClose = active.session.close();
+	let closeSettled = false;
+	void repeatedClose.then(() => {
+		closeSettled = true;
+	});
+	await Promise.resolve();
+	assert.equal(closeSettled, false);
+	assert.equal(active.peer.closeCalls, 1);
+	active.peer.releaseClose();
+	await Promise.all([firstClose, repeatedClose]);
 });
 
 function createConversation(answerState: "ready" | "closed"): {
@@ -67,9 +84,11 @@ function createConversation(answerState: "ready" | "closed"): {
 
 class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
+	closeCalls = 0;
 	private readonly answerState: "ready" | "closed";
 	private readonly eventListeners = new Set<(event: CodexRealtimePeerEvent) => void>();
 	private readonly exitListeners = new Set<(error: Error) => void>();
+	private closeGate: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 
 	constructor(answerState: "ready" | "closed") {
 		this.answerState = answerState;
@@ -97,7 +116,18 @@ class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 		for (const listener of this.eventListeners) listener(event);
 	}
 
+	holdClose(): void {
+		this.closeGate = Promise.withResolvers<void>();
+	}
+
+	releaseClose(): void {
+		this.closeGate?.resolve();
+	}
+
 	sendData(): void {}
 	setInputMuted(): void {}
-	async close(): Promise<void> {}
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+		await this.closeGate?.promise;
+	}
 }

--- a/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import type { CodexVoiceAuth } from "../src/voice/auth.ts";
+import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
+import type {
+	CodexRealtimePeerEvent,
+	CodexRealtimeWebRtcPeer,
+} from "../src/voice/conversation/peer.ts";
+import {
+	type CodexConversationCallbacks,
+	CodexRealtimeConversation,
+} from "../src/voice/conversation/session.ts";
+
+const AUTH: CodexVoiceAuth = {
+	headers: new Headers(),
+	baseUrl: "https://example.test",
+	officialCodex: false,
+};
+
+test("only an established realtime transport failure is a resumable drop", async () => {
+	const startup = createConversation("closed");
+	await startup.session.start(
+		AUTH,
+		DEFAULT_CODEX_CONVERSION_CONFIG,
+		"instructions",
+	);
+	assert.deepEqual(startup.failures, ["Codex realtime connection closed"]);
+	assert.deepEqual(startup.drops, []);
+
+	const active = createConversation("ready");
+	await active.session.start(
+		AUTH,
+		DEFAULT_CODEX_CONVERSION_CONFIG,
+		"instructions",
+	);
+	active.session.markEstablished();
+	active.peer.emit({ type: "state", state: "closed" });
+	assert.deepEqual(active.failures, []);
+	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
+});
+
+function createConversation(answerState: "ready" | "closed"): {
+	session: CodexRealtimeConversation;
+	peer: FakeRealtimePeer;
+	failures: string[];
+	drops: string[];
+} {
+	const failures: string[] = [];
+	const drops: string[] = [];
+	const peer = new FakeRealtimePeer(answerState);
+	const callbacks: CodexConversationCallbacks = {
+		onError: (error) => failures.push(error.message),
+		onDrop: (error) => drops.push(error.message),
+		onStatus: () => {},
+		onTurn: () => {},
+		onUserTranscript: () => {},
+		onTranscriptTail: () => {},
+	};
+	const session = new CodexRealtimeConversation(callbacks, peer);
+	(session as unknown as { callSetup: RealtimeCallSetup }).callSetup = async () => ({
+		status: 201,
+		answer: "answer",
+	});
+	return { session, peer, failures, drops };
+}
+
+class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
+	readonly kind = "webrtc" as const;
+	private readonly answerState: "ready" | "closed";
+	private readonly eventListeners = new Set<(event: CodexRealtimePeerEvent) => void>();
+	private readonly exitListeners = new Set<(error: Error) => void>();
+
+	constructor(answerState: "ready" | "closed") {
+		this.answerState = answerState;
+	}
+
+	onEvent(listener: (event: CodexRealtimePeerEvent) => void): () => void {
+		this.eventListeners.add(listener);
+		return () => this.eventListeners.delete(listener);
+	}
+
+	onExit(listener: (error: Error) => void): () => void {
+		this.exitListeners.add(listener);
+		return () => this.exitListeners.delete(listener);
+	}
+
+	async start(): Promise<string> {
+		return "offer";
+	}
+
+	applyAnswer(): void {
+		this.emit({ type: "state", state: this.answerState });
+	}
+
+	emit(event: CodexRealtimePeerEvent): void {
+		for (const listener of this.eventListeners) listener(event);
+	}
+
+	sendData(): void {}
+	setInputMuted(): void {}
+	async close(): Promise<void> {}
+}

--- a/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-reconnect.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
 import type { CodexVoiceAuth } from "../src/voice/auth.ts";
-import { currentVoiceSession } from "../src/voice/controller-support.ts";
 import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
 import type {
 	CodexRealtimePeerEvent,
@@ -36,25 +35,16 @@ test("only an established realtime transport failure is a resumable drop", async
 		"instructions",
 	);
 	active.session.markEstablished();
-	active.peer.holdClose();
+	active.peer.emit({
+		type: "error",
+		message: "realtime speaker stream ended: connection reset",
+	});
 	active.peer.emit({ type: "state", state: "closed" });
 	assert.deepEqual(active.failures, []);
-	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
-	assert.equal(
-		currentVoiceSession({ type: "reconnecting", session: active.session }),
-		active.session,
-	);
-	const firstClose = active.session.close();
-	const repeatedClose = active.session.close();
-	let closeSettled = false;
-	void repeatedClose.then(() => {
-		closeSettled = true;
-	});
-	await Promise.resolve();
-	assert.equal(closeSettled, false);
-	assert.equal(active.peer.closeCalls, 1);
-	active.peer.releaseClose();
-	await Promise.all([firstClose, repeatedClose]);
+	assert.deepEqual(active.drops, [
+		"realtime speaker stream ended: connection reset",
+	]);
+	await active.session.close();
 });
 
 function createConversation(answerState: "ready" | "closed"): {
@@ -84,11 +74,9 @@ function createConversation(answerState: "ready" | "closed"): {
 
 class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
-	closeCalls = 0;
 	private readonly answerState: "ready" | "closed";
 	private readonly eventListeners = new Set<(event: CodexRealtimePeerEvent) => void>();
 	private readonly exitListeners = new Set<(error: Error) => void>();
-	private closeGate: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 
 	constructor(answerState: "ready" | "closed") {
 		this.answerState = answerState;
@@ -116,18 +104,7 @@ class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 		for (const listener of this.eventListeners) listener(event);
 	}
 
-	holdClose(): void {
-		this.closeGate = Promise.withResolvers<void>();
-	}
-
-	releaseClose(): void {
-		this.closeGate?.resolve();
-	}
-
 	sendData(): void {}
 	setInputMuted(): void {}
-	async close(): Promise<void> {
-		this.closeCalls += 1;
-		await this.closeGate?.promise;
-	}
+	async close(): Promise<void> {}
 }

--- a/packages/pi-gippity-control/package.json
+++ b/packages/pi-gippity-control/package.json
@@ -43,7 +43,7 @@
 	"dependencies": {
 		"proxy-from-env": "1.1.0",
 		"selfsigned": "^3.0.1",
-		"undici": "8.5.0",
+		"undici": "8.10.0",
 		"ws": "^8.21.0"
 	},
 	"peerDependencies": {

--- a/packages/pi-gippity-control/src/config.ts
+++ b/packages/pi-gippity-control/src/config.ts
@@ -34,6 +34,7 @@ export type RealtimeV3Voice = (typeof REALTIME_V3_VOICES)[number];
 export interface GippityControlConfig {
 	voice: {
 		v3Voice: RealtimeV3Voice;
+		autoResumeRealtime: boolean;
 		dictationShortcut: string;
 		realtimeShortcut: string;
 		muteShortcut: string;
@@ -49,6 +50,7 @@ export interface GippityControlConfig {
 export const DEFAULT_GIPPITY_CONTROL_CONFIG: GippityControlConfig = {
 	voice: {
 		v3Voice: "cove",
+		autoResumeRealtime: false,
 		dictationShortcut: "ctrl+alt+d",
 		realtimeShortcut: "ctrl+alt+space",
 		muteShortcut: "ctrl+alt+m",
@@ -113,6 +115,10 @@ export function normalizeGippityControlConfig(
 			v3Voice:
 				normalizeRealtimeV3Voice(voice["v3Voice"]) ??
 				DEFAULT_GIPPITY_CONTROL_CONFIG.voice.v3Voice,
+			autoResumeRealtime:
+				typeof voice["autoResumeRealtime"] === "boolean"
+					? voice["autoResumeRealtime"]
+					: DEFAULT_GIPPITY_CONTROL_CONFIG.voice.autoResumeRealtime,
 			dictationShortcut: stringValue(
 				voice["dictationShortcut"],
 				DEFAULT_GIPPITY_CONTROL_CONFIG.voice.dictationShortcut,

--- a/packages/pi-gippity-control/src/settings.ts
+++ b/packages/pi-gippity-control/src/settings.ts
@@ -69,6 +69,19 @@ export async function openGippitySettings(options: {
 				}),
 			},
 			{
+				id: "autoResumeRealtime",
+				label: "Auto-resume realtime voice",
+				currentValue: config.voice.autoResumeRealtime ? "on" : "off",
+				values: ["off", "on"],
+				update: (value, current) => ({
+					...current,
+					voice: {
+						...current.voice,
+						autoResumeRealtime: value === "on",
+					},
+				}),
+			},
+			{
 				id: "dictationMode",
 				label: "Dictation key behavior",
 				currentValue:

--- a/packages/pi-gippity-control/src/voice/AGENTS.md
+++ b/packages/pi-gippity-control/src/voice/AGENTS.md
@@ -9,6 +9,7 @@
 - Delegation `<input>` is authoritative. `<transcript_delta>` contains deduplicated finalized frontend history before that input; keep partial recognition and the current utterance out.
 - On finalized user `turn.done`, immediately show one display-only `You said` entry before routing any hidden canonical delegation. Never render partial recognition.
 - Buffer Pi worker text to its assistant-message boundary. Route tool-use messages to V3 commentary and terminal messages to speakable without changing visible Pi text. Never forward raw thinking deltas.
+- Opt-in auto-resume replaces only established host-to-OpenAI V3 calls after terminal transport drops. Preserve LAN browser ownership, rerun normal context startup, omit lifecycle end/start, and leave failed replacement startup terminal.
 - LAN realtime is host-owned: one helper WebRTC V3 call owns authenticated setup and delegation; browser disconnect/takeover preserves it, explicit Stop closes it so the next Start snapshots fresh Pi context.
 - Realtime mic mute keeps V3 warm. Gate browser tracks, discard captured samples, send silence RTP, and reset mute when input ownership ends.
 - Native `v3.rs` owns WebRTC signaling/session state; `v3_media.rs` owns audio tracks, playout, encoding, and silence RTP.

--- a/packages/pi-gippity-control/src/voice/controller-sessions.ts
+++ b/packages/pi-gippity-control/src/voice/controller-sessions.ts
@@ -33,6 +33,7 @@ export async function startControllerConversation(options: {
 	config: GippityControlConfig;
 	instructions: string;
 	initialItems?: RealtimeInitialMessageItem[] | undefined;
+	inputMuted?: boolean | undefined;
 	peer?: CodexRealtimePeer | undefined;
 	signal?: AbortSignal | undefined;
 	lifecycle: RealtimeSessionLifecycle;
@@ -84,6 +85,7 @@ export async function startControllerConversation(options: {
 			options.config,
 			options.instructions,
 			options.initialItems,
+			options.inputMuted,
 		);
 	} finally {
 		options.signal?.removeEventListener("abort", closeOnAbort);

--- a/packages/pi-gippity-control/src/voice/controller-sessions.ts
+++ b/packages/pi-gippity-control/src/voice/controller-sessions.ts
@@ -17,6 +17,7 @@ interface SessionLifecycle<T> {
 
 interface RealtimeSessionLifecycle
 	extends SessionLifecycle<CodexRealtimeConversation> {
+	onDrop(session: CodexRealtimeConversation, error: Error): void;
 	onTurn(turn: RealtimeVoiceTurn): void;
 	onUserTranscript(transcript: string): void;
 	onTranscriptTail(transcript: string): void;
@@ -60,6 +61,7 @@ export async function startControllerConversation(options: {
 	session = new CodexRealtimeConversation(
 		{
 			onError: (error) => options.lifecycle.onError(session, error),
+			onDrop: (error) => options.lifecycle.onDrop(session, error),
 			onStatus: options.lifecycle.onStatus,
 			onTurn: options.lifecycle.onTurn,
 			onUserTranscript: options.lifecycle.onUserTranscript,
@@ -86,8 +88,10 @@ export async function startControllerConversation(options: {
 	} finally {
 		options.signal?.removeEventListener("abort", closeOnAbort);
 	}
-	if (options.lifecycle.isCurrent(session)) options.lifecycle.onActive(session);
-	else await session.close();
+	if (options.lifecycle.isCurrent(session)) {
+		session.markEstablished();
+		options.lifecycle.onActive(session);
+	} else await session.close();
 }
 
 export async function startControllerDictation(options: {

--- a/packages/pi-gippity-control/src/voice/controller-start.ts
+++ b/packages/pi-gippity-control/src/voice/controller-start.ts
@@ -49,6 +49,7 @@ export async function startControllerMode(options: {
 	mode: CodexVoiceMode;
 	realtimePeerPlan?: RealtimePeerPlan | undefined;
 	resume?: boolean | undefined;
+	inputMuted?: boolean | undefined;
 	signal?: AbortSignal | undefined;
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined;
 	stopCurrent(): Promise<void>;
@@ -175,6 +176,7 @@ async function startConversation(
 		config: options.config,
 		instructions,
 		initialItems,
+		inputMuted: options.inputMuted,
 		peer,
 		signal,
 		lifecycle: {

--- a/packages/pi-gippity-control/src/voice/controller-start.ts
+++ b/packages/pi-gippity-control/src/voice/controller-start.ts
@@ -20,6 +20,16 @@ import type { CodexRealtimeConversation } from "./conversation/session.ts";
 import type { CodexVoiceSessionMessages } from "./session-messages.ts";
 import type { CodexVoiceMode } from "./ui.ts";
 
+export interface RealtimePeerPlan {
+	createPeer(): CodexRealtimePeer;
+	onActive?(session: CodexRealtimeConversation, peer: CodexRealtimePeer): void;
+	onInactive?(
+		session: CodexRealtimeConversation,
+		error: Error,
+		resuming: boolean,
+	): void;
+}
+
 export interface VoiceControllerRuntime {
 	state: VoiceState;
 	context?: ExtensionContext | undefined;
@@ -28,6 +38,7 @@ export interface VoiceControllerRuntime {
 	startGeneration: number;
 	startAbortController?: AbortController | undefined;
 	voiceStatus: string;
+	realtimePeerPlan?: RealtimePeerPlan | undefined;
 }
 
 export async function startControllerMode(options: {
@@ -36,31 +47,29 @@ export async function startControllerMode(options: {
 	ctx: ExtensionContext;
 	config: GippityControlConfig;
 	mode: CodexVoiceMode;
-	peer?: CodexRealtimePeer | undefined;
+	realtimePeerPlan?: RealtimePeerPlan | undefined;
+	resume?: boolean | undefined;
 	signal?: AbortSignal | undefined;
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined;
 	stopCurrent(): Promise<void>;
 	finishCurrentDictation(): Promise<void>;
-	onError(error: Error): void;
+	onError(error: Error, session?: CodexRealtimeConversation | undefined): void;
+	onDrop(session: CodexRealtimeConversation, error: Error): void;
 	onStatus(status: string): void;
 }): Promise<CodexRealtimeConversation | undefined> {
-	const { runtime, peer, signal } = options;
-	if (signal?.aborted) {
-		await peer?.close();
-		return;
-	}
+	const { runtime, signal } = options;
+	if (signal?.aborted) return;
 	const realtimePrompt =
 		options.mode === "realtime"
 			? options.prepareRealtimePrompt(options.ctx)
 			: undefined;
 	if (options.mode === "realtime" && realtimePrompt === undefined) return;
-	if (runtime.state.type === "dictation")
-		await options.finishCurrentDictation();
-	else await options.stopCurrent();
-	if (signal?.aborted) {
-		await peer?.close();
-		return;
-	}
+	if (!options.resume) {
+		if (runtime.state.type === "dictation")
+			await options.finishCurrentDictation();
+		else await options.stopCurrent();
+	} else if (runtime.state.type !== "reconnecting") return;
+	if (signal?.aborted) return;
 	const startAbortController = new AbortController();
 	runtime.startAbortController = startAbortController;
 	const startSignal = signal
@@ -69,6 +78,8 @@ export async function startControllerMode(options: {
 	const startGeneration = ++runtime.startGeneration;
 	runtime.context = options.ctx;
 	runtime.config = options.config;
+	runtime.realtimePeerPlan =
+		options.mode === "realtime" ? options.realtimePeerPlan : undefined;
 	options.messages.setContext(options.ctx);
 	runtime.state =
 		options.mode === "realtime"
@@ -94,7 +105,6 @@ export async function startControllerMode(options: {
 			startSignal,
 		);
 		if (startup === CANCELLED) {
-			await peer?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
@@ -102,10 +112,8 @@ export async function startControllerMode(options: {
 		if (
 			startGeneration !== runtime.startGeneration ||
 			runtime.state.type !== "connecting"
-		) {
-			await peer?.close();
+		)
 			return;
-		}
 		if (options.mode === "dictation") await startDictation(options, auth);
 		else
 			await startConversation(
@@ -116,19 +124,18 @@ export async function startControllerMode(options: {
 				startSignal,
 			);
 		if (startSignal.aborted) {
-			await peer?.close();
+			await currentVoiceSession(runtime.state)?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
 		const activeState = snapshotState(runtime);
 		if (options.mode === "realtime") {
-			if (activeState.type !== "conversation") {
-				await peer?.close();
-				return;
-			}
+			if (activeState.type !== "conversation") return;
 			if (realtimeSummary) options.messages.contextSummary(realtimeSummary);
-			runtime.announcedMode = options.mode;
-			options.messages.modeStarted(options.mode);
+			if (runtime.announcedMode !== options.mode) {
+				runtime.announcedMode = options.mode;
+				options.messages.modeStarted(options.mode);
+			}
 			return activeState.session;
 		}
 		if (activeState.type !== "dictation") return;
@@ -137,14 +144,11 @@ export async function startControllerMode(options: {
 		return undefined;
 	} catch (error) {
 		if (startSignal.aborted) {
-			await peer?.close();
+			await currentVoiceSession(runtime.state)?.close();
 			cancelStart(runtime, startGeneration);
 			return;
 		}
-		if (startGeneration !== runtime.startGeneration) {
-			await peer?.close();
-			return;
-		}
+		if (startGeneration !== runtime.startGeneration) return;
 		options.onError(error instanceof Error ? error : new Error(String(error)));
 		return undefined;
 	}
@@ -165,12 +169,13 @@ async function startConversation(
 		connecting.phase !== "authorizing"
 	)
 		return;
+	const peer = options.realtimePeerPlan?.createPeer();
 	await startControllerConversation({
 		auth,
 		config: options.config,
 		instructions,
 		initialItems,
-		peer: options.peer,
+		peer,
 		signal,
 		lifecycle: {
 			stillAuthorizing: () => runtime.state === connecting,
@@ -185,10 +190,15 @@ async function startConversation(
 			isCurrent: (session) => currentVoiceSession(runtime.state) === session,
 			onActive: (session) => {
 				runtime.state = { type: "conversation", session };
+				if (peer) options.realtimePeerPlan?.onActive?.(session, peer);
 			},
 			onError: (session, error) => {
 				if (currentVoiceSession(runtime.state) === session)
-					options.onError(error);
+					options.onError(error, session);
+			},
+			onDrop: (session, error) => {
+				if (currentVoiceSession(runtime.state) === session)
+					options.onDrop(session, error);
 			},
 			onStatus: options.onStatus,
 			onTurn: (turn) => options.messages.voiceTurn(turn),
@@ -247,6 +257,7 @@ function cancelStart(
 	if (startGeneration !== runtime.startGeneration) return;
 	runtime.state = { type: "idle" };
 	runtime.config = undefined;
+	runtime.realtimePeerPlan = undefined;
 	runtime.voiceStatus = "";
 	runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 }

--- a/packages/pi-gippity-control/src/voice/controller-support.ts
+++ b/packages/pi-gippity-control/src/voice/controller-support.ts
@@ -14,6 +14,7 @@ export const VOICE_STATUS_KEY = "gippity-voice";
 export type VoiceSession = CodexRealtimeConversation | CodexDictationSession;
 export type VoiceState =
 	| { type: "idle" }
+	| { type: "reconnecting" }
 	| { type: "connecting"; mode: "realtime"; phase: "authorizing" }
 	| {
 			type: "connecting";

--- a/packages/pi-gippity-control/src/voice/controller-support.ts
+++ b/packages/pi-gippity-control/src/voice/controller-support.ts
@@ -14,7 +14,7 @@ export const VOICE_STATUS_KEY = "gippity-voice";
 export type VoiceSession = CodexRealtimeConversation | CodexDictationSession;
 export type VoiceState =
 	| { type: "idle" }
-	| { type: "reconnecting" }
+	| { type: "reconnecting"; session: CodexRealtimeConversation }
 	| { type: "connecting"; mode: "realtime"; phase: "authorizing" }
 	| {
 			type: "connecting";
@@ -36,7 +36,11 @@ export type VoiceState =
 export function currentVoiceSession(
 	state: VoiceState,
 ): VoiceSession | undefined {
-	if (state.type === "conversation" || state.type === "dictation")
+	if (
+		state.type === "conversation" ||
+		state.type === "dictation" ||
+		state.type === "reconnecting"
+	)
 		return state.session;
 	return state.type === "connecting" && state.phase === "starting"
 		? state.session

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -6,6 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { GippityControlConfig } from "../config.ts";
 import {
+	type RealtimePeerPlan,
 	startControllerMode,
 	type VoiceControllerRuntime,
 } from "./controller-start.ts";
@@ -18,7 +19,6 @@ import {
 	voiceModeForState,
 } from "./controller-support.ts";
 import { realtimeHandoffChannel } from "./conversation/handoff.ts";
-import type { CodexRealtimePeer } from "./conversation/peer.ts";
 import type { CodexRealtimeConversation } from "./conversation/session.ts";
 import { CodexVoiceSessionMessages } from "./session-messages.ts";
 import { formatVoiceAudioError } from "./setup.ts";
@@ -100,13 +100,13 @@ export class CodexVoiceController {
 		await this.startMode(ctx, config, mode);
 	}
 
-	async startRealtimeWithPeer(
+	async startRealtimeWithPeerPlan(
 		ctx: ExtensionContext,
 		config: GippityControlConfig,
-		peer: CodexRealtimePeer,
+		plan: RealtimePeerPlan,
 		signal?: AbortSignal,
 	): Promise<CodexRealtimeConversation | undefined> {
-		return this.startMode(ctx, config, "realtime", peer, signal);
+		return this.startMode(ctx, config, "realtime", plan, signal);
 	}
 	prepareRealtimePrompt(ctx: ExtensionContext): string | undefined {
 		return prepareRealtimeVoicePrompt(ctx);
@@ -117,6 +117,13 @@ export class CodexVoiceController {
 		options?: { announce?: boolean },
 	): Promise<void> {
 		if (this.currentSession() === session) await this.stop(options);
+	}
+
+	async stopRealtimeWithPeerPlan(
+		plan: RealtimePeerPlan,
+		options?: { announce?: boolean },
+	): Promise<void> {
+		if (this.runtime.realtimePeerPlan === plan) await this.stop(options);
 	}
 
 	setConversationInputActive(
@@ -140,8 +147,9 @@ export class CodexVoiceController {
 		ctx: ExtensionContext,
 		config: GippityControlConfig,
 		mode: CodexVoiceMode,
-		peer?: CodexRealtimePeer,
+		realtimePeerPlan?: RealtimePeerPlan,
 		signal?: AbortSignal,
+		resume = false,
 	): Promise<CodexRealtimeConversation | undefined> {
 		return startControllerMode({
 			runtime: this.runtime,
@@ -149,12 +157,14 @@ export class CodexVoiceController {
 			ctx,
 			config,
 			mode,
-			peer,
+			realtimePeerPlan,
 			signal,
+			resume,
 			prepareRealtimePrompt: (current) => this.prepareRealtimePrompt(current),
 			stopCurrent: () => this.stop({ announce: true }),
 			finishCurrentDictation: () => this.finishDictation({ announce: true }),
-			onError: (error) => this.fail(error),
+			onError: (error, session) => this.fail(error, session),
+			onDrop: (session, error) => this.drop(session, error),
 			onStatus: (status) => this.renderStatus(status),
 		});
 	}
@@ -172,6 +182,7 @@ export class CodexVoiceController {
 		this.runtime.state = { type: "idle" };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		await closePromise;
@@ -202,6 +213,7 @@ export class CodexVoiceController {
 		this.runtime.state = { type: "idle" };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.messages.voiceStopped(endedMode);
@@ -244,7 +256,10 @@ export class CodexVoiceController {
 		return currentVoiceSession(this.runtime.state);
 	}
 
-	private fail(error: Error): void {
+	private fail(
+		error: Error,
+		failedSession?: CodexRealtimeConversation | undefined,
+	): void {
 		if (
 			this.runtime.state.type === "idle" ||
 			this.runtime.state.type === "failed"
@@ -260,10 +275,13 @@ export class CodexVoiceController {
 		const endedMode = this.runtime.announcedMode;
 		const wasMuted = this.inputMuted;
 		const session = this.currentSession();
+		if (failedSession)
+			this.markRealtimePeerInactive(failedSession, error, false);
 		const closePromise = session?.close();
 		this.runtime.state = { type: "failed", message };
 		this.runtime.announcedMode = undefined;
 		this.runtime.config = undefined;
+		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.runtime.context?.ui.notify(message, "error");
@@ -271,6 +289,70 @@ export class CodexVoiceController {
 		if (wasMuted)
 			for (const listener of this.inputMuteListeners) listener(false);
 		void closePromise;
+	}
+
+	private drop(session: CodexRealtimeConversation, error: Error): void {
+		if (this.currentSession() !== session) return;
+		const config = this.runtime.config;
+		const ctx = this.runtime.context;
+		if (!config?.voice.autoResumeRealtime || !ctx) {
+			this.markRealtimePeerInactive(session, error, false);
+			this.fail(error);
+			return;
+		}
+		const realtimePeerPlan = this.runtime.realtimePeerPlan;
+		this.markRealtimePeerInactive(session, error, true);
+		this.runtime.startAbortController?.abort();
+		this.runtime.startAbortController = undefined;
+		const resumeGeneration = ++this.runtime.startGeneration;
+		const wasMuted = this.inputMuted;
+		this.runtime.state = { type: "reconnecting" };
+		this.renderStatus("reconnecting…");
+		void (async () => {
+			await Promise.allSettled([session.close()]);
+			if (
+				this.runtime.startGeneration !== resumeGeneration ||
+				this.runtime.state.type !== "reconnecting"
+			)
+				return;
+			const resumed = await this.startMode(
+				ctx,
+				config,
+				"realtime",
+				realtimePeerPlan,
+				undefined,
+				true,
+			);
+			if (!resumed) {
+				const resumeError = new Error("Codex realtime voice could not resume");
+				this.markRealtimePeerInactive(
+					session,
+					resumeError,
+					false,
+					realtimePeerPlan,
+				);
+				if (this.runtime.state.type === "reconnecting") this.fail(resumeError);
+				return;
+			}
+			if (wasMuted && this.currentSession() === resumed)
+				this.setInputMuted(true);
+		})();
+	}
+
+	private markRealtimePeerInactive(
+		session: CodexRealtimeConversation,
+		error: Error,
+		resuming: boolean,
+		plan = this.runtime.realtimePeerPlan,
+	): void {
+		try {
+			plan?.onInactive?.(session, error, resuming);
+		} catch (ownerError) {
+			this.runtime.context?.ui.notify(
+				`Could not update realtime voice owner: ${ownerError instanceof Error ? ownerError.message : String(ownerError)}`,
+				"error",
+			);
+		}
 	}
 
 	private renderStatus(status: string): void {

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -150,6 +150,7 @@ export class CodexVoiceController {
 		realtimePeerPlan?: RealtimePeerPlan,
 		signal?: AbortSignal,
 		resume = false,
+		inputMuted = false,
 	): Promise<CodexRealtimeConversation | undefined> {
 		return startControllerMode({
 			runtime: this.runtime,
@@ -160,6 +161,7 @@ export class CodexVoiceController {
 			realtimePeerPlan,
 			signal,
 			resume,
+			inputMuted,
 			prepareRealtimePrompt: (current) => this.prepareRealtimePrompt(current),
 			stopCurrent: () => this.stop({ announce: true }),
 			finishCurrentDictation: () => this.finishDictation({ announce: true }),
@@ -322,6 +324,7 @@ export class CodexVoiceController {
 				realtimePeerPlan,
 				undefined,
 				true,
+				wasMuted,
 			);
 			const replacementGeneration = this.runtime.startGeneration;
 			let resumed: CodexRealtimeConversation | undefined;
@@ -348,7 +351,7 @@ export class CodexVoiceController {
 				return;
 			}
 			if (wasMuted && this.currentSession() === resumed)
-				this.setInputMuted(true);
+				this.renderCurrentStatus();
 		})();
 	}
 

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -306,7 +306,7 @@ export class CodexVoiceController {
 		this.runtime.startAbortController = undefined;
 		const resumeGeneration = ++this.runtime.startGeneration;
 		const wasMuted = this.inputMuted;
-		this.runtime.state = { type: "reconnecting" };
+		this.runtime.state = { type: "reconnecting", session };
 		this.renderStatus("reconnecting…");
 		void (async () => {
 			await Promise.allSettled([session.close()]);

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -288,7 +288,7 @@ export class CodexVoiceController {
 		this.messages.voiceStopped(endedMode);
 		if (wasMuted)
 			for (const listener of this.inputMuteListeners) listener(false);
-		void closePromise;
+		void Promise.allSettled([closePromise]);
 	}
 
 	private drop(session: CodexRealtimeConversation, error: Error): void {
@@ -315,7 +315,7 @@ export class CodexVoiceController {
 				this.runtime.state.type !== "reconnecting"
 			)
 				return;
-			const resumed = await this.startMode(
+			const resumePromise = this.startMode(
 				ctx,
 				config,
 				"realtime",
@@ -323,6 +323,19 @@ export class CodexVoiceController {
 				undefined,
 				true,
 			);
+			const replacementGeneration = this.runtime.startGeneration;
+			let resumed: CodexRealtimeConversation | undefined;
+			try {
+				resumed = await resumePromise;
+			} catch (resumeError) {
+				if (this.runtime.startGeneration === replacementGeneration)
+					this.fail(
+						resumeError instanceof Error
+							? resumeError
+							: new Error(String(resumeError)),
+					);
+				return;
+			}
 			if (!resumed) {
 				const resumeError = new Error("Codex realtime voice could not resume");
 				this.markRealtimePeerInactive(

--- a/packages/pi-gippity-control/src/voice/conversation/session.ts
+++ b/packages/pi-gippity-control/src/voice/conversation/session.ts
@@ -29,6 +29,7 @@ type ConversationState = "idle" | "starting" | "active" | "failed" | "closed";
 
 export interface CodexConversationCallbacks {
 	onError(error: Error): void;
+	onDrop(error: Error): void;
 	onStatus(status: string): void;
 	onTurn(turn: RealtimeVoiceTurn): void;
 	onUserTranscript(transcript: string): void;
@@ -45,6 +46,7 @@ export class CodexRealtimeConversation {
 	private peerReady: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 	private callSetup: RealtimeCallSetup = setupRealtimeCall;
 	private inputMuted = false;
+	private established = false;
 
 	constructor(callbacks: CodexConversationCallbacks, peer: CodexRealtimePeer) {
 		this.callbacks = callbacks;
@@ -56,7 +58,11 @@ export class CodexRealtimeConversation {
 			onStatus: (status) => this.callbacks.onStatus(status),
 		});
 		this.peer.onEvent((event) => this.handlePeerEvent(event));
-		this.peer.onExit((error) => this.fail(error));
+		this.peer.onExit((error) => this.drop(error));
+	}
+
+	markEstablished(): void {
+		if (this.state === "active") this.established = true;
 	}
 
 	async start(
@@ -151,6 +157,7 @@ export class CodexRealtimeConversation {
 	async close(): Promise<void> {
 		if (this.state === "closed") return;
 		this.state = "closed";
+		this.established = false;
 		this.abortSetup();
 		this.handoff.clear();
 		this.drainConversation();
@@ -178,7 +185,7 @@ export class CodexRealtimeConversation {
 	private handleHelperState(state: string): void {
 		const failure = realtimePeerStateFailure(state);
 		if (failure) {
-			this.fail(new Error(failure));
+			this.drop(new Error(failure));
 			return;
 		}
 		if (state === "ready" || state === "listening") {
@@ -290,6 +297,14 @@ export class CodexRealtimeConversation {
 	}
 
 	private fail(error: Error): void {
+		this.finishFailure(error, false);
+	}
+
+	private drop(error: Error): void {
+		this.finishFailure(error, this.established);
+	}
+
+	private finishFailure(error: Error, dropped: boolean): void {
 		if (
 			this.state === "idle" ||
 			this.state === "closed" ||
@@ -297,12 +312,14 @@ export class CodexRealtimeConversation {
 		)
 			return;
 		this.state = "failed";
+		this.established = false;
 		this.abortSetup();
 		this.handoff.clear();
 		this.drainConversation();
 		this.peerReady?.resolve();
 		this.peerReady = undefined;
-		this.callbacks.onError(error);
+		if (dropped) this.callbacks.onDrop(error);
+		else this.callbacks.onError(error);
 		void this.peer.close();
 	}
 }

--- a/packages/pi-gippity-control/src/voice/conversation/session.ts
+++ b/packages/pi-gippity-control/src/voice/conversation/session.ts
@@ -71,6 +71,7 @@ export class CodexRealtimeConversation {
 		config: GippityControlConfig,
 		instructions: string,
 		initialItems?: RealtimeInitialMessageItem[],
+		inputMuted = false,
 	): Promise<void> {
 		this.state = "starting";
 		const sdp = await this.peer.start(config);
@@ -104,6 +105,7 @@ export class CodexRealtimeConversation {
 				`Codex voice call failed (${status}): ${answer.slice(0, 1_000)}`,
 			);
 		this.state = "active";
+		if (inputMuted) this.setInputMuted(true);
 		const peerReady = Promise.withResolvers<void>();
 		this.peerReady = peerReady;
 		this.callbacks.onStatus("connecting…");
@@ -180,7 +182,9 @@ export class CodexRealtimeConversation {
 		)
 			return;
 		if (event.type === "error") {
-			this.fail(new Error(event.message));
+			const error = new Error(event.message);
+			if (terminalTransportError(event.message)) this.drop(error);
+			else this.fail(error);
 			return;
 		}
 		if (event.type === "data") this.handleServerEvent(event.message);
@@ -327,4 +331,11 @@ export class CodexRealtimeConversation {
 		else this.callbacks.onError(error);
 		void this.close();
 	}
+}
+
+function terminalTransportError(message: string): boolean {
+	return (
+		message.startsWith("realtime speaker stream ended:") ||
+		message.startsWith("realtime microphone stream failed:")
+	);
 }

--- a/packages/pi-gippity-control/src/voice/conversation/session.ts
+++ b/packages/pi-gippity-control/src/voice/conversation/session.ts
@@ -44,6 +44,7 @@ export class CodexRealtimeConversation {
 	private state: ConversationState = "idle";
 	private setupAbortController: AbortController | undefined;
 	private peerReady: ReturnType<typeof Promise.withResolvers<void>> | undefined;
+	private closePromise: Promise<void> | undefined;
 	private callSetup: RealtimeCallSetup = setupRealtimeCall;
 	private inputMuted = false;
 	private established = false;
@@ -155,7 +156,11 @@ export class CodexRealtimeConversation {
 	}
 
 	async close(): Promise<void> {
-		if (this.state === "closed") return;
+		this.closePromise ??= this.closeSession();
+		return this.closePromise;
+	}
+
+	private async closeSession(): Promise<void> {
 		this.state = "closed";
 		this.established = false;
 		this.abortSetup();
@@ -320,6 +325,6 @@ export class CodexRealtimeConversation {
 		this.peerReady = undefined;
 		if (dropped) this.callbacks.onDrop(error);
 		else this.callbacks.onError(error);
-		void this.peer.close();
+		void this.close();
 	}
 }

--- a/packages/pi-gippity-control/src/voice/lan/browser-peer.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-peer.ts
@@ -11,16 +11,9 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
 	private readonly helper = new VoiceHelperClient();
 	private readonly onAudio: (pcm: Buffer) => void;
-	private readonly onFailure: (error: Error) => void;
-	private failed = false;
-	private closing = false;
 
-	constructor(options: {
-		onAudio(pcm: Buffer): void;
-		onFailure(error: Error): void;
-	}) {
+	constructor(options: { onAudio(pcm: Buffer): void }) {
 		this.onAudio = options.onAudio;
-		this.onFailure = options.onFailure;
 	}
 
 	onEvent(listener: (event: CodexRealtimePeerEvent) => void): () => void {
@@ -31,19 +24,11 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 			}
 			const peerEvent = toPeerEvent(event);
 			if (peerEvent) listener(peerEvent);
-			if (event.type === "error") this.fail(new Error(event.message));
 		});
 	}
 
 	onExit(listener: (error: Error) => void): () => void {
-		const remove = this.helper.onExit(listener);
-		const removeFailure = this.helper.onExit((error) => {
-			if (!this.closing) this.fail(error);
-		});
-		return () => {
-			remove();
-			removeFailure();
-		};
+		return this.helper.onExit(listener);
 	}
 
 	async start(_config: GippityControlConfig): Promise<string> {
@@ -96,14 +81,7 @@ export class LanHostRealtimePeer implements CodexRealtimeWebRtcPeer {
 	}
 
 	close(): Promise<void> {
-		this.closing = true;
 		return this.helper.close();
-	}
-
-	private fail(error: Error): void {
-		if (this.failed) return;
-		this.failed = true;
-		this.onFailure(error);
 	}
 }
 

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer } from "ws";
 import type { GippityControlConfig } from "../../config.ts";
 import type { CodexVoiceAuth } from "../auth.ts";
 import type { CodexVoiceController } from "../controller.ts";
+import type { RealtimePeerPlan } from "../controller-start.ts";
 import type { CodexRealtimeConversation } from "../conversation/session.ts";
 import { LanVoiceActivity } from "./activity.ts";
 import { createLanVoiceWebManifest } from "./app-assets.ts";
@@ -54,11 +55,11 @@ export async function startCodexLanVoiceServer(options: {
 		| undefined;
 	let conversationStart:
 		| {
-				peer: LanHostRealtimePeer;
 				abort: AbortController;
 				promise: Promise<void>;
 		  }
 		| undefined;
+	let realtimePlan: RealtimePeerPlan | undefined;
 	let closing = false;
 	let clients!: LanVoiceBrowserClients;
 	const activity = new LanVoiceActivity({
@@ -75,44 +76,54 @@ export async function startCodexLanVoiceServer(options: {
 			clients.sendControl(clientId, { type: "error", message: error.message }),
 	});
 
-	const conversationFailed = (
-		peer: LanHostRealtimePeer,
-		error: Error,
-	): void => {
-		if (activeConversation?.peer !== peer) return;
-		activeConversation = undefined;
-		clients.broadcastControl({ type: "error", message: error.message });
-	};
 	const ensureConversation = async (): Promise<void> => {
 		if (activeConversation) return;
 		if (conversationStart) return conversationStart.promise;
-		const peer = new LanHostRealtimePeer({
-			onAudio: (pcm) => clients.sendConversationAudio(pcm),
-			onFailure: (error) => conversationFailed(peer, error),
-		});
+		if (realtimePlan) return;
 		const abort = new AbortController();
+		let activated = false;
+		const plan: RealtimePeerPlan = {
+			createPeer: () => {
+				let peer!: LanHostRealtimePeer;
+				peer = new LanHostRealtimePeer({
+					onAudio: (pcm) => {
+						if (activeConversation?.peer === peer)
+							clients.sendConversationAudio(pcm);
+					},
+				});
+				return peer;
+			},
+			onActive: (conversation, peer) => {
+				activated = true;
+				activeConversation = {
+					peer: peer as LanHostRealtimePeer,
+					conversation,
+				};
+			},
+			onInactive: (conversation, error, resuming) => {
+				const ownedActive = activeConversation?.conversation === conversation;
+				if (!ownedActive && realtimePlan !== plan) return;
+				if (ownedActive) activeConversation = undefined;
+				if (resuming) return;
+				if (realtimePlan === plan) realtimePlan = undefined;
+				if (activated)
+					clients.broadcastControl({ type: "error", message: error.message });
+			},
+		};
+		realtimePlan = plan;
 		const promise = (async () => {
-			let started: CodexRealtimeConversation | undefined;
-			try {
-				started = await options.voice.startRealtimeWithPeer(
-					options.ctx,
-					options.getConfig(),
-					peer,
-					abort.signal,
-				);
-			} catch (error) {
-				await peer.close();
-				throw error;
-			}
-			if (!started) {
-				await peer.close();
-				throw new Error("Codex voice could not start");
-			}
-			activeConversation = { peer, conversation: started };
+			const started = await options.voice.startRealtimeWithPeerPlan(
+				options.ctx,
+				options.getConfig(),
+				plan,
+				abort.signal,
+			);
+			if (!started) throw new Error("Codex voice could not start");
 		})().finally(() => {
-			if (conversationStart?.peer === peer) conversationStart = undefined;
+			if (conversationStart?.abort === abort) conversationStart = undefined;
+			if (!activated && realtimePlan === plan) realtimePlan = undefined;
 		});
-		conversationStart = { peer, abort, promise };
+		conversationStart = { abort, promise };
 		return promise;
 	};
 	clients = new LanVoiceBrowserClients({
@@ -137,15 +148,16 @@ export async function startCodexLanVoiceServer(options: {
 		cancelDictation: (clientId) => dictation.cancel(clientId),
 		async onConversationActivity(active) {
 			const current = activeConversation;
-			if (!current) return;
 			if (active) {
-				options.voice.setConversationInputActive(current.conversation, true);
+				if (current)
+					options.voice.setConversationInputActive(current.conversation, true);
 				return;
 			}
+			const plan = realtimePlan;
+			realtimePlan = undefined;
 			activeConversation = undefined;
-			await options.voice.stopConversation(current.conversation, {
-				announce: true,
-			});
+			if (plan)
+				await options.voice.stopRealtimeWithPeerPlan(plan, { announce: true });
 		},
 		conversationMuted: () => options.voice.inputMuted,
 		onConversationMute(muted) {
@@ -231,12 +243,13 @@ export async function startCodexLanVoiceServer(options: {
 		const clientsClosing = clients.close();
 		const failures: unknown[] = [];
 		await collectFailures([clientsClosing, dictation.close()], failures);
-		const remainingConversation = activeConversation;
-		if (remainingConversation) {
-			activeConversation = undefined;
+		const remainingPlan = realtimePlan;
+		realtimePlan = undefined;
+		activeConversation = undefined;
+		if (remainingPlan) {
 			await collectFailures(
 				[
-					options.voice.stopConversation(remainingConversation.conversation, {
+					options.voice.stopRealtimeWithPeerPlan(remainingPlan, {
 						announce: true,
 					}),
 				],

--- a/packages/pi-gippity-control/tests/voice-reconnect.test.ts
+++ b/packages/pi-gippity-control/tests/voice-reconnect.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_GIPPITY_CONTROL_CONFIG } from "../src/config.ts";
 import type { CodexVoiceAuth } from "../src/voice/auth.ts";
+import { currentVoiceSession } from "../src/voice/controller-support.ts";
 import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
 import type {
 	CodexRealtimePeerEvent,
@@ -35,9 +36,25 @@ test("only an established realtime transport failure is a resumable drop", async
 		"instructions",
 	);
 	active.session.markEstablished();
+	active.peer.holdClose();
 	active.peer.emit({ type: "state", state: "closed" });
 	assert.deepEqual(active.failures, []);
 	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
+	assert.equal(
+		currentVoiceSession({ type: "reconnecting", session: active.session }),
+		active.session,
+	);
+	const firstClose = active.session.close();
+	const repeatedClose = active.session.close();
+	let closeSettled = false;
+	void repeatedClose.then(() => {
+		closeSettled = true;
+	});
+	await Promise.resolve();
+	assert.equal(closeSettled, false);
+	assert.equal(active.peer.closeCalls, 1);
+	active.peer.releaseClose();
+	await Promise.all([firstClose, repeatedClose]);
 });
 
 function createConversation(answerState: "ready" | "closed"): {
@@ -68,11 +85,13 @@ function createConversation(answerState: "ready" | "closed"): {
 
 class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
+	closeCalls = 0;
 	private readonly answerState: "ready" | "closed";
 	private readonly eventListeners = new Set<
 		(event: CodexRealtimePeerEvent) => void
 	>();
 	private readonly exitListeners = new Set<(error: Error) => void>();
+	private closeGate: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 
 	constructor(answerState: "ready" | "closed") {
 		this.answerState = answerState;
@@ -100,7 +119,18 @@ class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 		for (const listener of this.eventListeners) listener(event);
 	}
 
+	holdClose(): void {
+		this.closeGate = Promise.withResolvers<void>();
+	}
+
+	releaseClose(): void {
+		this.closeGate?.resolve();
+	}
+
 	sendData(): void {}
 	setInputMuted(): void {}
-	async close(): Promise<void> {}
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+		await this.closeGate?.promise;
+	}
 }

--- a/packages/pi-gippity-control/tests/voice-reconnect.test.ts
+++ b/packages/pi-gippity-control/tests/voice-reconnect.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_GIPPITY_CONTROL_CONFIG } from "../src/config.ts";
 import type { CodexVoiceAuth } from "../src/voice/auth.ts";
-import { currentVoiceSession } from "../src/voice/controller-support.ts";
 import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
 import type {
 	CodexRealtimePeerEvent,
@@ -36,25 +35,16 @@ test("only an established realtime transport failure is a resumable drop", async
 		"instructions",
 	);
 	active.session.markEstablished();
-	active.peer.holdClose();
+	active.peer.emit({
+		type: "error",
+		message: "realtime speaker stream ended: connection reset",
+	});
 	active.peer.emit({ type: "state", state: "closed" });
 	assert.deepEqual(active.failures, []);
-	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
-	assert.equal(
-		currentVoiceSession({ type: "reconnecting", session: active.session }),
-		active.session,
-	);
-	const firstClose = active.session.close();
-	const repeatedClose = active.session.close();
-	let closeSettled = false;
-	void repeatedClose.then(() => {
-		closeSettled = true;
-	});
-	await Promise.resolve();
-	assert.equal(closeSettled, false);
-	assert.equal(active.peer.closeCalls, 1);
-	active.peer.releaseClose();
-	await Promise.all([firstClose, repeatedClose]);
+	assert.deepEqual(active.drops, [
+		"realtime speaker stream ended: connection reset",
+	]);
+	await active.session.close();
 });
 
 function createConversation(answerState: "ready" | "closed"): {
@@ -85,13 +75,11 @@ function createConversation(answerState: "ready" | "closed"): {
 
 class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 	readonly kind = "webrtc" as const;
-	closeCalls = 0;
 	private readonly answerState: "ready" | "closed";
 	private readonly eventListeners = new Set<
 		(event: CodexRealtimePeerEvent) => void
 	>();
 	private readonly exitListeners = new Set<(error: Error) => void>();
-	private closeGate: ReturnType<typeof Promise.withResolvers<void>> | undefined;
 
 	constructor(answerState: "ready" | "closed") {
 		this.answerState = answerState;
@@ -119,18 +107,7 @@ class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
 		for (const listener of this.eventListeners) listener(event);
 	}
 
-	holdClose(): void {
-		this.closeGate = Promise.withResolvers<void>();
-	}
-
-	releaseClose(): void {
-		this.closeGate?.resolve();
-	}
-
 	sendData(): void {}
 	setInputMuted(): void {}
-	async close(): Promise<void> {
-		this.closeCalls += 1;
-		await this.closeGate?.promise;
-	}
+	async close(): Promise<void> {}
 }

--- a/packages/pi-gippity-control/tests/voice-reconnect.test.ts
+++ b/packages/pi-gippity-control/tests/voice-reconnect.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_GIPPITY_CONTROL_CONFIG } from "../src/config.ts";
+import type { CodexVoiceAuth } from "../src/voice/auth.ts";
+import type { RealtimeCallSetup } from "../src/voice/conversation/call-setup.ts";
+import type {
+	CodexRealtimePeerEvent,
+	CodexRealtimeWebRtcPeer,
+} from "../src/voice/conversation/peer.ts";
+import {
+	type CodexConversationCallbacks,
+	CodexRealtimeConversation,
+} from "../src/voice/conversation/session.ts";
+
+const AUTH: CodexVoiceAuth = {
+	headers: new Headers(),
+	baseUrl: "https://example.test",
+	officialCodex: false,
+};
+
+test("only an established realtime transport failure is a resumable drop", async () => {
+	const startup = createConversation("closed");
+	await startup.session.start(
+		AUTH,
+		DEFAULT_GIPPITY_CONTROL_CONFIG,
+		"instructions",
+	);
+	assert.deepEqual(startup.failures, ["Codex realtime connection closed"]);
+	assert.deepEqual(startup.drops, []);
+
+	const active = createConversation("ready");
+	await active.session.start(
+		AUTH,
+		DEFAULT_GIPPITY_CONTROL_CONFIG,
+		"instructions",
+	);
+	active.session.markEstablished();
+	active.peer.emit({ type: "state", state: "closed" });
+	assert.deepEqual(active.failures, []);
+	assert.deepEqual(active.drops, ["Codex realtime connection closed"]);
+});
+
+function createConversation(answerState: "ready" | "closed"): {
+	session: CodexRealtimeConversation;
+	peer: FakeRealtimePeer;
+	failures: string[];
+	drops: string[];
+} {
+	const failures: string[] = [];
+	const drops: string[] = [];
+	const peer = new FakeRealtimePeer(answerState);
+	const callbacks: CodexConversationCallbacks = {
+		onError: (error) => failures.push(error.message),
+		onDrop: (error) => drops.push(error.message),
+		onStatus: () => {},
+		onTurn: () => {},
+		onUserTranscript: () => {},
+		onTranscriptTail: () => {},
+	};
+	const session = new CodexRealtimeConversation(callbacks, peer);
+	(session as unknown as { callSetup: RealtimeCallSetup }).callSetup =
+		async () => ({
+			status: 201,
+			answer: "answer",
+		});
+	return { session, peer, failures, drops };
+}
+
+class FakeRealtimePeer implements CodexRealtimeWebRtcPeer {
+	readonly kind = "webrtc" as const;
+	private readonly answerState: "ready" | "closed";
+	private readonly eventListeners = new Set<
+		(event: CodexRealtimePeerEvent) => void
+	>();
+	private readonly exitListeners = new Set<(error: Error) => void>();
+
+	constructor(answerState: "ready" | "closed") {
+		this.answerState = answerState;
+	}
+
+	onEvent(listener: (event: CodexRealtimePeerEvent) => void): () => void {
+		this.eventListeners.add(listener);
+		return () => this.eventListeners.delete(listener);
+	}
+
+	onExit(listener: (error: Error) => void): () => void {
+		this.exitListeners.add(listener);
+		return () => this.exitListeners.delete(listener);
+	}
+
+	async start(): Promise<string> {
+		return "offer";
+	}
+
+	applyAnswer(): void {
+		this.emit({ type: "state", state: this.answerState });
+	}
+
+	emit(event: CodexRealtimePeerEvent): void {
+		for (const listener of this.eventListeners) listener(event);
+	}
+
+	sendData(): void {}
+	setInputMuted(): void {}
+	async close(): Promise<void> {}
+}


### PR DESCRIPTION
This PR lets Pi Codex Conversion and GipPity Control recover dropped OpenAI realtime voice calls without interrupting an ongoing voice workflow. It also updates their transport dependency and tightens the repository’s local PR and test-review guidance.

## Summary

- add a default-off toggle that automatically recreates established realtime voice sessions after the host connection to OpenAI drops
- support native and LAN voice in Pi Codex Conversion and GipPity Control while preserving mute, lifecycle, browser ownership, and the configured context-summary startup pipeline
- route terminal helper media failures through resume while leaving unrelated helper errors terminal
- update the direct Undici pin from 8.5.0 to 8.10.0
- make the local GitHub PR skill lead with a concise goal sentence and make test-scope review deletion-first

## Validation

- `bun run check:changed`
- `bun run changeset:check`
- `git diff --check`

## Release

- Changeset: yes, patch for both direct packages
- Packages: `@howaboua/pi-codex-conversion`, `@howaboua/pi-gippity-control`
- Aggregates: generated by release automation

Closes #250
