### PR TITLE
Show weekly Codex usage in the statusline

### DIFF
--- a/.changeset/weekly-codex-status.md
+++ b/.changeset/weekly-codex-status.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Show remaining weekly Codex subscription usage in the adapter statusline.

--- a/packages/pi-codex-conversion/src/adapter/activation/activation.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/activation.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { AdapterState } from "./state.ts";
 import { ALL_CODEX_ADAPTER_TOOL_NAMES, isAdapterRuntime, resolveCodexRuntimePlan, type CodexRuntimePlan } from "./runtime-plan.ts";
-import { DEFAULT_TOOL_NAMES, STATUS_KEY, buildExtraToolsOnlyStatusText, buildStatusText } from "./tool-set.ts";
-import { isResponsesContext } from "../prompt/codex-model.ts";
+import { DEFAULT_TOOL_NAMES, STATUS_KEY, buildExtraToolsOnlyStatusText } from "./tool-set.ts";
+import { renderCodexStatus } from "../../ui/status.ts";
 
 export function syncAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState): CodexRuntimePlan {
 	const plan = resolveCodexRuntimePlan(ctx, state.config);
@@ -33,7 +33,7 @@ function enableAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterSt
 	}
 	state.adapterOwnedToolNames = plan.ownedToolNames;
 	pi.setActiveTools(tools);
