### PR TITLE
Show voice startup progress and greet on connection

### DIFF
--- a/.changeset/voice-startup-feedback.md
+++ b/.changeset/voice-startup-feedback.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-conversion": patch
+"@howaboua/pi-gippity-control": patch
+---
+
+Show voice context summarization progress, greet the user when a fresh realtime session becomes ready, and warn in Pi and the LAN controller when detectable microphone input remains too quiet.

--- a/packages/pi-codex-conversion/src/voice/context.ts
+++ b/packages/pi-codex-conversion/src/voice/context.ts
@@ -12,6 +12,7 @@ import { REALTIME_DELEGATION_MESSAGE_TYPE } from "./ui.ts";
 
 const VOICE_CONTEXT_SYSTEM_PROMPT = `Summarize the current Pi conversation for a realtime voice assistant joining the same session. Preserve the user's goal, relevant preferences, decisions, current state, unresolved questions, and next step. Treat the conversation as history: do not continue its work or answer it. Return only the self-contained continuity summary.`;
 const VOICE_CONTEXT_REQUEST = "Create the voice continuity summary now.";
+const VOICE_START_GREETING_REQUEST = "The voice session has started. Greet the user briefly and naturally, then wait for them to speak.";
 const VOICE_STARTUP_CONTEXT_HEADER = `Startup context from Pi.
 This is background context from the current Pi conversation before realtime voice started. It may be summarized. Use it to answer questions about the earlier conversation, and do not repeat it unless relevant.`;
 const SUMMARIZABLE_CUSTOM_TYPES = new Set([
@@ -33,37 +34,55 @@ export interface RealtimeInitialMessageItem {
 export async function buildRealtimeInitialItems(args: {
 	ctx: ExtensionContext;
 	config: CodexConversionConfig;
+	greet?: boolean | undefined;
 	onSummary?: ((summary: string) => void) | undefined;
+	onSummaryStatus?: ((active: boolean) => void) | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<RealtimeInitialMessageItem[] | undefined> {
 	const selected = args.config.voice.contextModel;
-	if (!selected) return undefined;
-	const reasoning = args.config.voice.contextReasoning;
-	const cacheKey = voiceContextCacheKey(args.ctx, selected, reasoning);
-	let text = summaryCache.get(cacheKey);
-	if (!text) {
-		const generated = await createVoiceContextSummary(
-			args.ctx,
-			selected,
-			reasoning,
-			args.signal,
-		);
-		if (!generated) return undefined;
-		text = generated;
-		if (cacheKey === voiceContextCacheKey(args.ctx, selected, reasoning)) {
-			summaryCache.set(cacheKey, text);
-			while (summaryCache.size > SUMMARY_CACHE_LIMIT)
-				summaryCache.delete(summaryCache.keys().next().value!);
+	const initialItems: RealtimeInitialMessageItem[] = [];
+	if (selected) {
+		const reasoning = args.config.voice.contextReasoning;
+		const cacheKey = voiceContextCacheKey(args.ctx, selected, reasoning);
+		let text = summaryCache.get(cacheKey);
+		if (!text) {
+			args.onSummaryStatus?.(true);
+			try {
+				const generated = await createVoiceContextSummary(
+					args.ctx,
+					selected,
+					reasoning,
+					args.signal,
+				);
+				if (generated) {
+					text = generated;
+					if (cacheKey === voiceContextCacheKey(args.ctx, selected, reasoning)) {
+						summaryCache.set(cacheKey, text);
+						while (summaryCache.size > SUMMARY_CACHE_LIMIT)
+							summaryCache.delete(summaryCache.keys().next().value!);
+					}
+				}
+			} finally {
+				args.onSummaryStatus?.(false);
+			}
+		}
+		if (text) {
+			args.onSummary?.(text);
+			initialItems.push({
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: renderVoiceStartupContext(text) }],
+			});
 		}
 	}
-	args.onSummary?.(text);
-	return [
-		{
+	if (args.greet) {
+		initialItems.push({
 			type: "message",
-			role: "developer",
-			content: [{ type: "input_text", text: renderVoiceStartupContext(text) }],
-		},
-	];
+			role: "user",
+			content: [{ type: "input_text", text: VOICE_START_GREETING_REQUEST }],
+		});
+	}
+	return initialItems.length > 0 ? initialItems : undefined;
 }
 
 function renderVoiceStartupContext(summary: string): string {

--- a/packages/pi-codex-conversion/src/voice/controller-sessions.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-sessions.ts
@@ -32,6 +32,7 @@ export async function startControllerConversation(options: {
 	instructions: string;
 	initialItems?: RealtimeInitialMessageItem[] | undefined;
 	inputMuted?: boolean | undefined;
+	greet?: boolean | undefined;
 	peer?: CodexRealtimePeer | undefined;
 	signal?: AbortSignal | undefined;
 	lifecycle: RealtimeSessionLifecycle;
@@ -68,6 +69,11 @@ export async function startControllerConversation(options: {
 	if (options.lifecycle.isCurrent(session)) {
 		session.markEstablished();
 		options.lifecycle.onActive(session);
+		if (options.greet) {
+			setTimeout(() => {
+				if (options.lifecycle.isCurrent(session)) session.greet();
+			}, 0).unref?.();
+		}
 	}
 	else await session.close();
 }

--- a/packages/pi-codex-conversion/src/voice/controller-start.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-start.ts
@@ -34,6 +34,7 @@ export interface VoiceControllerRuntime {
 	startGeneration: number;
 	startAbortController?: AbortController | undefined;
 	voiceStatus: string;
+	inputTooQuiet: boolean;
 	realtimePeerPlan?: RealtimePeerPlan | undefined;
 }
 
@@ -91,8 +92,12 @@ export async function startControllerMode(options: {
 					? buildRealtimeInitialItems({
 							ctx: options.ctx,
 							config: options.config,
+							greet: !options.resume,
 							onSummary: (summary) => {
 								realtimeSummary = summary;
+							},
+							onSummaryStatus: (active) => {
+								options.onStatus(active ? "summarizing…" : "connecting…");
 							},
 							signal: startSignal,
 						})
@@ -173,6 +178,7 @@ async function startConversation(
 		instructions,
 		initialItems,
 		inputMuted: options.inputMuted,
+		greet: !options.resume,
 		peer,
 		signal,
 		lifecycle: {
@@ -257,6 +263,7 @@ function cancelStart(
 	runtime.config = undefined;
 	runtime.realtimePeerPlan = undefined;
 	runtime.voiceStatus = "";
+	runtime.inputTooQuiet = false;
 	runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 }
 

--- a/packages/pi-codex-conversion/src/voice/controller-start.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-start.ts
@@ -24,6 +24,7 @@ export interface RealtimePeerPlan {
 	createPeer(): CodexRealtimePeer;
 	onActive?(session: CodexRealtimeConversation, peer: CodexRealtimePeer): void;
 	onInactive?(session: CodexRealtimeConversation, error: Error, resuming: boolean): void;
+	onStatus?(status: string): void;
 }
 
 export interface VoiceControllerRuntime {
@@ -82,7 +83,16 @@ export async function startControllerMode(options: {
 		options.mode === "realtime"
 			? { type: "connecting", mode: "realtime", phase: "authorizing" }
 			: { type: "connecting", mode: "dictation", phase: "authorizing" };
-	options.onStatus("connecting…");
+	const setStartupStatus = (status: string) => {
+		if (
+			startGeneration !== runtime.startGeneration ||
+			runtime.startAbortController !== startAbortController ||
+			runtime.state.type !== "connecting"
+		) return;
+		options.onStatus(status);
+		options.realtimePeerPlan?.onStatus?.(status);
+	};
+	setStartupStatus("connecting…");
 	let realtimeSummary: string | undefined;
 	try {
 		const startup = await interruptible(
@@ -97,7 +107,7 @@ export async function startControllerMode(options: {
 								realtimeSummary = summary;
 							},
 							onSummaryStatus: (active) => {
-								options.onStatus(active ? "summarizing…" : "connecting…");
+								setStartupStatus(active ? "summarizing…" : "connecting…");
 							},
 							signal: startSignal,
 						})

--- a/packages/pi-codex-conversion/src/voice/controller-support.ts
+++ b/packages/pi-codex-conversion/src/voice/controller-support.ts
@@ -45,8 +45,9 @@ export function prepareRealtimeVoicePrompt(ctx: ExtensionContext): string | unde
 	}
 }
 
-export function renderVoiceStatus(ctx: ExtensionContext | undefined, status: string, muted: boolean): void {
+export function renderVoiceStatus(ctx: ExtensionContext | undefined, status: string, muted: boolean, inputTooQuiet: boolean): void {
 	if (!ctx || !status) return;
 	const mute = muted ? ctx.ui.theme.fg("warning", " · mic muted") : "";
-	ctx.ui.setStatus(VOICE_STATUS_KEY, `${ctx.ui.theme.fg("accent", `voice: ${status}`)}${mute}`);
+	const level = !muted && inputTooQuiet ? ctx.ui.theme.fg("warning", " · mic too quiet") : "";
+	ctx.ui.setStatus(VOICE_STATUS_KEY, `${ctx.ui.theme.fg("accent", `voice: ${status}`)}${mute}${level}`);
 }

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -92,7 +92,10 @@ export class CodexVoiceController {
 		return true;
 	}
 	setInputTooQuiet(inputTooQuiet: boolean): void {
-		const next = this.runtime.state.type === "conversation" && inputTooQuiet;
+		const receivesInput =
+			this.runtime.state.type === "conversation" ||
+			this.runtime.state.type === "reconnecting";
+		const next = receivesInput && inputTooQuiet;
 		if (this.runtime.inputTooQuiet === next) return;
 		this.runtime.inputTooQuiet = next;
 		this.renderCurrentStatus();

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -94,7 +94,8 @@ export class CodexVoiceController {
 	setInputTooQuiet(inputTooQuiet: boolean): void {
 		const receivesInput =
 			this.runtime.state.type === "conversation" ||
-			this.runtime.state.type === "reconnecting";
+			this.runtime.state.type === "reconnecting" ||
+			this.runtime.state.type === "connecting";
 		const next = receivesInput && inputTooQuiet;
 		if (this.runtime.inputTooQuiet === next) return;
 		this.runtime.inputTooQuiet = next;

--- a/packages/pi-codex-conversion/src/voice/controller.ts
+++ b/packages/pi-codex-conversion/src/voice/controller.ts
@@ -29,6 +29,7 @@ export class CodexVoiceController {
 		state: { type: "idle" },
 		startGeneration: 0,
 		voiceStatus: "",
+		inputTooQuiet: false,
 	};
 	private readonly messages: CodexVoiceSessionMessages;
 	private readonly inputMuteListeners = new Set<(muted: boolean) => void>();
@@ -89,6 +90,12 @@ export class CodexVoiceController {
 			for (const listener of this.inputMuteListeners) listener(current);
 		}
 		return true;
+	}
+	setInputTooQuiet(inputTooQuiet: boolean): void {
+		const next = this.runtime.state.type === "conversation" && inputTooQuiet;
+		if (this.runtime.inputTooQuiet === next) return;
+		this.runtime.inputTooQuiet = next;
+		this.renderCurrentStatus();
 	}
 	resetContextAnnouncements(): void {
 		this.messages.resetContextAnnouncements();
@@ -197,6 +204,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		await closePromise;
 		this.messages.cancelPendingDelegations();
@@ -231,6 +239,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.messages.voiceStopped(endedMode);
 	}
@@ -299,6 +308,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.runtime.context?.ui.notify(message, "error");
 		if (wasMuted)
@@ -406,6 +416,7 @@ export class CodexVoiceController {
 			this.runtime.context,
 			this.runtime.voiceStatus,
 			this.inputMuted,
+			this.runtime.inputTooQuiet,
 		);
 	}
 }

--- a/packages/pi-codex-conversion/src/voice/conversation/session.ts
+++ b/packages/pi-codex-conversion/src/voice/conversation/session.ts
@@ -99,6 +99,15 @@ export class CodexRealtimeConversation {
 		if (this.state === "active") this.established = true;
 	}
 
+	greet(): void {
+		if (this.state !== "active") return;
+		try {
+			this.peer.sendData({ type: "response.create" });
+		} catch (error) {
+			this.fail(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
 	activateDelegation(id: string): void {
 		this.handoff.activate(id);
 	}

--- a/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
@@ -14,12 +14,18 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
   let mode = 'conversation';
   let active = false;
   let muted = false;
+  let inputTooQuiet = false;
   let busy = false;
   let finishingDictation = false;
   let starting = false;
   let startGeneration = 0;
 
   const setStatus = (title, message = '') => { audioState.textContent = title; audioDetail.textContent = message; };
+  const renderConversationStatus = () => {
+    if (!active || mode !== 'conversation') return;
+    if (muted) setStatus('Microphone muted', 'Voice remains connected');
+    else setStatus('Listening', inputTooQuiet ? 'Microphone level is too low' : 'Tap to stop');
+  };
   const updateControls = () => {
     button.disabled = false;
     button.setAttribute('aria-busy', String(busy));
@@ -35,7 +41,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
     muteButton.setAttribute('aria-label', muted ? 'Unmute microphone' : 'Mute microphone');
     muteButton.lastElementChild.textContent = muted ? 'Unmute mic' : 'Mute mic';
     if (notify && socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify({ type:'mute', muted }));
-    if (active) setStatus(muted ? 'Microphone muted' : 'Listening', muted ? 'Voice remains connected' : 'Tap to stop');
+    renderConversationStatus();
     updateControls();
   };
   const closeHardware = () => {
@@ -70,6 +76,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
     }
     active = false;
     muted = false;
+    inputTooQuiet = false;
     muteButton.setAttribute('aria-pressed', 'false');
     finishingDictation = false;
     const currentSocket = socket;
@@ -105,6 +112,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
         button.setAttribute('aria-pressed', 'true');
         button.setAttribute('aria-label', mode === 'dictation' ? 'Finish dictation' : 'Stop voice');
         if (mode === 'conversation') {
+          inputTooQuiet = false;
           if (typeof message.muted === 'boolean') muted = message.muted;
           realtimeAudio?.releaseInput();
         }
@@ -225,6 +233,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       if (command.type === 'stop') stop(false, command.reason || 'server');
       if (command.type === 'error') { stop(false, 'server-error'); setStatus('Voice stopped', command.message); }
       if (command.type === 'mute') setMuted(command.muted, false);
+      if (command.type === 'microphone') { inputTooQuiet = command.state === 'too-quiet'; renderConversationStatus(); }
     },
     pagehide() {
       stream?.getTracks().forEach((track) => track.stop());

--- a/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
@@ -105,6 +105,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       const message = JSON.parse(event.data);
 	  if (message.type === 'stop') { stop(false, message.reason || 'server'); return; }
 	  if (message.type === 'mute') setMuted(message.muted, false);
+	  if (message.type === 'status' && busy && !active) setStatus(message.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (message.type === 'active') {
         active = true;
         busy = false;

--- a/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-audio-script.ts
@@ -105,7 +105,6 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       const message = JSON.parse(event.data);
 	  if (message.type === 'stop') { stop(false, message.reason || 'server'); return; }
 	  if (message.type === 'mute') setMuted(message.muted, false);
-	  if (message.type === 'status' && busy && !active) setStatus(message.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (message.type === 'active') {
         active = true;
         busy = false;
@@ -234,6 +233,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       if (command.type === 'stop') stop(false, command.reason || 'server');
       if (command.type === 'error') { stop(false, 'server-error'); setStatus('Voice stopped', command.message); }
       if (command.type === 'mute') setMuted(command.muted, false);
+	  if (command.type === 'status' && busy && !active) setStatus(command.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (command.type === 'microphone') { inputTooQuiet = command.state === 'too-quiet'; renderConversationStatus(); }
     },
     pagehide() {

--- a/packages/pi-codex-conversion/src/voice/lan/browser-clients.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-clients.ts
@@ -38,6 +38,10 @@ export class LanVoiceBrowserClients {
 		this.session.sendConversationAudio(pcm);
 	}
 
+	resetConversationInputLevel(): void {
+		this.session.resetConversationInputLevel();
+	}
+
 	release(clientId: string, socket?: WebSocket, terminateConversation = false): void {
 		this.session.release(clientId, socket, terminateConversation);
 	}

--- a/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
@@ -18,6 +18,7 @@ export interface LanVoiceBrowserClientsOptions {
 	onConversationActivity(active: boolean): void | Promise<void>;
 	onConversationMute(muted: boolean): void;
 	conversationMuted(): boolean;
+	onConversationInputTooQuiet(inputTooQuiet: boolean): void;
 	onConversationAudio(pcm: Buffer): void;
 	onDictationAudio(clientId: string, pcm: Buffer): void;
 }
@@ -28,10 +29,12 @@ export class LanVoiceBrowserSession {
 	private state: LanVoiceBrowserState = { type: "idle" };
 	private operation = Promise.resolve();
 	private conversationOwnerId: string | undefined;
+	private readonly microphoneLevel: MicrophoneLevelMonitor;
 
 	constructor(options: LanVoiceBrowserClientsOptions, connections: LanVoiceBrowserConnections) {
 		this.options = options;
 		this.connections = connections;
+		this.microphoneLevel = new MicrophoneLevelMonitor(options.onConversationInputTooQuiet);
 	}
 
 	get closed(): boolean { return this.state.type === "closed"; }
@@ -47,6 +50,7 @@ export class LanVoiceBrowserSession {
 			const active = this.state;
 			const ownsActive = active.type === "active" && active.clientId === clientId && (!socket || active.socket === socket);
 			if (ownsActive) this.state = { type: "idle" };
+			if (ownsActive && active.mode === "conversation") this.microphoneLevel.reset();
 			if (terminateConversation && this.conversationOwnerId === clientId) {
 				this.conversationOwnerId = undefined;
 				await this.options.onConversationActivity(false);
@@ -76,6 +80,7 @@ export class LanVoiceBrowserSession {
 			const previous = this.state.type === "active" ? this.state : undefined;
 			if (previous?.clientId === clientId && previous.socket === socket && previous.mode === mode) return;
 			this.state = { type: "idle" };
+			if (previous?.mode === "conversation") this.microphoneLevel.reset();
 			if (previous && previous.socket !== socket) {
 				this.connections.sendControl(previous.clientId, { type: "stop", reason: "replaced" });
 				previous.socket.close(4001, "replaced");
@@ -122,12 +127,16 @@ export class LanVoiceBrowserSession {
 	mute(clientId: string, socket: WebSocket, muted: boolean): void {
 		const active = this.state;
 		if (active.type === "active" && active.clientId === clientId && active.socket === socket && active.mode === "conversation") this.options.onConversationMute(muted);
+		if (muted) this.microphoneLevel.reset();
 	}
 
 	receiveAudio(clientId: string, socket: WebSocket, pcm: Buffer): void {
 		const active = this.state;
 		if (active.type !== "active" || active.clientId !== clientId || active.socket !== socket) return;
-		if (active.mode === "conversation") this.options.onConversationAudio(pcm);
+		if (active.mode === "conversation") {
+			this.microphoneLevel.append(pcm);
+			this.options.onConversationAudio(pcm);
+		}
 		else this.options.onDictationAudio(clientId, pcm);
 	}
 
@@ -152,5 +161,50 @@ export class LanVoiceBrowserSession {
 		const result = this.operation.then(action, action);
 		this.operation = result.then(() => undefined, () => undefined);
 		return result;
+	}
+}
+
+const MICROPHONE_RATE = 24_000;
+const DETECTABLE_PEAK = 82;
+const HEALTHY_PEAK = 655;
+
+class MicrophoneLevelMonitor {
+	private readonly onChange: (inputTooQuiet: boolean) => void;
+	private samples = 0;
+	private peak = 0;
+	private inputTooQuiet = false;
+
+	constructor(onChange: (inputTooQuiet: boolean) => void) {
+		this.onChange = onChange;
+	}
+
+	append(pcm: Buffer): void {
+		let framePeak = 0;
+		for (let offset = 0; offset + 1 < pcm.byteLength; offset += 2)
+			framePeak = Math.max(framePeak, Math.abs(pcm.readInt16LE(offset)));
+		if (framePeak >= HEALTHY_PEAK) {
+			this.samples = 0;
+			this.peak = 0;
+			this.set(false);
+			return;
+		}
+		this.samples += Math.floor(pcm.byteLength / 2);
+		this.peak = Math.max(this.peak, framePeak);
+		if (this.samples < MICROPHONE_RATE) return;
+		if (this.peak >= DETECTABLE_PEAK) this.set(true);
+		this.samples = 0;
+		this.peak = 0;
+	}
+
+	reset(): void {
+		this.samples = 0;
+		this.peak = 0;
+		this.set(false);
+	}
+
+	private set(inputTooQuiet: boolean): void {
+		if (this.inputTooQuiet === inputTooQuiet) return;
+		this.inputTooQuiet = inputTooQuiet;
+		this.onChange(inputTooQuiet);
 	}
 }

--- a/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
@@ -126,8 +126,10 @@ export class LanVoiceBrowserSession {
 
 	mute(clientId: string, socket: WebSocket, muted: boolean): void {
 		const active = this.state;
-		if (active.type === "active" && active.clientId === clientId && active.socket === socket && active.mode === "conversation") this.options.onConversationMute(muted);
-		if (muted) this.microphoneLevel.reset();
+		if (active.type === "active" && active.clientId === clientId && active.socket === socket && active.mode === "conversation") {
+			this.options.onConversationMute(muted);
+			if (muted) this.microphoneLevel.reset();
+		}
 	}
 
 	receiveAudio(clientId: string, socket: WebSocket, pcm: Buffer): void {

--- a/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/browser-session.ts
@@ -123,12 +123,12 @@ export class LanVoiceBrowserSession {
 	}
 
 	cancelDictation(clientId: string): Promise<void> { return this.options.cancelDictation(clientId); }
+	resetConversationInputLevel(): void { this.microphoneLevel.reset(); }
 
 	mute(clientId: string, socket: WebSocket, muted: boolean): void {
 		const active = this.state;
 		if (active.type === "active" && active.clientId === clientId && active.socket === socket && active.mode === "conversation") {
 			this.options.onConversationMute(muted);
-			if (muted) this.microphoneLevel.reset();
 		}
 	}
 

--- a/packages/pi-codex-conversion/src/voice/lan/server.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/server.ts
@@ -66,6 +66,7 @@ export async function startCodexLanVoiceServer(options: {
 		const abort = new AbortController();
 		let activated = false;
 		const plan: RealtimePeerPlan = {
+			onStatus: (status) => clients.broadcastControl({ type: "status", status }),
 			createPeer: () => {
 				let peer!: LanHostRealtimePeer;
 				peer = new LanHostRealtimePeer({

--- a/packages/pi-codex-conversion/src/voice/lan/server.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/server.ts
@@ -157,7 +157,10 @@ export async function startCodexLanVoiceServer(options: {
 		},
 		onDictationAudio: (clientId, pcm) => dictation.append(clientId, pcm),
 	});
-	const removeInputMuteListener = options.voice.onInputMuteChange((muted) => clients.broadcastControl({ type: "mute", muted }));
+	const removeInputMuteListener = options.voice.onInputMuteChange((muted) => {
+		if (muted) clients.resetConversationInputLevel();
+		clients.broadcastControl({ type: "mute", muted });
+	});
 
 	const server = createServer({ cert: certificate.cert, key: certificate.key }, (request, response) => {
 		void handleLanVoiceHttpRequest(request, response, {

--- a/packages/pi-codex-conversion/src/voice/lan/server.ts
+++ b/packages/pi-codex-conversion/src/voice/lan/server.ts
@@ -147,6 +147,10 @@ export async function startCodexLanVoiceServer(options: {
 		onConversationMute(muted) {
 			if (!options.voice.setInputMuted(muted)) throw new Error("Realtime voice is not active");
 		},
+		onConversationInputTooQuiet(inputTooQuiet) {
+			options.voice.setInputTooQuiet(inputTooQuiet);
+			clients.broadcastControl({ type: "microphone", state: inputTooQuiet ? "too-quiet" : "ok" });
+		},
 		onConversationAudio(pcm) {
 			activeConversation?.peer.sendAudio(pcm);
 		},

--- a/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
@@ -8,6 +8,7 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	let hostStarts = 0;
 	let hostConversation: object | undefined;
 	const received: Buffer[] = [];
+	const inputLevels: boolean[] = [];
 	const clients = testBrowserClients({
 		async ensureConversation() {
 			if (!hostConversation) {
@@ -18,6 +19,9 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 		onConversationAudio(pcm) {
 			received.push(pcm);
 		},
+		onConversationInputTooQuiet(inputTooQuiet) {
+			inputLevels.push(inputTooQuiet);
+		},
 		onConversationActivity(active) {
 			if (!active) hostConversation = undefined;
 		},
@@ -26,7 +30,9 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	clients.connectAudio("first", first.asWebSocket());
 	first.receive({ type: "start", mode: "conversation" });
 	await settle();
-	first.receiveBinary(Buffer.from([1, 0]));
+	const quietFrame = pcmFrame(100);
+	for (let frame = 0; frame < 50; frame += 1) first.receiveBinary(quietFrame);
+	first.receiveBinary(pcmFrame(1_000));
 	first.close();
 	await settle();
 
@@ -35,7 +41,8 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	second.receive({ type: "start", mode: "conversation" });
 	await settle();
 	assert.equal(hostStarts, 1);
-	assert.deepEqual(received, [Buffer.from([1, 0])]);
+	assert.equal(received.length, 51);
+	assert.deepEqual(inputLevels, [true, false]);
 	assert.deepEqual(
 		second.sent.map((value) => JSON.parse(value)),
 		[
@@ -55,6 +62,7 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 	const setup = Promise.withResolvers<void>();
 	let hostStarts = 0;
 	let sharedSetup: Promise<void> | undefined;
+	const inputLevels: boolean[] = [];
 	const clients = testBrowserClients({
 		ensureConversation() {
 			if (!sharedSetup) {
@@ -62,6 +70,9 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 				sharedSetup = setup.promise;
 			}
 			return sharedSetup;
+		},
+		onConversationInputTooQuiet(inputTooQuiet) {
+			inputLevels.push(inputTooQuiet);
 		},
 	});
 	const first = new TestWebSocket();
@@ -81,12 +92,20 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 		mode: "conversation",
 		muted: false,
 	});
+	const quietFrame = pcmFrame(100);
+	for (let frame = 0; frame < 50; frame += 1) second.receiveBinary(quietFrame);
+	const third = new TestWebSocket();
+	clients.connectAudio("third", third.asWebSocket());
+	third.receive({ type: "start", mode: "conversation" });
+	await settle();
+	assert.deepEqual(inputLevels, [true, false]);
 	await clients.close();
 });
 
 function testBrowserClients(overrides: {
 	ensureConversation(): Promise<void>;
 	onConversationActivity?(active: boolean): void | Promise<void>;
+	onConversationInputTooQuiet?(inputTooQuiet: boolean): void;
 	onConversationAudio?(pcm: Buffer): void;
 }): LanVoiceBrowserClients {
 	return new LanVoiceBrowserClients({
@@ -97,9 +116,18 @@ function testBrowserClients(overrides: {
 		onConversationActivity: overrides.onConversationActivity ?? (() => {}),
 		onConversationMute: () => {},
 		conversationMuted: () => false,
+		onConversationInputTooQuiet:
+			overrides.onConversationInputTooQuiet ?? (() => {}),
 		onConversationAudio: overrides.onConversationAudio ?? (() => {}),
 		onDictationAudio: () => {},
 	});
+}
+
+function pcmFrame(peak: number): Buffer {
+	const frame = Buffer.alloc(480 * 2);
+	for (let sample = 0; sample < 480; sample += 1)
+		frame.writeInt16LE(peak, sample * 2);
+	return frame;
 }
 
 class TestWebSocket extends EventEmitter {

--- a/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
@@ -32,7 +32,8 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	await settle();
 	const quietFrame = pcmFrame(100);
 	for (let frame = 0; frame < 50; frame += 1) first.receiveBinary(quietFrame);
-	first.receiveBinary(pcmFrame(1_000));
+	const healthyFrame = pcmFrame(1_000);
+	first.receiveBinary(healthyFrame);
 	first.close();
 	await settle();
 
@@ -42,6 +43,7 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	await settle();
 	assert.equal(hostStarts, 1);
 	assert.equal(received.length, 51);
+	assert.deepEqual(received.at(-1), healthyFrame);
 	assert.deepEqual(inputLevels, [true, false]);
 	assert.deepEqual(
 		second.sent.map((value) => JSON.parse(value)),

--- a/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
+++ b/packages/pi-codex-conversion/tests/voice-lan-browser.test.ts
@@ -8,7 +8,6 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	let hostStarts = 0;
 	let hostConversation: object | undefined;
 	const received: Buffer[] = [];
-	const inputLevels: boolean[] = [];
 	const clients = testBrowserClients({
 		async ensureConversation() {
 			if (!hostConversation) {
@@ -19,9 +18,6 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 		onConversationAudio(pcm) {
 			received.push(pcm);
 		},
-		onConversationInputTooQuiet(inputTooQuiet) {
-			inputLevels.push(inputTooQuiet);
-		},
 		onConversationActivity(active) {
 			if (!active) hostConversation = undefined;
 		},
@@ -30,10 +26,7 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	clients.connectAudio("first", first.asWebSocket());
 	first.receive({ type: "start", mode: "conversation" });
 	await settle();
-	const quietFrame = pcmFrame(100);
-	for (let frame = 0; frame < 50; frame += 1) first.receiveBinary(quietFrame);
-	const healthyFrame = pcmFrame(1_000);
-	first.receiveBinary(healthyFrame);
+	first.receiveBinary(Buffer.from([1, 0]));
 	first.close();
 	await settle();
 
@@ -42,9 +35,7 @@ test("LAN browser preserves handoff and restarts after explicit release", async 
 	second.receive({ type: "start", mode: "conversation" });
 	await settle();
 	assert.equal(hostStarts, 1);
-	assert.equal(received.length, 51);
-	assert.deepEqual(received.at(-1), healthyFrame);
-	assert.deepEqual(inputLevels, [true, false]);
+	assert.deepEqual(received, [Buffer.from([1, 0])]);
 	assert.deepEqual(
 		second.sent.map((value) => JSON.parse(value)),
 		[
@@ -64,7 +55,6 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 	const setup = Promise.withResolvers<void>();
 	let hostStarts = 0;
 	let sharedSetup: Promise<void> | undefined;
-	const inputLevels: boolean[] = [];
 	const clients = testBrowserClients({
 		ensureConversation() {
 			if (!sharedSetup) {
@@ -72,9 +62,6 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 				sharedSetup = setup.promise;
 			}
 			return sharedSetup;
-		},
-		onConversationInputTooQuiet(inputTooQuiet) {
-			inputLevels.push(inputTooQuiet);
 		},
 	});
 	const first = new TestWebSocket();
@@ -94,20 +81,12 @@ test("LAN browser takeover shares an in-progress host conversation setup", async
 		mode: "conversation",
 		muted: false,
 	});
-	const quietFrame = pcmFrame(100);
-	for (let frame = 0; frame < 50; frame += 1) second.receiveBinary(quietFrame);
-	const third = new TestWebSocket();
-	clients.connectAudio("third", third.asWebSocket());
-	third.receive({ type: "start", mode: "conversation" });
-	await settle();
-	assert.deepEqual(inputLevels, [true, false]);
 	await clients.close();
 });
 
 function testBrowserClients(overrides: {
 	ensureConversation(): Promise<void>;
 	onConversationActivity?(active: boolean): void | Promise<void>;
-	onConversationInputTooQuiet?(inputTooQuiet: boolean): void;
 	onConversationAudio?(pcm: Buffer): void;
 }): LanVoiceBrowserClients {
 	return new LanVoiceBrowserClients({
@@ -118,18 +97,10 @@ function testBrowserClients(overrides: {
 		onConversationActivity: overrides.onConversationActivity ?? (() => {}),
 		onConversationMute: () => {},
 		conversationMuted: () => false,
-		onConversationInputTooQuiet:
-			overrides.onConversationInputTooQuiet ?? (() => {}),
+		onConversationInputTooQuiet: () => {},
 		onConversationAudio: overrides.onConversationAudio ?? (() => {}),
 		onDictationAudio: () => {},
 	});
-}
-
-function pcmFrame(peak: number): Buffer {
-	const frame = Buffer.alloc(480 * 2);
-	for (let sample = 0; sample < 480; sample += 1)
-		frame.writeInt16LE(peak, sample * 2);
-	return frame;
 }
 
 class TestWebSocket extends EventEmitter {

--- a/packages/pi-gippity-control/src/voice/context.ts
+++ b/packages/pi-gippity-control/src/voice/context.ts
@@ -9,6 +9,8 @@ import { REALTIME_DELEGATION_MESSAGE_TYPE } from "./ui.ts";
 
 const VOICE_CONTEXT_SYSTEM_PROMPT = `Summarize the current Pi conversation for a realtime voice assistant joining the same session. Preserve the user's goal, relevant preferences, decisions, current state, unresolved questions, and next step. Treat the conversation as history: do not continue its work or answer it. Return only the self-contained continuity summary.`;
 const VOICE_CONTEXT_REQUEST = "Create the voice continuity summary now.";
+const VOICE_START_GREETING_REQUEST =
+	"The voice session has started. Greet the user briefly and naturally, then wait for them to speak.";
 const VOICE_STARTUP_CONTEXT_HEADER = `Startup context from Pi.
 This is background context from the current Pi conversation before realtime voice started. It may be summarized. Use it to answer questions about the earlier conversation, and do not repeat it unless relevant.`;
 
@@ -31,37 +33,59 @@ export interface RealtimeInitialMessageItem {
 export async function buildRealtimeInitialItems(args: {
 	ctx: ExtensionContext;
 	config: GippityControlConfig;
+	greet?: boolean | undefined;
 	onSummary?: ((summary: string) => void) | undefined;
+	onSummaryStatus?: ((active: boolean) => void) | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<RealtimeInitialMessageItem[] | undefined> {
 	const selected = args.config.voice.contextModel;
-	if (!selected) return undefined;
-	const reasoning = args.config.voice.contextReasoning;
-	const cacheKey = voiceContextCacheKey(args.ctx, selected, reasoning);
-	let text = summaryCache.get(cacheKey);
-	if (!text) {
-		const generated = await createVoiceContextSummary(
-			args.ctx,
-			selected,
-			reasoning,
-			args.signal,
-		);
-		if (!generated) return undefined;
-		text = generated;
-		if (cacheKey === voiceContextCacheKey(args.ctx, selected, reasoning)) {
-			summaryCache.set(cacheKey, text);
-			while (summaryCache.size > SUMMARY_CACHE_LIMIT)
-				summaryCache.delete(summaryCache.keys().next().value!);
+	const initialItems: RealtimeInitialMessageItem[] = [];
+	if (selected) {
+		const reasoning = args.config.voice.contextReasoning;
+		const cacheKey = voiceContextCacheKey(args.ctx, selected, reasoning);
+		let text = summaryCache.get(cacheKey);
+		if (!text) {
+			args.onSummaryStatus?.(true);
+			try {
+				const generated = await createVoiceContextSummary(
+					args.ctx,
+					selected,
+					reasoning,
+					args.signal,
+				);
+				if (generated) {
+					text = generated;
+					if (
+						cacheKey === voiceContextCacheKey(args.ctx, selected, reasoning)
+					) {
+						summaryCache.set(cacheKey, text);
+						while (summaryCache.size > SUMMARY_CACHE_LIMIT)
+							summaryCache.delete(summaryCache.keys().next().value!);
+					}
+				}
+			} finally {
+				args.onSummaryStatus?.(false);
+			}
+		}
+		if (text) {
+			args.onSummary?.(text);
+			initialItems.push({
+				type: "message",
+				role: "developer",
+				content: [
+					{ type: "input_text", text: renderVoiceStartupContext(text) },
+				],
+			});
 		}
 	}
-	args.onSummary?.(text);
-	return [
-		{
+	if (args.greet) {
+		initialItems.push({
 			type: "message",
-			role: "developer",
-			content: [{ type: "input_text", text: renderVoiceStartupContext(text) }],
-		},
-	];
+			role: "user",
+			content: [{ type: "input_text", text: VOICE_START_GREETING_REQUEST }],
+		});
+	}
+	return initialItems.length > 0 ? initialItems : undefined;
 }
 
 function renderVoiceStartupContext(summary: string): string {

--- a/packages/pi-gippity-control/src/voice/controller-sessions.ts
+++ b/packages/pi-gippity-control/src/voice/controller-sessions.ts
@@ -34,6 +34,7 @@ export async function startControllerConversation(options: {
 	instructions: string;
 	initialItems?: RealtimeInitialMessageItem[] | undefined;
 	inputMuted?: boolean | undefined;
+	greet?: boolean | undefined;
 	peer?: CodexRealtimePeer | undefined;
 	signal?: AbortSignal | undefined;
 	lifecycle: RealtimeSessionLifecycle;
@@ -93,6 +94,11 @@ export async function startControllerConversation(options: {
 	if (options.lifecycle.isCurrent(session)) {
 		session.markEstablished();
 		options.lifecycle.onActive(session);
+		if (options.greet) {
+			setTimeout(() => {
+				if (options.lifecycle.isCurrent(session)) session.greet();
+			}, 0).unref?.();
+		}
 	} else await session.close();
 }
 

--- a/packages/pi-gippity-control/src/voice/controller-start.ts
+++ b/packages/pi-gippity-control/src/voice/controller-start.ts
@@ -28,6 +28,7 @@ export interface RealtimePeerPlan {
 		error: Error,
 		resuming: boolean,
 	): void;
+	onStatus?(status: string): void;
 }
 
 export interface VoiceControllerRuntime {
@@ -87,7 +88,17 @@ export async function startControllerMode(options: {
 		options.mode === "realtime"
 			? { type: "connecting", mode: "realtime", phase: "authorizing" }
 			: { type: "connecting", mode: "dictation", phase: "authorizing" };
-	options.onStatus("connecting…");
+	const setStartupStatus = (status: string) => {
+		if (
+			startGeneration !== runtime.startGeneration ||
+			runtime.startAbortController !== startAbortController ||
+			runtime.state.type !== "connecting"
+		)
+			return;
+		options.onStatus(status);
+		options.realtimePeerPlan?.onStatus?.(status);
+	};
+	setStartupStatus("connecting…");
 	let realtimeSummary: string | undefined;
 	try {
 		const startup = await interruptible(
@@ -97,8 +108,12 @@ export async function startControllerMode(options: {
 					? buildRealtimeInitialItems({
 							ctx: options.ctx,
 							config: options.config,
+							greet: !options.resume,
 							onSummary: (summary) => {
 								realtimeSummary = summary;
+							},
+							onSummaryStatus: (active) => {
+								setStartupStatus(active ? "summarizing…" : "connecting…");
 							},
 							signal: startSignal,
 						})
@@ -178,6 +193,7 @@ async function startConversation(
 		instructions,
 		initialItems,
 		inputMuted: options.inputMuted,
+		greet: !options.resume,
 		peer,
 		signal,
 		lifecycle: {

--- a/packages/pi-gippity-control/src/voice/controller-start.ts
+++ b/packages/pi-gippity-control/src/voice/controller-start.ts
@@ -38,6 +38,7 @@ export interface VoiceControllerRuntime {
 	startGeneration: number;
 	startAbortController?: AbortController | undefined;
 	voiceStatus: string;
+	inputTooQuiet: boolean;
 	realtimePeerPlan?: RealtimePeerPlan | undefined;
 }
 
@@ -261,6 +262,7 @@ function cancelStart(
 	runtime.config = undefined;
 	runtime.realtimePeerPlan = undefined;
 	runtime.voiceStatus = "";
+	runtime.inputTooQuiet = false;
 	runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 }
 

--- a/packages/pi-gippity-control/src/voice/controller-support.ts
+++ b/packages/pi-gippity-control/src/voice/controller-support.ts
@@ -86,11 +86,16 @@ export function renderVoiceStatus(
 	ctx: ExtensionContext | undefined,
 	status: string,
 	muted: boolean,
+	inputTooQuiet: boolean,
 ): void {
 	if (!ctx || !status) return;
 	const mute = muted ? ctx.ui.theme.fg("warning", " · mic muted") : "";
+	const level =
+		!muted && inputTooQuiet
+			? ctx.ui.theme.fg("warning", " · mic too quiet")
+			: "";
 	ctx.ui.setStatus(
 		VOICE_STATUS_KEY,
-		`${ctx.ui.theme.fg("accent", `voice: ${status}`)}${mute}`,
+		`${ctx.ui.theme.fg("accent", `voice: ${status}`)}${mute}${level}`,
 	);
 }

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -84,7 +84,8 @@ export class CodexVoiceController {
 	setInputTooQuiet(inputTooQuiet: boolean): void {
 		const receivesInput =
 			this.runtime.state.type === "conversation" ||
-			this.runtime.state.type === "reconnecting";
+			this.runtime.state.type === "reconnecting" ||
+			this.runtime.state.type === "connecting";
 		const next = receivesInput && inputTooQuiet;
 		if (this.runtime.inputTooQuiet === next) return;
 		this.runtime.inputTooQuiet = next;

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -82,7 +82,10 @@ export class CodexVoiceController {
 		return true;
 	}
 	setInputTooQuiet(inputTooQuiet: boolean): void {
-		const next = this.runtime.state.type === "conversation" && inputTooQuiet;
+		const receivesInput =
+			this.runtime.state.type === "conversation" ||
+			this.runtime.state.type === "reconnecting";
+		const next = receivesInput && inputTooQuiet;
 		if (this.runtime.inputTooQuiet === next) return;
 		this.runtime.inputTooQuiet = next;
 		this.renderCurrentStatus();

--- a/packages/pi-gippity-control/src/voice/controller.ts
+++ b/packages/pi-gippity-control/src/voice/controller.ts
@@ -29,6 +29,7 @@ export class CodexVoiceController {
 		state: { type: "idle" },
 		startGeneration: 0,
 		voiceStatus: "",
+		inputTooQuiet: false,
 	};
 	private readonly messages: CodexVoiceSessionMessages;
 	private readonly inputMuteListeners = new Set<(muted: boolean) => void>();
@@ -79,6 +80,12 @@ export class CodexVoiceController {
 			for (const listener of this.inputMuteListeners) listener(current);
 		}
 		return true;
+	}
+	setInputTooQuiet(inputTooQuiet: boolean): void {
+		const next = this.runtime.state.type === "conversation" && inputTooQuiet;
+		if (this.runtime.inputTooQuiet === next) return;
+		this.runtime.inputTooQuiet = next;
+		this.renderCurrentStatus();
 	}
 	resetContextAnnouncements(): void {
 		this.messages.resetContextAnnouncements();
@@ -186,6 +193,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		await closePromise;
 		if (wasMuted)
@@ -217,6 +225,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.messages.voiceStopped(endedMode);
 	}
@@ -285,6 +294,7 @@ export class CodexVoiceController {
 		this.runtime.config = undefined;
 		this.runtime.realtimePeerPlan = undefined;
 		this.runtime.voiceStatus = "";
+		this.runtime.inputTooQuiet = false;
 		this.runtime.context?.ui.setStatus(VOICE_STATUS_KEY, undefined);
 		this.runtime.context?.ui.notify(message, "error");
 		this.messages.voiceStopped(endedMode);
@@ -381,6 +391,7 @@ export class CodexVoiceController {
 			this.runtime.context,
 			this.runtime.voiceStatus,
 			this.inputMuted,
+			this.runtime.inputTooQuiet,
 		);
 	}
 }

--- a/packages/pi-gippity-control/src/voice/conversation/session.ts
+++ b/packages/pi-gippity-control/src/voice/conversation/session.ts
@@ -66,6 +66,15 @@ export class CodexRealtimeConversation {
 		if (this.state === "active") this.established = true;
 	}
 
+	greet(): void {
+		if (this.state !== "active") return;
+		try {
+			this.peer.sendData({ type: "response.create" });
+		} catch (error) {
+			this.fail(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
 	async start(
 		auth: CodexVoiceAuth,
 		config: GippityControlConfig,

--- a/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
@@ -14,12 +14,18 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
   let mode = 'conversation';
   let active = false;
   let muted = false;
+  let inputTooQuiet = false;
   let busy = false;
   let finishingDictation = false;
   let starting = false;
   let startGeneration = 0;
 
   const setStatus = (title, message = '') => { audioState.textContent = title; audioDetail.textContent = message; };
+  const renderConversationStatus = () => {
+    if (!active || mode !== 'conversation') return;
+    if (muted) setStatus('Microphone muted', 'Voice remains connected');
+    else setStatus('Listening', inputTooQuiet ? 'Microphone level is too low' : 'Tap to stop');
+  };
   const updateControls = () => {
     button.disabled = false;
     button.setAttribute('aria-busy', String(busy));
@@ -35,7 +41,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
     muteButton.setAttribute('aria-label', muted ? 'Unmute microphone' : 'Mute microphone');
     muteButton.lastElementChild.textContent = muted ? 'Unmute mic' : 'Mute mic';
     if (notify && socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify({ type:'mute', muted }));
-    if (active) setStatus(muted ? 'Microphone muted' : 'Listening', muted ? 'Voice remains connected' : 'Tap to stop');
+    renderConversationStatus();
     updateControls();
   };
   const closeHardware = () => {
@@ -70,6 +76,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
     }
     active = false;
     muted = false;
+    inputTooQuiet = false;
     muteButton.setAttribute('aria-pressed', 'false');
     finishingDictation = false;
     const currentSocket = socket;
@@ -105,6 +112,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
         button.setAttribute('aria-pressed', 'true');
         button.setAttribute('aria-label', mode === 'dictation' ? 'Finish dictation' : 'Stop voice');
         if (mode === 'conversation') {
+          inputTooQuiet = false;
           if (typeof message.muted === 'boolean') muted = message.muted;
           realtimeAudio?.releaseInput();
         }
@@ -225,6 +233,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       if (command.type === 'stop') stop(false, command.reason || 'server');
       if (command.type === 'error') { stop(false, 'server-error'); setStatus('Voice stopped', command.message); }
       if (command.type === 'mute') setMuted(command.muted, false);
+      if (command.type === 'microphone') { inputTooQuiet = command.state === 'too-quiet'; renderConversationStatus(); }
     },
     pagehide() {
       stream?.getTracks().forEach((track) => track.stop());

--- a/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
@@ -105,6 +105,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       const message = JSON.parse(event.data);
 	  if (message.type === 'stop') { stop(false, message.reason || 'server'); return; }
 	  if (message.type === 'mute') setMuted(message.muted, false);
+	  if (message.type === 'status' && busy && !active) setStatus(message.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (message.type === 'active') {
         active = true;
         busy = false;

--- a/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-audio-script.ts
@@ -105,7 +105,6 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       const message = JSON.parse(event.data);
 	  if (message.type === 'stop') { stop(false, message.reason || 'server'); return; }
 	  if (message.type === 'mute') setMuted(message.muted, false);
-	  if (message.type === 'status' && busy && !active) setStatus(message.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (message.type === 'active') {
         active = true;
         busy = false;
@@ -234,6 +233,7 @@ function createAudioController({ button, muteButton, audioState, audioDetail, mo
       if (command.type === 'stop') stop(false, command.reason || 'server');
       if (command.type === 'error') { stop(false, 'server-error'); setStatus('Voice stopped', command.message); }
       if (command.type === 'mute') setMuted(command.muted, false);
+	  if (command.type === 'status' && busy && !active) setStatus(command.status === 'summarizing…' ? 'Summarizing conversation…' : 'Connecting…');
       if (command.type === 'microphone') { inputTooQuiet = command.state === 'too-quiet'; renderConversationStatus(); }
     },
     pagehide() {

--- a/packages/pi-gippity-control/src/voice/lan/browser-clients.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-clients.ts
@@ -43,6 +43,10 @@ export class LanVoiceBrowserClients {
 		this.session.sendConversationAudio(pcm);
 	}
 
+	resetConversationInputLevel(): void {
+		this.session.resetConversationInputLevel();
+	}
+
 	release(
 		clientId: string,
 		socket?: WebSocket,

--- a/packages/pi-gippity-control/src/voice/lan/browser-session.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-session.ts
@@ -231,9 +231,10 @@ export class LanVoiceBrowserSession {
 			active.clientId === clientId &&
 			active.socket === socket &&
 			active.mode === "conversation"
-		)
+		) {
 			this.options.onConversationMute(muted);
-		if (muted) this.microphoneLevel.reset();
+			if (muted) this.microphoneLevel.reset();
+		}
 	}
 
 	receiveAudio(clientId: string, socket: WebSocket, pcm: Buffer): void {

--- a/packages/pi-gippity-control/src/voice/lan/browser-session.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-session.ts
@@ -224,6 +224,10 @@ export class LanVoiceBrowserSession {
 		return this.options.cancelDictation(clientId);
 	}
 
+	resetConversationInputLevel(): void {
+		this.microphoneLevel.reset();
+	}
+
 	mute(clientId: string, socket: WebSocket, muted: boolean): void {
 		const active = this.state;
 		if (
@@ -233,7 +237,6 @@ export class LanVoiceBrowserSession {
 			active.mode === "conversation"
 		) {
 			this.options.onConversationMute(muted);
-			if (muted) this.microphoneLevel.reset();
 		}
 	}
 

--- a/packages/pi-gippity-control/src/voice/lan/browser-session.ts
+++ b/packages/pi-gippity-control/src/voice/lan/browser-session.ts
@@ -34,6 +34,7 @@ export interface LanVoiceBrowserClientsOptions {
 	onConversationActivity(active: boolean): void | Promise<void>;
 	onConversationMute(muted: boolean): void;
 	conversationMuted(): boolean;
+	onConversationInputTooQuiet(inputTooQuiet: boolean): void;
 	onConversationAudio(pcm: Buffer): void;
 	onDictationAudio(clientId: string, pcm: Buffer): void;
 }
@@ -44,6 +45,7 @@ export class LanVoiceBrowserSession {
 	private state: LanVoiceBrowserState = { type: "idle" };
 	private operation = Promise.resolve();
 	private conversationOwnerId: string | undefined;
+	private readonly microphoneLevel: MicrophoneLevelMonitor;
 
 	constructor(
 		options: LanVoiceBrowserClientsOptions,
@@ -51,6 +53,9 @@ export class LanVoiceBrowserSession {
 	) {
 		this.options = options;
 		this.connections = connections;
+		this.microphoneLevel = new MicrophoneLevelMonitor(
+			options.onConversationInputTooQuiet,
+		);
 	}
 
 	get closed(): boolean {
@@ -76,6 +81,8 @@ export class LanVoiceBrowserSession {
 				active.clientId === clientId &&
 				(!socket || active.socket === socket);
 			if (ownsActive) this.state = { type: "idle" };
+			if (ownsActive && active.mode === "conversation")
+				this.microphoneLevel.reset();
 			if (terminateConversation && this.conversationOwnerId === clientId) {
 				this.conversationOwnerId = undefined;
 				await this.options.onConversationActivity(false);
@@ -139,6 +146,7 @@ export class LanVoiceBrowserSession {
 			)
 				return;
 			this.state = { type: "idle" };
+			if (previous?.mode === "conversation") this.microphoneLevel.reset();
 			if (previous && previous.socket !== socket) {
 				this.connections.sendControl(previous.clientId, {
 					type: "stop",
@@ -225,6 +233,7 @@ export class LanVoiceBrowserSession {
 			active.mode === "conversation"
 		)
 			this.options.onConversationMute(muted);
+		if (muted) this.microphoneLevel.reset();
 	}
 
 	receiveAudio(clientId: string, socket: WebSocket, pcm: Buffer): void {
@@ -235,8 +244,10 @@ export class LanVoiceBrowserSession {
 			active.socket !== socket
 		)
 			return;
-		if (active.mode === "conversation") this.options.onConversationAudio(pcm);
-		else this.options.onDictationAudio(clientId, pcm);
+		if (active.mode === "conversation") {
+			this.microphoneLevel.append(pcm);
+			this.options.onConversationAudio(pcm);
+		} else this.options.onDictationAudio(clientId, pcm);
 	}
 
 	async close(): Promise<void> {
@@ -283,5 +294,50 @@ export class LanVoiceBrowserSession {
 			() => undefined,
 		);
 		return result;
+	}
+}
+
+const MICROPHONE_RATE = 24_000;
+const DETECTABLE_PEAK = 82;
+const HEALTHY_PEAK = 655;
+
+class MicrophoneLevelMonitor {
+	private readonly onChange: (inputTooQuiet: boolean) => void;
+	private samples = 0;
+	private peak = 0;
+	private inputTooQuiet = false;
+
+	constructor(onChange: (inputTooQuiet: boolean) => void) {
+		this.onChange = onChange;
+	}
+
+	append(pcm: Buffer): void {
+		let framePeak = 0;
+		for (let offset = 0; offset + 1 < pcm.byteLength; offset += 2)
+			framePeak = Math.max(framePeak, Math.abs(pcm.readInt16LE(offset)));
+		if (framePeak >= HEALTHY_PEAK) {
+			this.samples = 0;
+			this.peak = 0;
+			this.set(false);
+			return;
+		}
+		this.samples += Math.floor(pcm.byteLength / 2);
+		this.peak = Math.max(this.peak, framePeak);
+		if (this.samples < MICROPHONE_RATE) return;
+		if (this.peak >= DETECTABLE_PEAK) this.set(true);
+		this.samples = 0;
+		this.peak = 0;
+	}
+
+	reset(): void {
+		this.samples = 0;
+		this.peak = 0;
+		this.set(false);
+	}
+
+	private set(inputTooQuiet: boolean): void {
+		if (this.inputTooQuiet === inputTooQuiet) return;
+		this.inputTooQuiet = inputTooQuiet;
+		this.onChange(inputTooQuiet);
 	}
 }

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -164,6 +164,13 @@ export async function startCodexLanVoiceServer(options: {
 			if (!options.voice.setInputMuted(muted))
 				throw new Error("Realtime voice is not active");
 		},
+		onConversationInputTooQuiet(inputTooQuiet) {
+			options.voice.setInputTooQuiet(inputTooQuiet);
+			clients.broadcastControl({
+				type: "microphone",
+				state: inputTooQuiet ? "too-quiet" : "ok",
+			});
+		},
 		onConversationAudio(pcm) {
 			activeConversation?.peer.sendAudio(pcm);
 		},

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -178,9 +178,10 @@ export async function startCodexLanVoiceServer(options: {
 		},
 		onDictationAudio: (clientId, pcm) => dictation.append(clientId, pcm),
 	});
-	const removeInputMuteListener = options.voice.onInputMuteChange((muted) =>
-		clients.broadcastControl({ type: "mute", muted }),
-	);
+	const removeInputMuteListener = options.voice.onInputMuteChange((muted) => {
+		if (muted) clients.resetConversationInputLevel();
+		clients.broadcastControl({ type: "mute", muted });
+	});
 
 	const server = createServer(
 		{ cert: certificate.cert, key: certificate.key },

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -83,6 +83,8 @@ export async function startCodexLanVoiceServer(options: {
 		const abort = new AbortController();
 		let activated = false;
 		const plan: RealtimePeerPlan = {
+			onStatus: (status) =>
+				clients.broadcastControl({ type: "status", status }),
 			createPeer: () => {
 				let peer!: LanHostRealtimePeer;
 				peer = new LanHostRealtimePeer({

--- a/packages/pi-gippity-control/tests/voice-lan.test.ts
+++ b/packages/pi-gippity-control/tests/voice-lan.test.ts
@@ -53,7 +53,6 @@ describe("LAN conversation setup", () => {
 		const setup = Promise.withResolvers<void>();
 		let hostStarts = 0;
 		let sharedSetup: Promise<void> | undefined;
-		const inputLevels: boolean[] = [];
 		const clients = testBrowserClients({
 			ensureConversation() {
 				if (!sharedSetup) {
@@ -61,9 +60,6 @@ describe("LAN conversation setup", () => {
 					sharedSetup = setup.promise;
 				}
 				return sharedSetup;
-			},
-			onConversationInputTooQuiet(inputTooQuiet) {
-				inputLevels.push(inputTooQuiet);
 			},
 		});
 		const first = new TestWebSocket();
@@ -83,14 +79,6 @@ describe("LAN conversation setup", () => {
 			mode: "conversation",
 			muted: false,
 		});
-		const quietFrame = pcmFrame(100);
-		for (let frame = 0; frame < 50; frame += 1)
-			second.receiveBinary(quietFrame);
-		const third = new TestWebSocket();
-		clients.connectAudio("third", third.asWebSocket());
-		third.receive({ type: "start", mode: "conversation" });
-		await settle();
-		expect(inputLevels).toEqual([true, false]);
 		await clients.close();
 	});
 
@@ -115,7 +103,6 @@ describe("LAN conversation setup", () => {
 function testBrowserClients(overrides: {
 	ensureConversation(): Promise<void>;
 	onConversationActivity?(active: boolean): void | Promise<void>;
-	onConversationInputTooQuiet?(inputTooQuiet: boolean): void;
 }): LanVoiceBrowserClients {
 	return new LanVoiceBrowserClients({
 		...overrides,
@@ -125,8 +112,7 @@ function testBrowserClients(overrides: {
 		onConversationActivity: overrides.onConversationActivity ?? (() => {}),
 		onConversationMute: () => {},
 		conversationMuted: () => false,
-		onConversationInputTooQuiet:
-			overrides.onConversationInputTooQuiet ?? (() => {}),
+		onConversationInputTooQuiet: () => {},
 		onConversationAudio: () => {},
 		onDictationAudio: () => {},
 	});
@@ -134,13 +120,6 @@ function testBrowserClients(overrides: {
 
 async function settle(): Promise<void> {
 	await new Promise((resolve) => setImmediate(resolve));
-}
-
-function pcmFrame(peak: number): Buffer {
-	const frame = Buffer.alloc(480 * 2);
-	for (let sample = 0; sample < 480; sample += 1)
-		frame.writeInt16LE(peak, sample * 2);
-	return frame;
 }
 
 class TestWebSocket extends EventEmitter {
@@ -157,10 +136,6 @@ class TestWebSocket extends EventEmitter {
 
 	receive(value: unknown): void {
 		this.emit("message", Buffer.from(JSON.stringify(value)), false);
-	}
-
-	receiveBinary(value: Buffer): void {
-		this.emit("message", value, true);
 	}
 
 	close(code = 1000, reason = "closed"): void {

--- a/packages/pi-gippity-control/tests/voice-lan.test.ts
+++ b/packages/pi-gippity-control/tests/voice-lan.test.ts
@@ -53,6 +53,7 @@ describe("LAN conversation setup", () => {
 		const setup = Promise.withResolvers<void>();
 		let hostStarts = 0;
 		let sharedSetup: Promise<void> | undefined;
+		const inputLevels: boolean[] = [];
 		const clients = testBrowserClients({
 			ensureConversation() {
 				if (!sharedSetup) {
@@ -60,6 +61,9 @@ describe("LAN conversation setup", () => {
 					sharedSetup = setup.promise;
 				}
 				return sharedSetup;
+			},
+			onConversationInputTooQuiet(inputTooQuiet) {
+				inputLevels.push(inputTooQuiet);
 			},
 		});
 		const first = new TestWebSocket();
@@ -79,6 +83,14 @@ describe("LAN conversation setup", () => {
 			mode: "conversation",
 			muted: false,
 		});
+		const quietFrame = pcmFrame(100);
+		for (let frame = 0; frame < 50; frame += 1)
+			second.receiveBinary(quietFrame);
+		const third = new TestWebSocket();
+		clients.connectAudio("third", third.asWebSocket());
+		third.receive({ type: "start", mode: "conversation" });
+		await settle();
+		expect(inputLevels).toEqual([true, false]);
 		await clients.close();
 	});
 
@@ -103,6 +115,7 @@ describe("LAN conversation setup", () => {
 function testBrowserClients(overrides: {
 	ensureConversation(): Promise<void>;
 	onConversationActivity?(active: boolean): void | Promise<void>;
+	onConversationInputTooQuiet?(inputTooQuiet: boolean): void;
 }): LanVoiceBrowserClients {
 	return new LanVoiceBrowserClients({
 		...overrides,
@@ -112,6 +125,8 @@ function testBrowserClients(overrides: {
 		onConversationActivity: overrides.onConversationActivity ?? (() => {}),
 		onConversationMute: () => {},
 		conversationMuted: () => false,
+		onConversationInputTooQuiet:
+			overrides.onConversationInputTooQuiet ?? (() => {}),
 		onConversationAudio: () => {},
 		onDictationAudio: () => {},
 	});
@@ -119,6 +134,13 @@ function testBrowserClients(overrides: {
 
 async function settle(): Promise<void> {
 	await new Promise((resolve) => setImmediate(resolve));
+}
+
+function pcmFrame(peak: number): Buffer {
+	const frame = Buffer.alloc(480 * 2);
+	for (let sample = 0; sample < 480; sample += 1)
+		frame.writeInt16LE(peak, sample * 2);
+	return frame;
 }
 
 class TestWebSocket extends EventEmitter {
@@ -135,6 +157,10 @@ class TestWebSocket extends EventEmitter {
 
 	receive(value: unknown): void {
 		this.emit("message", Buffer.from(JSON.stringify(value)), false);
+	}
+
+	receiveBinary(value: Buffer): void {
+		this.emit("message", value, true);
 	}
 
 	close(code = 1000, reason = "closed"): void {


### PR DESCRIPTION
## Summary

- show `voice: summarizing…` only while an uncached continuity summary is generated
- return to `connecting…` for authorization and transport setup
- seed a one-shot greeting after a fresh V3 session becomes ready
- keep Codex and GipPity startup status and greeting behavior aligned
- show summarization progress in both Pi and the LAN controller
- skip the greeting during automatic reconnection
- detect one second of weak but real LAN microphone input
- show `mic too quiet` in Pi and `Microphone level is too low` in the LAN controller
- clear the warning immediately on healthy input; silence alone does not trigger it

## Validation

- `bun run check:changed`
- Codex conversion: 76 tests
- GipPity: 12 tests
- no gain, buffering, latency, native helper, or binary changes

## Release

Changeset included for:

- `@howaboua/pi-codex-conversion`
- `@howaboua/pi-gippity-control`
