### PR TITLE
Teach GitHub skills collaborator-owned stacks

### DIFF
--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -17,6 +17,16 @@ description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/wor
 - Do not create unrelated GitHub side effects. Filing an issue does not authorize implementation.
 - Never use plain `--force`. Use `--force-with-lease` only for a branch whose rewrite is clearly intended and safe.
 
+## Contributor identity and ownership
+
+Before the first commit or push, verify `gh api user --jq .login`, `git config user.name`, and `git config user.email`. Do not silently switch accounts or attribute collaborator work to the repository owner.
+
+- If the checkout's branch or dirty state belongs to another task, create a dedicated worktree and focused branch from fetched `origin/main`.
+- A collaborator with push permission uses a focused branch on `origin` and opens the PR as themself. Use a fork only when the repository does not grant branch push access.
+- Preserve imported authorship: cherry-pick supplied commits where possible; otherwise retain their author metadata. New integration, repair, release, and documentation commits use the active contributor identity.
+- The PR author may update but not approve their own work. Surface known product choices under `Review focus`; an eligible maintainer owns approval and explicit merge direction.
+- If protection requires another identity, report the boundary rather than switching accounts to bypass it.
+
 ## Route the request
 
 ### File or update an issue
@@ -28,7 +38,7 @@ description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/wor
 
 ### Implement work and open a PR
 
-1. Establish a clean focused branch from current `main`, unless the current branch is already dedicated to the work.
+1. Establish a clean focused branch from fetched `origin/main`, unless the current branch is already dedicated to the work.
 2. Implement only the agreed scope and run validation chosen from the changed surface.
 3. Before final submission, apply the verification cull below to every added or changed test.
 4. For shipped package work, read `references/release-and-repository-hygiene.md` before finalizing release artifacts.