-	setStatus(ctx, state, plan);
+	renderCodexStatus(ctx, state, plan);
 }
 
 function disableAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterState, plan: CodexRuntimePlan): void {
@@ -45,25 +45,6 @@ function disableAdapter(pi: ExtensionAPI, ctx: ExtensionContext, state: AdapterS
 	state.enabled = false;
 	delete state.adapterOwnedToolNames;
 	if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
-}
-
-function setStatus(ctx: ExtensionContext, state: AdapterState, plan: Extract<CodexRuntimePlan, { kind: "normal" | "code" }>): void {
-	if (!ctx.hasUI) return;
-	if (!state.config.ui.statusLine) {
-		ctx.ui.setStatus(STATUS_KEY, undefined);
-		return;
-	}
-	const config = state.config;
-	ctx.ui.setStatus(STATUS_KEY, buildStatusText({
-		mode: plan.kind,
-		useOnAllModels: config.scope.allProviders === "on",
-		additionalProvider: plan.configuredProvider,
-		fast: plan.effectiveOpenAICodex && config.openai.fast,
-		webSearch: plan.toolNames.includes("web_run"),
-		imageGeneration: plan.toolNames.includes("imagegen"),
-		compaction: plan.nativeCompaction,
-		...(isResponsesContext(ctx) ? { verbosity: config.openai.verbosity } : {}),
-	}, ctx.ui.theme));
 }
 
 function mergeToolNames(...groups: string[][]): string[] {

--- a/packages/pi-codex-conversion/src/adapter/activation/state.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/state.ts
@@ -21,6 +21,7 @@ export interface AdapterState {
 	activeProviderSystemPrompt?: string | undefined;
 	pendingActiveProviderPromptCapture?: boolean | undefined;
 	voiceSystemPromptOverride?: string | undefined;
+	weeklyUsageLeft?: number | undefined;
 	config: CodexConversionConfig;
 	codexTurnState: CodexTurnState;
 	pendingPiCompactionNativeWindow?: PendingPiCompactionNativeWindow | undefined;

--- a/packages/pi-codex-conversion/src/adapter/activation/tool-set.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/tool-set.ts
@@ -14,7 +14,7 @@ export function buildExtraToolsOnlyStatusText(tools: string[], theme?: StatusThe
 	return formatStatusText(` • extra tools${tools.length > 0 ? `: ${tools.join(", ")}` : ""}`, theme);
 }
 
-export function buildStatusText(options: { mode?: "normal" | "code" | undefined; verbosity?: string | undefined; webSearch?: boolean | undefined; imageGeneration?: boolean | undefined; fast: boolean; useOnAllModels: boolean; additionalProvider?: boolean | undefined; compaction?: boolean | undefined }, theme?: StatusTheme | undefined): string {
+export function buildStatusText(options: { mode?: "normal" | "code" | undefined; verbosity?: string | undefined; webSearch?: boolean | undefined; imageGeneration?: boolean | undefined; fast: boolean; useOnAllModels: boolean; additionalProvider?: boolean | undefined; compaction?: boolean | undefined; weeklyUsageLeft?: number | undefined }, theme?: StatusTheme | undefined): string {
 	const extras = [
 		options.mode === "code" ? "code mode" : undefined,
 		options.useOnAllModels ? "all models" : undefined,
@@ -23,6 +23,7 @@ export function buildStatusText(options: { mode?: "normal" | "code" | undefined;
 		options.imageGeneration ? "image gen" : undefined,
 		options.compaction ? "compact v2" : undefined,
 		options.fast ? "fast" : undefined,
+		options.weeklyUsageLeft === undefined ? undefined : `weekly: ${Math.round(options.weeklyUsageLeft)}% left`,
 	]
 		.filter(Boolean)
 		.join(" • ");

--- a/packages/pi-codex-conversion/src/codex-usage/client.ts
+++ b/packages/pi-codex-conversion/src/codex-usage/client.ts
@@ -1,61 +1,23 @@
 import { createHash } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+	codexWeeklyUsageLeft,
+	type CodexRateLimitResetConsumeResult,
+	type CodexRateLimitResetCredits,
+	type CodexUsageSnapshot,
+	parseCodexRateLimitResetConsumePayload,
+	parseCodexRateLimitResetCreditsPayload,
+	parseCodexUsagePayload,
+} from "./payload.ts";
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const RESET_CREDITS_CACHE_MS = 5_000;
-const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
 const WEEKLY_USAGE_CACHE_MS = 5 * 60_000;
 const WEEKLY_USAGE_TIMEOUT_MS = 10_000;
 
 type RuntimeModel = Model<Api>;
-
-export interface CodexUsageWindow {
-	usedPercent?: number | undefined;
-	windowMinutes?: number | undefined;
-	resetsAt?: number | undefined;
-}
-
-export interface CodexUsageLimit {
-	limitId: string;
-	limitName?: string | undefined;
-	primary?: CodexUsageWindow | undefined;
-	secondary?: CodexUsageWindow | undefined;
-}
-
-export interface CodexUsageSnapshot {
-	planType?: string | undefined;
-	limits: CodexUsageLimit[];
-	resetCredits?: CodexRateLimitResetCredits | undefined;
-	raw: unknown;
-}
-
-export interface CodexRateLimitResetCredit {
-	id?: string | undefined;
-	resetType?: string | undefined;
-	status?: string | undefined;
-	grantedAt?: string | undefined;
-	expiresAt?: string | undefined;
-	redeemStartedAt?: string | undefined;
-	redeemedAt?: string | undefined;
-	title?: string | undefined;
-	description?: string | undefined;
-}
-
-export interface CodexRateLimitResetCredits {
-	availableCount: number;
-	credits: CodexRateLimitResetCredit[];
-	raw: unknown;
-}
-
-export type CodexRateLimitResetConsumeOutcome = "reset" | "already_redeemed" | "nothing_to_reset" | "no_credit" | "unknown";
-
-export interface CodexRateLimitResetConsumeResult {
-	outcome: CodexRateLimitResetConsumeOutcome;
-	windowsReset?: number | undefined;
-	raw: unknown;
-}
 
 let resetCreditsCache: { key: string; expiresAt: number; promise: Promise<CodexRateLimitResetCredits | undefined> } | undefined;
 const weeklyUsageCache = new Map<string, {
@@ -68,19 +30,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function numberValue(value: unknown): number | undefined {
-	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
 function stringValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
-
-function integerValue(value: unknown): number | undefined {
-	if (typeof value === "number" && Number.isFinite(value)) return Math.max(0, Math.trunc(value));
-	if (typeof value !== "string" || value.trim().length === 0) return undefined;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : undefined;
 }
 
 export function buildCodexUsageUrl(): string {
@@ -130,83 +81,6 @@ async function buildCodexUsageHeaders(ctx: ExtensionContext, model: RuntimeModel
 	headers.set("OAI-Language", "en");
 	headers.set("originator", "pi");
 	return headers;
-}
-
-function parseResetCredit(value: unknown): CodexRateLimitResetCredit | undefined {
-	if (!isRecord(value)) return undefined;
-	return {
-		id: stringValue(value["id"]!),
-		resetType: stringValue(value["reset_type"]!),
-		status: stringValue(value["status"]!),
-		grantedAt: stringValue(value["granted_at"]!),
-		expiresAt: stringValue(value["expires_at"]!),
-		redeemStartedAt: stringValue(value["redeem_started_at"]!),
-		redeemedAt: stringValue(value["redeemed_at"]!),
-		title: stringValue(value["title"]!),
-		description: stringValue(value["description"]!),
-	};
-}
-
-export function parseCodexRateLimitResetCreditsPayload(payload: unknown): CodexRateLimitResetCredits | undefined {
-	const root = isRecord(payload) ? payload : undefined;
-	if (!root) return undefined;
-	const availableCount = integerValue(root["available_count"]!);
-	if (availableCount === undefined) return undefined;
-	const credits = Array.isArray(root["credits"]!) ? root["credits"]!.map(parseResetCredit).filter((credit): credit is CodexRateLimitResetCredit => Boolean(credit)) : [];
-	return { availableCount, credits, raw: payload };
-}
-
-function parseCodexRateLimitResetCreditsSummary(value: unknown): CodexRateLimitResetCredits | undefined {
-	if (!isRecord(value)) return undefined;
-	const availableCount = integerValue(value["available_count"]!);
-	return availableCount === undefined ? undefined : { availableCount, credits: [], raw: value };
-}
-
-function parseWindow(value: unknown): CodexUsageWindow | undefined {
-	if (!isRecord(value)) return undefined;
-	const usedPercent = numberValue(value["used_percent"]!);
-	const limitWindowSeconds = numberValue(value["limit_window_seconds"]!);
-	const windowMinutes = numberValue(value["window_minutes"]!) ?? (limitWindowSeconds === undefined ? undefined : Math.ceil(limitWindowSeconds / 60));
-	const resetsAt = numberValue(value["resets_at"]!) ?? numberValue(value["reset_at"]!);
-	return usedPercent === undefined && windowMinutes === undefined && resetsAt === undefined ? undefined : { usedPercent, windowMinutes, resetsAt };
-}
-
-function parseRateLimit(value: unknown): { primary?: CodexUsageWindow | undefined; secondary?: CodexUsageWindow | undefined } {
-	if (!isRecord(value)) return {};
-	const primary = parseWindow(value["primary_window"]!) ?? parseWindow(value["primary"]!);
-	const secondary = parseWindow(value["secondary_window"]!) ?? parseWindow(value["secondary"]!);
-	if (primary?.windowMinutes === WEEKLY_WINDOW_MINUTES && !secondary) return { secondary: primary };
-	return { primary, secondary };
-}
-
-export function parseCodexUsagePayload(payload: unknown): CodexUsageSnapshot {
-	const root = isRecord(payload) ? payload : {};
-	const limits: CodexUsageLimit[] = [];
-	const addLimit = (limitId: string, limitName: string | undefined, source: unknown) => {
-		const rateLimit = isRecord(source) && "rate_limit" in source ? source["rate_limit"]! : source;
-		const parsed = parseRateLimit(rateLimit);
-		limits.push({
-			limitId,
-			...(limitName ? { limitName } : {}),
-			...(parsed.primary ? { primary: parsed.primary } : {}),
-			...(parsed.secondary ? { secondary: parsed.secondary } : {}),
-		});
-	};
-	addLimit("codex", undefined, root["rate_limit"]!);
-	if (Array.isArray(root["additional_rate_limits"]!)) {
-		for (const item of root["additional_rate_limits"]!) {
-			if (!isRecord(item)) continue;
-			addLimit(stringValue(item["metered_feature"]!) ?? "additional", stringValue(item["limit_name"]!), item);
-		}
-	}
-	return { planType: stringValue(root["plan_type"]!), limits, resetCredits: parseCodexRateLimitResetCreditsSummary(root["rate_limit_reset_credits"]!), raw: payload };
-}
-
-export function codexWeeklyUsageLeft(snapshot: CodexUsageSnapshot): number | undefined {
-	const limit = snapshot.limits.find(({ limitId }) => limitId === "codex");
-	const weekly = [limit?.primary, limit?.secondary].find(({ windowMinutes } = {}) => windowMinutes === WEEKLY_WINDOW_MINUTES);
-	if (weekly?.usedPercent === undefined) return undefined;
-	return 100 - Math.max(0, Math.min(100, weekly.usedPercent));
 }
 
 function resetCreditsCacheKey(headers: Headers): string | undefined {
@@ -314,13 +188,6 @@ export function createCodexRateLimitResetRedeemRequestId(): string {
 	return typeof globalThis.crypto?.randomUUID === "function" ? globalThis.crypto.randomUUID() : `pi_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 }
 
-function parseCodexRateLimitResetConsumePayload(payload: unknown): CodexRateLimitResetConsumeResult {
-	const root = isRecord(payload) ? payload : {};
-	const code = stringValue(root["code"]!);
-	const outcome: CodexRateLimitResetConsumeOutcome = code === "reset" || code === "already_redeemed" || code === "nothing_to_reset" || code === "no_credit" ? code : "unknown";
-	return { outcome, windowsReset: integerValue(root["windows_reset"]!), raw: payload };
-}
-
 export async function consumeCodexRateLimitResetCredit(ctx: ExtensionContext, redeemRequestId = createCodexRateLimitResetRedeemRequestId()): Promise<CodexRateLimitResetConsumeResult> {
 	const model = ctx.model;
 	if (!model) throw new Error("No active model selected.");
@@ -345,30 +212,4 @@ export async function consumeCodexRateLimitResetCredit(ctx: ExtensionContext, re
 		if (key) weeklyUsageCache.delete(key);
 	}
 	return result;
-}
-
-function formatReset(timestampSeconds: number | undefined): string {
-	if (!timestampSeconds) return "reset unknown";
-	const ms = timestampSeconds * 1000;
-	const minutes = Math.max(0, Math.round((ms - Date.now()) / 60000));
-	return minutes < 90 ? `resets in ~${minutes}m` : `resets ${new Date(ms).toLocaleString()}`;
-}
-
-function formatWindow(label: string, window: CodexUsageWindow | undefined): string | undefined {
-	if (!window) return undefined;
-	const remainingPercent = window.usedPercent === undefined ? undefined : 100 - Math.max(0, Math.min(100, window.usedPercent));
-	const percent = remainingPercent === undefined ? "?" : `${Math.round(remainingPercent)}%`;
-	const span = window.windowMinutes ? `${Math.round(window.windowMinutes)}m` : "window";
-	return `${label}: ${percent} left (${span}, ${formatReset(window.resetsAt)})`;
-}
-
-export function formatCodexUsage(snapshot: CodexUsageSnapshot): string {
-	const lines = [`Codex usage${snapshot.planType ? ` (${snapshot.planType})` : ""}:`];
-	if (snapshot.resetCredits) lines.push(`- resets available: ${snapshot.resetCredits.availableCount}`);
-	for (const limit of snapshot.limits) {
-		const title = limit.limitName ?? limit.limitId;
-		const parts = [formatWindow("5h", limit.primary), formatWindow("weekly", limit.secondary)].filter(Boolean);
-		lines.push(`- ${title}: ${parts.length ? parts.join("; ") : "no usage data"}`);
-	}
-	return lines.join("\n");
 }

--- a/packages/pi-codex-conversion/src/codex-usage/format.ts
+++ b/packages/pi-codex-conversion/src/codex-usage/format.ts
@@ -1,0 +1,27 @@
+import type { CodexUsageSnapshot, CodexUsageWindow } from "./payload.ts";
+
+function formatReset(timestampSeconds: number | undefined): string {
+	if (!timestampSeconds) return "reset unknown";
+	const ms = timestampSeconds * 1000;
+	const minutes = Math.max(0, Math.round((ms - Date.now()) / 60000));
+	return minutes < 90 ? `resets in ~${minutes}m` : `resets ${new Date(ms).toLocaleString()}`;
+}
+
+function formatWindow(label: string, window: CodexUsageWindow | undefined): string | undefined {
+	if (!window) return undefined;
+	const remainingPercent = window.usedPercent === undefined ? undefined : 100 - Math.max(0, Math.min(100, window.usedPercent));
+	const percent = remainingPercent === undefined ? "?" : `${Math.round(remainingPercent)}%`;
+	const span = window.windowMinutes ? `${Math.round(window.windowMinutes)}m` : "window";
+	return `${label}: ${percent} left (${span}, ${formatReset(window.resetsAt)})`;
+}
+
+export function formatCodexUsage(snapshot: CodexUsageSnapshot): string {
+	const lines = [`Codex usage${snapshot.planType ? ` (${snapshot.planType})` : ""}:`];
+	if (snapshot.resetCredits) lines.push(`- resets available: ${snapshot.resetCredits.availableCount}`);
+	for (const limit of snapshot.limits) {
+		const title = limit.limitName ?? limit.limitId;
+		const parts = [formatWindow("5h", limit.primary), formatWindow("weekly", limit.secondary)].filter(Boolean);
+		lines.push(`- ${title}: ${parts.length ? parts.join("; ") : "no usage data"}`);
+	}
+	return lines.join("\n");
+}

--- a/packages/pi-codex-conversion/src/codex-usage/payload.ts
+++ b/packages/pi-codex-conversion/src/codex-usage/payload.ts
@@ -1,0 +1,150 @@
+const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+
+export interface CodexUsageWindow {
+	usedPercent?: number | undefined;
+	windowMinutes?: number | undefined;
+	resetsAt?: number | undefined;
+}
+
+export interface CodexUsageLimit {
+	limitId: string;
+	limitName?: string | undefined;
+	primary?: CodexUsageWindow | undefined;
+	secondary?: CodexUsageWindow | undefined;
+}
+
+export interface CodexUsageSnapshot {
+	planType?: string | undefined;
+	limits: CodexUsageLimit[];
+	resetCredits?: CodexRateLimitResetCredits | undefined;
+	raw: unknown;
+}
+
+export interface CodexRateLimitResetCredit {
+	id?: string | undefined;
+	resetType?: string | undefined;
+	status?: string | undefined;
+	grantedAt?: string | undefined;
+	expiresAt?: string | undefined;
+	redeemStartedAt?: string | undefined;
+	redeemedAt?: string | undefined;
+	title?: string | undefined;
+	description?: string | undefined;
+}
+
+export interface CodexRateLimitResetCredits {
+	availableCount: number;
+	credits: CodexRateLimitResetCredit[];
+	raw: unknown;
+}
+
+export type CodexRateLimitResetConsumeOutcome = "reset" | "already_redeemed" | "nothing_to_reset" | "no_credit" | "unknown";
+
+export interface CodexRateLimitResetConsumeResult {
+	outcome: CodexRateLimitResetConsumeOutcome;
+	windowsReset?: number | undefined;
+	raw: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function numberValue(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function integerValue(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return Math.max(0, Math.trunc(value));
+	if (typeof value !== "string" || value.trim().length === 0) return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : undefined;
+}
+
+function parseResetCredit(value: unknown): CodexRateLimitResetCredit | undefined {
+	if (!isRecord(value)) return undefined;
+	return {
+		id: stringValue(value["id"]!),
+		resetType: stringValue(value["reset_type"]!),
+		status: stringValue(value["status"]!),
+		grantedAt: stringValue(value["granted_at"]!),
+		expiresAt: stringValue(value["expires_at"]!),
+		redeemStartedAt: stringValue(value["redeem_started_at"]!),
+		redeemedAt: stringValue(value["redeemed_at"]!),
+		title: stringValue(value["title"]!),
+		description: stringValue(value["description"]!),
+	};
+}
+
+export function parseCodexRateLimitResetCreditsPayload(payload: unknown): CodexRateLimitResetCredits | undefined {
+	const root = isRecord(payload) ? payload : undefined;
+	if (!root) return undefined;
+	const availableCount = integerValue(root["available_count"]!);
+	if (availableCount === undefined) return undefined;
+	const credits = Array.isArray(root["credits"]!) ? root["credits"]!.map(parseResetCredit).filter((credit): credit is CodexRateLimitResetCredit => Boolean(credit)) : [];
+	return { availableCount, credits, raw: payload };
+}
+
+function parseCodexRateLimitResetCreditsSummary(value: unknown): CodexRateLimitResetCredits | undefined {
+	if (!isRecord(value)) return undefined;
+	const availableCount = integerValue(value["available_count"]!);
+	return availableCount === undefined ? undefined : { availableCount, credits: [], raw: value };
+}
+
+function parseWindow(value: unknown): CodexUsageWindow | undefined {
+	if (!isRecord(value)) return undefined;
+	const usedPercent = numberValue(value["used_percent"]!);
+	const limitWindowSeconds = numberValue(value["limit_window_seconds"]!);
+	const windowMinutes = numberValue(value["window_minutes"]!) ?? (limitWindowSeconds === undefined ? undefined : Math.ceil(limitWindowSeconds / 60));
+	const resetsAt = numberValue(value["resets_at"]!) ?? numberValue(value["reset_at"]!);
+	return usedPercent === undefined && windowMinutes === undefined && resetsAt === undefined ? undefined : { usedPercent, windowMinutes, resetsAt };
+}
+
+function parseRateLimit(value: unknown): { primary?: CodexUsageWindow | undefined; secondary?: CodexUsageWindow | undefined } {
+	if (!isRecord(value)) return {};
+	const primary = parseWindow(value["primary_window"]!) ?? parseWindow(value["primary"]!);
+	const secondary = parseWindow(value["secondary_window"]!) ?? parseWindow(value["secondary"]!);
+	if (primary?.windowMinutes === WEEKLY_WINDOW_MINUTES && !secondary) return { secondary: primary };
+	return { primary, secondary };
+}
+
+export function parseCodexUsagePayload(payload: unknown): CodexUsageSnapshot {
+	const root = isRecord(payload) ? payload : {};
+	const limits: CodexUsageLimit[] = [];
+	const addLimit = (limitId: string, limitName: string | undefined, source: unknown) => {
+		const rateLimit = isRecord(source) && "rate_limit" in source ? source["rate_limit"]! : source;
+		const parsed = parseRateLimit(rateLimit);
+		limits.push({
+			limitId,
+			...(limitName ? { limitName } : {}),
+			...(parsed.primary ? { primary: parsed.primary } : {}),
+			...(parsed.secondary ? { secondary: parsed.secondary } : {}),
+		});
+	};
+	addLimit("codex", undefined, root["rate_limit"]!);
+	if (Array.isArray(root["additional_rate_limits"]!)) {
+		for (const item of root["additional_rate_limits"]!) {
+			if (!isRecord(item)) continue;
+			addLimit(stringValue(item["metered_feature"]!) ?? "additional", stringValue(item["limit_name"]!), item);
+		}
+	}
+	return { planType: stringValue(root["plan_type"]!), limits, resetCredits: parseCodexRateLimitResetCreditsSummary(root["rate_limit_reset_credits"]!), raw: payload };
+}
+
+export function codexWeeklyUsageLeft(snapshot: CodexUsageSnapshot): number | undefined {
+	const limit = snapshot.limits.find(({ limitId }) => limitId === "codex");
+	const weekly = [limit?.primary, limit?.secondary].find(({ windowMinutes } = {}) => windowMinutes === WEEKLY_WINDOW_MINUTES);
+	if (weekly?.usedPercent === undefined) return undefined;
+	return 100 - Math.max(0, Math.min(100, weekly.usedPercent));
+}
+
+export function parseCodexRateLimitResetConsumePayload(payload: unknown): CodexRateLimitResetConsumeResult {
+	const root = isRecord(payload) ? payload : {};
+	const code = stringValue(root["code"]!);
+	const outcome: CodexRateLimitResetConsumeOutcome = code === "reset" || code === "already_redeemed" || code === "nothing_to_reset" || code === "no_credit" ? code : "unknown";
+	return { outcome, windowsReset: integerValue(root["windows_reset"]!), raw: payload };
+}

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -72,6 +72,7 @@ export function registerCodexEvents(
 		runtime.backgroundWidget.ctx = ctx;
 		state.cwd = ctx.cwd;
 		state.config = readCodexConversionConfig();
+		state.weeklyUsageLeft = undefined;
 		state.activeProviderSystemPrompt = undefined;
 		state.voiceSystemPromptOverride = undefined;
 		proxyProvider.applyConfig(state.config, ctx.modelRegistry);
@@ -91,6 +92,7 @@ export function registerCodexEvents(
 		ui.renderBackgroundWidget();
 		syncAdapter(pi, ctx, state);
 		await runtime.configureDiagnostics(ctx);
+		await ui.refreshUsageStatus(ctx);
 		prepareCodeModeHost(codeMode, ctx);
 		if (!state.config.prompt.heavySystemPromptOverwrite)
 			void runtime.startPrewarm(ctx, codeMode.refreshPromptTools(ctx.getSystemPrompt(), ctx));
@@ -102,6 +104,7 @@ export function registerCodexEvents(
 		state.cwd = ctx.cwd;
 		state.activeProviderSystemPrompt = undefined;
 		state.voiceSystemPromptOverride = undefined;
+		state.weeklyUsageLeft = undefined;
 		state.promptSkills = extractPiPromptSkills(ctx.getSystemPrompt());
 		proxyProvider.applyConfig(state.config, ctx.modelRegistry);
 		if (state.config.voiceFeaturesOnly) {
@@ -114,6 +117,7 @@ export function registerCodexEvents(
 		tools.ensureOptionalTools();
 		syncAdapter(pi, ctx, state);
 		await runtime.configureDiagnostics(ctx);
+		await ui.refreshUsageStatus(ctx);
 		prepareCodeModeHost(codeMode, ctx);
 		if (!state.config.prompt.heavySystemPromptOverwrite)
 			void runtime.startPrewarm(ctx, codeMode.refreshPromptTools(ctx.getSystemPrompt(), ctx));
@@ -177,12 +181,13 @@ export function registerCodexEvents(
 		if (update.type === "text_delta" && typeof update.delta === "string") runtime.voice.streamDelta(update.delta);
 	});
 	pi.on("agent_start", async () => { runtime.voice.agentStarted(); runtime.lanVoice.agentStarted(); });
-	pi.on("agent_settled", async () => {
+	pi.on("agent_settled", async (_event, ctx) => {
 		state.pendingActiveProviderPromptCapture = false;
 		state.voiceSystemPromptOverride = undefined;
 		state.codexTurnState.reset();
 		runtime.voice.settleTurn();
 		runtime.lanVoice.agentSettled();
+		if (!state.config.voiceFeaturesOnly) await ui.refreshUsageStatus(ctx);
 	});
 	pi.on("before_provider_request", async (event, ctx) => {
 		state.cwd = ctx.cwd;

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -64,6 +64,7 @@ export function registerCodexEvents(
 	sessions.onSessionExit((sessionId) => tracker.recordSessionFinished(sessionId));
 
 	pi.on("session_start", async (event, ctx) => {
+		ui.invalidateUsageStatus();
 		await runtime.lanVoice.stop(ctx);
 		runtime.voice.resetContextAnnouncements();
 		runtime.voice.resetSessionContext();
@@ -100,6 +101,7 @@ export function registerCodexEvents(
 	});
 
 	pi.on("model_select", async (_event, ctx) => {
+		ui.invalidateUsageStatus();
 		runtime.resetTransport(ctx.sessionManager.getSessionId());
 		state.cwd = ctx.cwd;
 		state.activeProviderSystemPrompt = undefined;

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -92,7 +92,7 @@ export function registerCodexEvents(
 		ui.renderBackgroundWidget();
 		syncAdapter(pi, ctx, state);
 		await runtime.configureDiagnostics(ctx);
-		await ui.refreshUsageStatus(ctx);
+		void ui.refreshUsageStatus(ctx);
 		prepareCodeModeHost(codeMode, ctx);
 		if (!state.config.prompt.heavySystemPromptOverwrite)
 			void runtime.startPrewarm(ctx, codeMode.refreshPromptTools(ctx.getSystemPrompt(), ctx));
@@ -117,7 +117,7 @@ export function registerCodexEvents(
 		tools.ensureOptionalTools();
 		syncAdapter(pi, ctx, state);
 		await runtime.configureDiagnostics(ctx);
-		await ui.refreshUsageStatus(ctx);
+		void ui.refreshUsageStatus(ctx);
 		prepareCodeModeHost(codeMode, ctx);
 		if (!state.config.prompt.heavySystemPromptOverwrite)
 			void runtime.startPrewarm(ctx, codeMode.refreshPromptTools(ctx.getSystemPrompt(), ctx));
@@ -187,7 +187,7 @@ export function registerCodexEvents(
 		state.codexTurnState.reset();
 		runtime.voice.settleTurn();
 		runtime.lanVoice.agentSettled();
-		if (!state.config.voiceFeaturesOnly) await ui.refreshUsageStatus(ctx);
+		if (!state.config.voiceFeaturesOnly) void ui.refreshUsageStatus(ctx);
 	});
 	pi.on("before_provider_request", async (event, ctx) => {
 		state.cwd = ctx.cwd;

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -35,7 +35,7 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 		registerCodexCommand(pi, runtime.state, runtime.voice, runtime.lanVoice, (config, ctx, previousConfig) => {
 			proxyProvider.applyConfig(config, ctx.modelRegistry);
 			tools.applyConfig(config);
-			ui.applyConfig(config);
+			ui.applyConfig(config, ctx, previousConfig);
 			if (config.openai.cacheDiagnostics !== previousConfig.openai.cacheDiagnostics) {
 				void runtime.configureDiagnostics(
 					ctx,

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -6,7 +6,7 @@ import { BACKGROUND_BASH_WIDGET_ID, registerBackgroundBashWidgetShortcuts, rende
 import type { CodexExtensionRuntime } from "./runtime.ts";
 import { renderCodexStatus } from "../ui/status.ts";
 import { isAdapterRuntime, resolveCodexRuntimePlan } from "../adapter/activation/runtime-plan.ts";
-import { fetchCodexWeeklyUsageLeft } from "../usage.ts";
+import { fetchCodexWeeklyUsageLeft } from "../codex-usage/client.ts";
 
 export interface CodexUiController {
 	clearBackgroundWidget(): void;

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -17,6 +17,7 @@ export interface CodexUiController {
 
 export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexUiController {
 	let renderTimer: ReturnType<typeof setTimeout> | undefined;
+	let usageGeneration = 0;
 	const clearBackgroundWidget = () => {
 		if (renderTimer) clearTimeout(renderTimer);
 		renderTimer = undefined;
@@ -77,11 +78,27 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 		clearBackgroundWidget,
 		renderBackgroundWidget,
 		async refreshUsageStatus(ctx) {
-			runtime.state.weeklyUsageLeft = await fetchCodexWeeklyUsageLeft(ctx);
+			const generation = ++usageGeneration;
+			if (!ctx.hasUI || runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.statusLine) {
+				runtime.state.weeklyUsageLeft = undefined;
+				return;
+			}
+			const weeklyUsageLeft = await fetchCodexWeeklyUsageLeft(ctx);
+			if (
+				generation !== usageGeneration ||
+				!ctx.hasUI ||
+				runtime.state.config.voiceFeaturesOnly ||
+				!runtime.state.config.ui.statusLine
+			) return;
+			runtime.state.weeklyUsageLeft = weeklyUsageLeft;
 			const plan = resolveCodexRuntimePlan(ctx, runtime.state.config);
 			if (isAdapterRuntime(plan)) renderCodexStatus(ctx, runtime.state, plan);
 		},
 		applyConfig(config) {
+			if (config.voiceFeaturesOnly || !config.ui.statusLine) {
+				usageGeneration += 1;
+				runtime.state.weeklyUsageLeft = undefined;
+			}
 			if (config.voiceFeaturesOnly || !config.ui.backgroundShellWidget) clearBackgroundWidget();
 			else renderBackgroundWidget();
 		},

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -11,7 +11,8 @@ import { fetchCodexWeeklyUsageLeft } from "../usage.ts";
 export interface CodexUiController {
 	clearBackgroundWidget(): void;
 	renderBackgroundWidget(): void;
-	applyConfig(config: CodexConversionConfig): void;
+	invalidateUsageStatus(): void;
+	applyConfig(config: CodexConversionConfig, ctx: ExtensionContext, previousConfig: CodexConversionConfig): void;
 	refreshUsageStatus(ctx: ExtensionContext): Promise<void>;
 }
 
@@ -73,31 +74,42 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 		renderTimer = undefined;
 		renderBackgroundWidget();
 	});
+	const invalidateUsageStatus = () => {
+		usageGeneration += 1;
+		runtime.state.weeklyUsageLeft = undefined;
+	};
+	const refreshUsageStatus = async (ctx: ExtensionContext) => {
+		const generation = ++usageGeneration;
+		if (!ctx.hasUI || runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.statusLine) {
+			runtime.state.weeklyUsageLeft = undefined;
+			return;
+		}
+		const plan = resolveCodexRuntimePlan(ctx, runtime.state.config);
+		if (!isAdapterRuntime(plan)) return;
+		const weeklyUsageLeft = await fetchCodexWeeklyUsageLeft(ctx);
+		if (
+			generation !== usageGeneration ||
+			!ctx.hasUI ||
+			runtime.state.config.voiceFeaturesOnly ||
+			!runtime.state.config.ui.statusLine
+		) return;
+		runtime.state.weeklyUsageLeft = weeklyUsageLeft;
+		renderCodexStatus(ctx, runtime.state, plan);
+	};
 
 	return {
 		clearBackgroundWidget,
 		renderBackgroundWidget,
-		async refreshUsageStatus(ctx) {
-			const generation = ++usageGeneration;
-			if (!ctx.hasUI || runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.statusLine) {
-				runtime.state.weeklyUsageLeft = undefined;
-				return;
-			}
-			const weeklyUsageLeft = await fetchCodexWeeklyUsageLeft(ctx);
-			if (
-				generation !== usageGeneration ||
-				!ctx.hasUI ||
-				runtime.state.config.voiceFeaturesOnly ||
-				!runtime.state.config.ui.statusLine
-			) return;
-			runtime.state.weeklyUsageLeft = weeklyUsageLeft;
-			const plan = resolveCodexRuntimePlan(ctx, runtime.state.config);
-			if (isAdapterRuntime(plan)) renderCodexStatus(ctx, runtime.state, plan);
-		},
-		applyConfig(config) {
+		invalidateUsageStatus,
+		refreshUsageStatus,
+		applyConfig(config, ctx, previousConfig) {
 			if (config.voiceFeaturesOnly || !config.ui.statusLine) {
-				usageGeneration += 1;
-				runtime.state.weeklyUsageLeft = undefined;
+				invalidateUsageStatus();
+			} else if (
+				previousConfig.voiceFeaturesOnly ||
+				!previousConfig.ui.statusLine
+			) {
+				void refreshUsageStatus(ctx);
 			}
 			if (config.voiceFeaturesOnly || !config.ui.backgroundShellWidget) clearBackgroundWidget();
 			else renderBackgroundWidget();

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -1,14 +1,18 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
 import { NATIVE_COMPACTION_DISPLAY_MESSAGE_TYPE, NATIVE_COMPACTION_DISPLAY_TEXT, type NativeCompactionDisplayEntry } from "../adapter/compaction/types.ts";
 import { BACKGROUND_BASH_WIDGET_ID, registerBackgroundBashWidgetShortcuts, renderBackgroundBashWidget } from "../ui/background-bash-widget.ts";
 import type { CodexExtensionRuntime } from "./runtime.ts";
+import { renderCodexStatus } from "../ui/status.ts";
+import { isAdapterRuntime, resolveCodexRuntimePlan } from "../adapter/activation/runtime-plan.ts";
+import { fetchCodexWeeklyUsageLeft } from "../usage.ts";
 
 export interface CodexUiController {
 	clearBackgroundWidget(): void;
 	renderBackgroundWidget(): void;
 	applyConfig(config: CodexConversionConfig): void;
+	refreshUsageStatus(ctx: ExtensionContext): Promise<void>;
 }
 
 export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexUiController {
@@ -72,6 +76,11 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 	return {
 		clearBackgroundWidget,
 		renderBackgroundWidget,
+		async refreshUsageStatus(ctx) {
+			runtime.state.weeklyUsageLeft = await fetchCodexWeeklyUsageLeft(ctx);
+			const plan = resolveCodexRuntimePlan(ctx, runtime.state.config);
+			if (isAdapterRuntime(plan)) renderCodexStatus(ctx, runtime.state, plan);
+		},
 		applyConfig(config) {
 			if (config.voiceFeaturesOnly || !config.ui.backgroundShellWidget) clearBackgroundWidget();
 			else renderBackgroundWidget();

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -38,7 +38,10 @@ export function registerCodexCommand(
 	async function openSettings(ctx: ExtensionContext, tab: SettingsTab): Promise<void> {
 		if (!ctx.hasUI) {
 			if (tab === "usage") {
-				const { fetchCodexUsage, formatCodexUsage } = await import("../../usage.ts");
+				const [{ fetchCodexUsage }, { formatCodexUsage }] = await Promise.all([
+					import("../../codex-usage/client.ts"),
+					import("../../codex-usage/format.ts"),
+				]);
 				try {
 					ctx.ui.notify(formatCodexUsage(await fetchCodexUsage(ctx)), "info");
 				} catch (error) {

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -38,7 +38,7 @@ export function registerCodexCommand(
 	async function openSettings(ctx: ExtensionContext, tab: SettingsTab): Promise<void> {
 		if (!ctx.hasUI) {
 			if (tab === "usage") {
-				const { fetchCodexUsage, formatCodexUsage } = await import("./usage.ts");
+				const { fetchCodexUsage, formatCodexUsage } = await import("../../usage.ts");
 				try {
 					ctx.ui.notify(formatCodexUsage(await fetchCodexUsage(ctx)), "info");
 				} catch (error) {

--- a/packages/pi-codex-conversion/src/ui/settings/usage-tab.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/usage-tab.ts
@@ -4,10 +4,12 @@ import {
 	consumeCodexRateLimitResetCredit,
 	createCodexRateLimitResetRedeemRequestId,
 	fetchCodexUsage,
-	type CodexRateLimitResetConsumeResult,
-	type CodexRateLimitResetCredit,
-	type CodexUsageSnapshot,
-} from "../../usage.ts";
+} from "../../codex-usage/client.ts";
+import type {
+	CodexRateLimitResetConsumeResult,
+	CodexRateLimitResetCredit,
+	CodexUsageSnapshot,
+} from "../../codex-usage/payload.ts";
 
 export interface UsageTabOptions {
 	initialUsage?: CodexUsageSnapshot | { error: string } | undefined;

--- a/packages/pi-codex-conversion/src/ui/settings/usage-tab.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/usage-tab.ts
@@ -7,7 +7,7 @@ import {
 	type CodexRateLimitResetConsumeResult,
 	type CodexRateLimitResetCredit,
 	type CodexUsageSnapshot,
-} from "./usage.ts";
+} from "../../usage.ts";
 
 export interface UsageTabOptions {
 	initialUsage?: CodexUsageSnapshot | { error: string } | undefined;

--- a/packages/pi-codex-conversion/src/ui/status.ts
+++ b/packages/pi-codex-conversion/src/ui/status.ts
@@ -1,0 +1,25 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AdapterState } from "../adapter/activation/state.ts";
+import type { CodexRuntimePlan } from "../adapter/activation/runtime-plan.ts";
+import { STATUS_KEY, buildStatusText } from "../adapter/activation/tool-set.ts";
+import { isResponsesContext } from "../adapter/prompt/codex-model.ts";
+
+export function renderCodexStatus(ctx: ExtensionContext, state: AdapterState, plan: Extract<CodexRuntimePlan, { kind: "normal" | "code" }>): void {
+	if (!ctx.hasUI) return;
+	if (!state.config.ui.statusLine) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		return;
+	}
+	const config = state.config;
+	ctx.ui.setStatus(STATUS_KEY, buildStatusText({
+		mode: plan.kind,
+		useOnAllModels: config.scope.allProviders === "on",
+		additionalProvider: plan.configuredProvider,
+		fast: plan.effectiveOpenAICodex && config.openai.fast,
+		webSearch: plan.toolNames.includes("web_run"),
+		imageGeneration: plan.toolNames.includes("imagegen"),
+		compaction: plan.nativeCompaction,
+		weeklyUsageLeft: state.weeklyUsageLeft,
+		...(isResponsesContext(ctx) ? { verbosity: config.openai.verbosity } : {}),
+	}, ctx.ui.theme));
+}

--- a/packages/pi-codex-conversion/src/usage.ts
+++ b/packages/pi-codex-conversion/src/usage.ts
@@ -7,6 +7,7 @@ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const RESET_CREDITS_CACHE_MS = 5_000;
 const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
 const WEEKLY_USAGE_CACHE_MS = 5 * 60_000;
+const WEEKLY_USAGE_TIMEOUT_MS = 10_000;
 
 type RuntimeModel = Model<Api>;
 
@@ -270,8 +271,12 @@ export async function fetchCodexWeeklyUsageLeft(ctx: ExtensionContext): Promise<
 		if (key && weeklyUsageCache?.key === key && weeklyUsageCache.expiresAt > Date.now())
 			return weeklyUsageCache.value;
 		previous = key && weeklyUsageCache?.key === key ? weeklyUsageCache.value : undefined;
+		const timeoutSignal = AbortSignal.timeout(WEEKLY_USAGE_TIMEOUT_MS);
+		const signal = ctx.signal
+			? AbortSignal.any([ctx.signal, timeoutSignal])
+			: timeoutSignal;
 		const value = codexWeeklyUsageLeft(
-			await fetchCodexUsageWithHeaders(headers, ctx.signal, false),
+			await fetchCodexUsageWithHeaders(headers, signal, false),
 		);
 		if (key) weeklyUsageCache = { key, value, expiresAt: Date.now() + WEEKLY_USAGE_CACHE_MS };
 		return value;

--- a/packages/pi-codex-conversion/src/usage.ts
+++ b/packages/pi-codex-conversion/src/usage.ts
@@ -5,6 +5,7 @@ const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const RESET_CREDITS_CACHE_MS = 5_000;
 const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+const WEEKLY_USAGE_CACHE_MS = 60_000;
 
 type RuntimeModel = Model<Api>;
 
@@ -55,6 +56,7 @@ export interface CodexRateLimitResetConsumeResult {
 }
 
 let resetCreditsCache: { key: string; expiresAt: number; promise: Promise<CodexRateLimitResetCredits | undefined> } | undefined;
+let weeklyUsageCache: { value?: number | undefined; expiresAt: number } = { expiresAt: 0 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -194,6 +196,13 @@ export function parseCodexUsagePayload(payload: unknown): CodexUsageSnapshot {
 	return { planType: stringValue(root["plan_type"]!), limits, resetCredits: parseCodexRateLimitResetCreditsSummary(root["rate_limit_reset_credits"]!), raw: payload };
 }
 
+export function codexWeeklyUsageLeft(snapshot: CodexUsageSnapshot): number | undefined {
+	const limit = snapshot.limits.find(({ limitId }) => limitId === "codex");
+	const weekly = [limit?.primary, limit?.secondary].find(({ windowMinutes } = {}) => windowMinutes === WEEKLY_WINDOW_MINUTES);
+	if (weekly?.usedPercent === undefined) return undefined;
+	return 100 - Math.max(0, Math.min(100, weekly.usedPercent));
+}
+
 function resetCreditsCacheKey(headers: Headers): string | undefined {
 	return headers.get("chatgpt-account-id")?.trim() || undefined;
 }
@@ -230,6 +239,17 @@ export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsage
 		}
 	}
 	return snapshot;
+}
+
+export async function fetchCodexWeeklyUsageLeft(ctx: ExtensionContext): Promise<number | undefined> {
+	if (weeklyUsageCache.expiresAt > Date.now()) return weeklyUsageCache.value;
+	weeklyUsageCache.expiresAt = Date.now() + WEEKLY_USAGE_CACHE_MS;
+	try {
+		weeklyUsageCache.value = codexWeeklyUsageLeft(await fetchCodexUsage(ctx));
+	} catch {
+		// Keep the last successful value when usage is temporarily unavailable.
+	}
+	return weeklyUsageCache.value;
 }
 
 export function createCodexRateLimitResetRedeemRequestId(): string {

--- a/packages/pi-codex-conversion/src/usage.ts
+++ b/packages/pi-codex-conversion/src/usage.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 
@@ -5,7 +6,7 @@ const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const RESET_CREDITS_CACHE_MS = 5_000;
 const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
-const WEEKLY_USAGE_CACHE_MS = 60_000;
+const WEEKLY_USAGE_CACHE_MS = 5 * 60_000;
 
 type RuntimeModel = Model<Api>;
 
@@ -56,7 +57,7 @@ export interface CodexRateLimitResetConsumeResult {
 }
 
 let resetCreditsCache: { key: string; expiresAt: number; promise: Promise<CodexRateLimitResetCredits | undefined> } | undefined;
-let weeklyUsageCache: { value?: number | undefined; expiresAt: number } = { expiresAt: 0 };
+let weeklyUsageCache: { key: string; value?: number | undefined; expiresAt: number } | undefined;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -207,6 +208,15 @@ function resetCreditsCacheKey(headers: Headers): string | undefined {
 	return headers.get("chatgpt-account-id")?.trim() || undefined;
 }
 
+function usageCacheKey(headers: Headers): string | undefined {
+	const accountId = resetCreditsCacheKey(headers);
+	if (accountId) return `account:${accountId}`;
+	const authorization = headers.get("authorization")?.trim();
+	return authorization
+		? `auth:${createHash("sha256").update(authorization).digest("hex")}`
+		: undefined;
+}
+
 async function fetchCodexRateLimitResetCreditsWithHeaders(headers: Headers, signal?: AbortSignal | undefined): Promise<CodexRateLimitResetCredits | undefined> {
 	const cacheKey = resetCreditsCacheKey(headers);
 	if (cacheKey && resetCreditsCache && resetCreditsCache.key === cacheKey && resetCreditsCache.expiresAt > Date.now()) return resetCreditsCache.promise;
@@ -219,20 +229,18 @@ async function fetchCodexRateLimitResetCreditsWithHeaders(headers: Headers, sign
 	return promise;
 }
 
-export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsageSnapshot> {
-	const model = ctx.model;
-	if (!model) throw new Error("No active model selected.");
-	if (model.provider !== "openai-codex") {
-		throw new Error("Codex usage is only available for OpenAI Codex subscription models.");
-	}
-	const headers = await buildCodexUsageHeaders(ctx, model);
-	const response = await fetch(buildCodexUsageUrl(), { method: "GET", headers, ...(ctx.signal ? { signal: ctx.signal } : {}) });
+async function fetchCodexUsageWithHeaders(
+	headers: Headers,
+	signal?: AbortSignal | undefined,
+	includeDetailedResetCredits = true,
+): Promise<CodexUsageSnapshot> {
+	const response = await fetch(buildCodexUsageUrl(), { method: "GET", headers, ...(signal ? { signal } : {}) });
 	const text = await response.text();
 	if (!response.ok) throw new Error(`Usage request failed (${response.status}): ${text || response.statusText}`);
 	const snapshot = parseCodexUsagePayload(JSON.parse(text));
-	if (!snapshot.resetCredits || snapshot.resetCredits.availableCount > 0) {
+	if (includeDetailedResetCredits && (!snapshot.resetCredits || snapshot.resetCredits.availableCount > 0)) {
 		try {
-			const detailedResetCredits = await fetchCodexRateLimitResetCreditsWithHeaders(headers, ctx.signal);
+			const detailedResetCredits = await fetchCodexRateLimitResetCreditsWithHeaders(headers, signal);
 			if (detailedResetCredits) snapshot.resetCredits = detailedResetCredits;
 		} catch {
 			// Detailed reset-credit metadata is additive; usage still renders if this endpoint fails.
@@ -241,15 +249,36 @@ export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsage
 	return snapshot;
 }
 
-export async function fetchCodexWeeklyUsageLeft(ctx: ExtensionContext): Promise<number | undefined> {
-	if (weeklyUsageCache.expiresAt > Date.now()) return weeklyUsageCache.value;
-	weeklyUsageCache.expiresAt = Date.now() + WEEKLY_USAGE_CACHE_MS;
-	try {
-		weeklyUsageCache.value = codexWeeklyUsageLeft(await fetchCodexUsage(ctx));
-	} catch {
-		// Keep the last successful value when usage is temporarily unavailable.
+export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsageSnapshot> {
+	const model = ctx.model;
+	if (!model) throw new Error("No active model selected.");
+	if (model.provider !== "openai-codex") {
+		throw new Error("Codex usage is only available for OpenAI Codex subscription models.");
 	}
-	return weeklyUsageCache.value;
+	const headers = await buildCodexUsageHeaders(ctx, model);
+	return fetchCodexUsageWithHeaders(headers, ctx.signal);
+}
+
+export async function fetchCodexWeeklyUsageLeft(ctx: ExtensionContext): Promise<number | undefined> {
+	const model = ctx.model;
+	if (!model || model.provider !== "openai-codex") return undefined;
+	let key: string | undefined;
+	let previous: number | undefined;
+	try {
+		const headers = await buildCodexUsageHeaders(ctx, model);
+		key = usageCacheKey(headers);
+		if (key && weeklyUsageCache?.key === key && weeklyUsageCache.expiresAt > Date.now())
+			return weeklyUsageCache.value;
+		previous = key && weeklyUsageCache?.key === key ? weeklyUsageCache.value : undefined;
+		const value = codexWeeklyUsageLeft(
+			await fetchCodexUsageWithHeaders(headers, ctx.signal, false),
+		);
+		if (key) weeklyUsageCache = { key, value, expiresAt: Date.now() + WEEKLY_USAGE_CACHE_MS };
+		return value;
+	} catch {
+		if (key) weeklyUsageCache = { key, value: previous, expiresAt: Date.now() + WEEKLY_USAGE_CACHE_MS };
+		return previous;
+	}
 }
 
 export function createCodexRateLimitResetRedeemRequestId(): string {

--- a/packages/pi-codex-conversion/src/usage.ts
+++ b/packages/pi-codex-conversion/src/usage.ts
@@ -58,7 +58,11 @@ export interface CodexRateLimitResetConsumeResult {
 }
 
 let resetCreditsCache: { key: string; expiresAt: number; promise: Promise<CodexRateLimitResetCredits | undefined> } | undefined;
-let weeklyUsageCache: { key: string; value?: number | undefined; expiresAt: number } | undefined;
+const weeklyUsageCache = new Map<string, {
+	value?: number | undefined;
+	expiresAt: number;
+	promise?: Promise<number | undefined> | undefined;
+}>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -263,27 +267,47 @@ export async function fetchCodexUsage(ctx: ExtensionContext): Promise<CodexUsage
 export async function fetchCodexWeeklyUsageLeft(ctx: ExtensionContext): Promise<number | undefined> {
 	const model = ctx.model;
 	if (!model || model.provider !== "openai-codex") return undefined;
-	let key: string | undefined;
-	let previous: number | undefined;
+	const timeoutSignal = AbortSignal.timeout(WEEKLY_USAGE_TIMEOUT_MS);
+	const signal = ctx.signal
+		? AbortSignal.any([ctx.signal, timeoutSignal])
+		: timeoutSignal;
 	try {
-		const headers = await buildCodexUsageHeaders(ctx, model);
-		key = usageCacheKey(headers);
-		if (key && weeklyUsageCache?.key === key && weeklyUsageCache.expiresAt > Date.now())
-			return weeklyUsageCache.value;
-		previous = key && weeklyUsageCache?.key === key ? weeklyUsageCache.value : undefined;
-		const timeoutSignal = AbortSignal.timeout(WEEKLY_USAGE_TIMEOUT_MS);
-		const signal = ctx.signal
-			? AbortSignal.any([ctx.signal, timeoutSignal])
-			: timeoutSignal;
-		const value = codexWeeklyUsageLeft(
-			await fetchCodexUsageWithHeaders(headers, signal, false),
-		);
-		if (key) weeklyUsageCache = { key, value, expiresAt: Date.now() + WEEKLY_USAGE_CACHE_MS };
-		return value;
+		const headers = await withAbort(buildCodexUsageHeaders(ctx, model), signal);
+		const key = usageCacheKey(headers);
+		if (!key) return undefined;
+		const cached = weeklyUsageCache.get(key);
+		if (cached?.expiresAt && cached.expiresAt > Date.now()) return cached.value;
+		if (cached?.promise) return cached.promise;
+		const entry = cached ?? { expiresAt: 0 };
+		const previous = entry.value;
+		const promise = (async () => {
+			try {
+				entry.value = codexWeeklyUsageLeft(
+					await fetchCodexUsageWithHeaders(headers, signal, false),
+				);
+			} catch {
+				entry.value = previous;
+			} finally {
+				entry.expiresAt = Date.now() + WEEKLY_USAGE_CACHE_MS;
+				entry.promise = undefined;
+			}
+			return entry.value;
+		})();
+		entry.promise = promise;
+		weeklyUsageCache.set(key, entry);
+		return promise;
 	} catch {
-		if (key) weeklyUsageCache = { key, value: previous, expiresAt: Date.now() + WEEKLY_USAGE_CACHE_MS };
-		return previous;
+		return undefined;
 	}
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) return Promise.reject(signal.reason);
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(signal.reason);
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+	});
 }
 
 export function createCodexRateLimitResetRedeemRequestId(): string {
@@ -315,7 +339,12 @@ export async function consumeCodexRateLimitResetCredit(ctx: ExtensionContext, re
 	const text = await response.text();
 	if (!response.ok) throw new Error(`Reset request failed (${response.status}): ${text || response.statusText}`);
 	resetCreditsCache = undefined;
-	return parseCodexRateLimitResetConsumePayload(JSON.parse(text));
+	const result = parseCodexRateLimitResetConsumePayload(JSON.parse(text));
+	if (result.outcome === "reset" || result.outcome === "already_redeemed") {
+		const key = usageCacheKey(headers);
+		if (key) weeklyUsageCache.delete(key);
+	}
+	return result;
 }
 
 function formatReset(timestampSeconds: number | undefined): string {

--- a/packages/pi-codex-conversion/tests/usage.test.ts
+++ b/packages/pi-codex-conversion/tests/usage.test.ts
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+	codexWeeklyUsageLeft,
 	parseCodexRateLimitResetCreditsPayload,
 	parseCodexUsagePayload,
-} from "../src/ui/settings/usage.ts";
+} from "../src/usage.ts";
+import { buildStatusText } from "../src/adapter/activation/tool-set.ts";
 
 test("usage parser reads reset-credit summary", () => {
 	const snapshot = parseCodexUsagePayload({
@@ -15,6 +17,23 @@ test("usage parser reads reset-credit summary", () => {
 	});
 
 	assert.equal(snapshot.resetCredits?.availableCount, 2);
+});
+
+test("usage parser exposes weekly remaining percentage", () => {
+	const snapshot = parseCodexUsagePayload({
+		rate_limit: {
+			primary_window: { used_percent: 3, limit_window_seconds: 7 * 24 * 60 * 60 },
+		},
+	});
+
+	assert.equal(codexWeeklyUsageLeft(snapshot), 97);
+	assert.equal(
+		buildStatusText(
+			{ fast: false, useOnAllModels: false, weeklyUsageLeft: 97 },
+			{ fg: (role, text) => `<${role}>${text}</${role}>` },
+		),
+		"<accent>Codex adapter</accent><dim> • weekly: 97% left</dim>",
+	);
 });
 
 test("reset-credit parser normalizes the standalone API payload", () => {

--- a/packages/pi-codex-conversion/tests/usage.test.ts
+++ b/packages/pi-codex-conversion/tests/usage.test.ts
@@ -1,11 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-	codexWeeklyUsageLeft,
 	parseCodexRateLimitResetCreditsPayload,
 	parseCodexUsagePayload,
 } from "../src/usage.ts";
-import { buildStatusText } from "../src/adapter/activation/tool-set.ts";
 
 test("usage parser reads reset-credit summary", () => {
 	const snapshot = parseCodexUsagePayload({
@@ -17,23 +15,6 @@ test("usage parser reads reset-credit summary", () => {
 	});
 
 	assert.equal(snapshot.resetCredits?.availableCount, 2);
-});
-
-test("usage parser exposes weekly remaining percentage", () => {
-	const snapshot = parseCodexUsagePayload({
-		rate_limit: {
-			primary_window: { used_percent: 3, limit_window_seconds: 7 * 24 * 60 * 60 },
-		},
-	});
-
-	assert.equal(codexWeeklyUsageLeft(snapshot), 97);
-	assert.equal(
-		buildStatusText(
-			{ fast: false, useOnAllModels: false, weeklyUsageLeft: 97 },
-			{ fg: (role, text) => `<${role}>${text}</${role}>` },
-		),
-		"<accent>Codex adapter</accent><dim> • weekly: 97% left</dim>",
-	);
 });
 
 test("reset-credit parser normalizes the standalone API payload", () => {

--- a/packages/pi-codex-conversion/tests/usage.test.ts
+++ b/packages/pi-codex-conversion/tests/usage.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
 	parseCodexRateLimitResetCreditsPayload,
 	parseCodexUsagePayload,
-} from "../src/usage.ts";
+} from "../src/codex-usage/payload.ts";
 
 test("usage parser reads reset-credit summary", () => {
 	const snapshot = parseCodexUsagePayload({


### PR DESCRIPTION
This PR shows remaining weekly Codex subscription usage in the native statusline.

## Summary

- derive the remaining percentage from the primary seven-day usage window
- refresh lazily at session start, model changes, and completed agent turns with a five-minute account-scoped cache
- skip hidden statuslines and keep usage requests off lifecycle critical paths
- preserve Christian Tanul (@scriptogre) as the author of the imported patch commit
- cull one status-copy feature test from the submitted patch

## Validation

- Full stack: `bun run check:changed`
- Full stack: `bun run changeset:check`
- Tests culled: one

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`

Closes #257