@@ -45,15 +55,15 @@ Dispatch is a handoff, not a supervision loop:
 2. Fetch `origin/main` once and record its SHA. In a dedicated coordinator worktree at that base, run `gh stack init --base main <issue-branch-1> <issue-branch-2> ...` to create and track every worker branch in stack order before implementation starts. Do not create sibling branches and retrofit them later.
 3. Detach the coordinator worktree to free the stack's current branch. Check out each tracked stack branch into its own worker worktree under a sibling root such as `<repo-parent>/.worktrees/<repo>/issue-123`.
 4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per worktree, label it with the issue number and short title, and launch a named Pi session with `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr's JSON; do not guess IDs.
-5. Give each worker this ownership contract: read the issue and repository instructions; implement only that issue directly on the assigned stack branch; run focused validation; cull weak tests; commit all intended work; do not push, open a PR, add a changeset, run the umbrella gate, invoke `gh stack`, or touch another worktree. If blocked, ask in this panel and wait for the user. When finished, report commit SHA, changed surface, checks, and risks, then remain idle.
+5. Give each worker this ownership contract: read the issue and repository instructions; implement only that issue directly on the assigned stack branch; add its changeset for shipped package work; run focused validation; cull weak tests; commit all intended work; do not push, open a PR, run the umbrella gate, invoke `gh stack`, or touch another worktree. If blocked, ask in this panel and wait for the user. When finished, report commit SHA, changed surface, checks, and risks, then remain idle.
 6. Return the issue → branch → worktree → Herdr workspace/pane map and stop. Do not wait for, read, message, steer, review, or decide readiness for dispatched agents. Resume only after an explicit user signal such as “workers X, Y, Z are ready.”
 
 ### Resume a dispatched issue batch
 
 1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready worktrees and commits. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
 2. Stop the ready panels and detach or remove their clean worktrees so Git can rewrite the checked-out branches. In the coordinator worktree, check out a stack branch, run the cascading `gh stack rebase`, resolve integration conflicts in the owning layer, and verify the complete order with `gh stack view --json`.
-3. From the top worker branch, run `gh stack add <batch-release-branch>`. This top branch is the batch PR. Add patch-autodetected `bun changeset -- "<combined release summary>"` there so the stack carries one release artifact, then apply the verification cull across the complete stack and run the umbrella gate once from the release layer.
-4. Run `gh stack submit --auto` to create draft native PRs and the stack object on GitHub.com. Verify the GitHub stack map, then edit every PR's title, body, issue linkage, base, and order. Use `Closes` only where the layer fully resolves its issue. Invoke configured review systems on each focused layer.
+3. From the top worker branch, run `gh stack add <batch-release-branch>`. This top branch is the single batch merge target; use an empty commit when it has no integration change. Verify each shipped package layer owns its changeset, then apply the verification cull across the complete stack and run the umbrella gate once from the release layer.
+4. Run `gh stack submit --auto --open` to create native PRs and the stack object on GitHub.com. Verify the GitHub stack map, then edit every PR's title, body, issue linkage, base, and order. Use `Closes` only where the layer fully resolves its issue. Invoke configured review systems on each focused layer.
 5. Return the layer → PR map and stop again. Dispatch review-fix workers only when the user asks; each fix wave follows the same launch-and-handoff boundary. After the user declares review converged, rebase and push the affected upstack, run `gh stack submit --auto --open`, and report readiness.
 6. Merge only on explicit user direction. Confirm every layer is approved and green and the target does not require a merge queue, then directly merge the top with `gh stack merge <top-pr> --yes` and the repository's merge method. Verify the atomic `main` landing and release workflow; until one live batch confirms event behavior, do not claim the one-run release property as measured fact.
 

--- a/.pi/skills/gh-issue-pr-flow/references/release-and-repository-hygiene.md
+++ b/.pi/skills/gh-issue-pr-flow/references/release-and-repository-hygiene.md
@@ -7,6 +7,7 @@ Read this reference only for shipped package work, release readiness, package ch
 - Workspace packages live under `packages/*` and remain separately installable.
 - Release tooling is Changesets. Do not manually bump package versions for normal feature or fix work.
 - Add a changeset when a change is meant to ship. Select only directly changed individual packages; patch is the normal fix/refinement bump.
+- In a release stack, each shipping layer owns its changeset; the top batch cap does not combine them. Multiple patch entries for one package coalesce into one version bump.
 - Do not manually add changesets or edit versions for aggregate packages: `@howaboua/pi-skills`, `@howaboua/pi-extensions`, or `@howaboua/pi-stuff`.
 - CI derives aggregate changesets with `bun run changeset:aggregates`.
 - Treat pending changesets on long-lived branches as suspect. Keep only changesets for changes intentionally present in the branch; remove files already consumed by `origin/main` release commits.

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -22,6 +22,10 @@ trunk; `down` moves toward it.
 - Repository instructions and explicit user direction override this skill.
 - **Never merge a stack without explicit user approval.** Readiness, green checks, or a prior submit
   request is not merge authorization.
+- Before creating or adopting a stack, verify the GitHub and Git author identities and isolate any
+  checkout already owned by another task. A collaborator authors and pushes the stack as themself.
+- The stack author does not approve their own PRs or switch identity to bypass protection. Surface known
+  choices in each PR's review focus; an eligible maintainer owns approval and explicit merge direction.
 - Stacks are linear. A layer may represent a code dependency or one bounded issue in an explicitly
   shared release batch. Keep work outside that release unit in another stack or PR.
 - Create the chain before implementation. Put each change on the lowest layer that owns it; edit a
@@ -70,7 +74,7 @@ gh stack init --base <trunk> <bottom-branch>
 # edit, validate, stage deliberately, commit
 gh stack add <next-branch>
 # repeat
-gh stack submit --auto
+gh stack submit --auto --open
 gh stack view --json
 ```
 
@@ -84,10 +88,10 @@ gh stack init --base <trunk> <issue-branch-1> <issue-branch-2> <issue-branch-3>
 order. Inspect existing ancestry first. Use ordinary `git add` and `git commit` so each branch owns
 only its concern.
 
-`submit --auto` pushes active branches, creates missing PRs as drafts, updates existing PRs where
-possible, and links them into a GitHub stack. Read its warnings. Add `--open` only when PRs should
-leave draft state, and use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic;
-rerun it after a partial failure.
+`submit --auto --open` pushes active branches, creates or opens PRs, updates existing PRs where
+possible, and links them into a GitHub stack. Omit `--open` only when drafts were explicitly requested.
+Use `gh pr edit` afterward for custom titles and bodies. Submit is not atomic; rerun it after a partial
+failure.
 
 ## Edit a lower layer
 


### PR DESCRIPTION
This PR teaches the repository's GitHub skills to preserve contributor identity while maintainers retain review and merge ownership.

## Summary

- verify GitHub and Git authorship before contributor work
- isolate occupied checkouts in dedicated worktrees
- preserve imported commit authorship and use collaborator-owned origin branches
- prevent PR authors from approving themselves or switching identity around protection
- keep changesets atomic in their shipping stack layers
- open normal stacked PRs by default and use an empty release cap as the single merge target

## Validation

- both skill efficiency checks: no issues or warnings
- `bun run check:changed`: no changed workspace packages

## Release

- Changeset: no
- Packages: none
