### PR TITLE
Contain exec processes during Pi shutdown

### DIFF
--- a/.changeset/exec-shutdown-containment.md
+++ b/.changeset/exec-shutdown-containment.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Await exec process-group termination and graceful bridge exit during Pi shutdown.

--- a/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
@@ -127,11 +127,12 @@ export function createExecBridgeClient(binaryPath: () => string | undefined = ()
 	async function shutdownBridge(): Promise<void> {
 		const child = bridge;
 		if (!child || child.exitCode !== null || child.signalCode !== null) return;
+		const deadline = performance.now() + BRIDGE_SHUTDOWN_TIMEOUT_MS;
 		const shutdownRequest = request({ op: "shutdown" });
 		bridgeClosing = true;
 		try {
-			await withTimeout(shutdownRequest, BRIDGE_SHUTDOWN_TIMEOUT_MS, "exec_bridge shutdown timed out");
-			await waitForBridgeClose(child, BRIDGE_SHUTDOWN_TIMEOUT_MS);
+			await withTimeout(shutdownRequest, remainingMs(deadline), "exec_bridge shutdown timed out");
+			await waitForBridgeClose(child, remainingMs(deadline));
 		} catch (error) {
 			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
 			throw error;
@@ -142,6 +143,10 @@ export function createExecBridgeClient(binaryPath: () => string | undefined = ()
 		request,
 		shutdown: () => bridgeShutdownPromise ??= shutdownBridge(),
 	};
+}
+
+function remainingMs(deadline: number): number {
+	return Math.max(0, deadline - performance.now());
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/bridge-client.ts
@@ -21,10 +21,11 @@ export interface BridgeReadResponse {
 
 export interface ExecBridgeClient {
 	request<T = unknown>(request: Record<string, unknown>): Promise<T>;
-	shutdown(): void;
+	shutdown(): Promise<void>;
 }
 
 const MAX_BRIDGE_STDERR_CHARS = 16_000;
+const BRIDGE_SHUTDOWN_TIMEOUT_MS = 5_000;
 function appendBoundedText(current: string, next: string): string {
 	const combined = `${current}${next}`;
 	return combined.length > MAX_BRIDGE_STDERR_CHARS ? combined.slice(-MAX_BRIDGE_STDERR_CHARS) : combined;
@@ -53,6 +54,7 @@ export function createExecBridgeClient(binaryPath: () => string | undefined = ()
 	let bridgeStderrDecoder = new StringDecoder("utf8");
 	let bridgeClosing = false;
 	let bridgeResponded = false;
+	let bridgeShutdownPromise: Promise<void> | undefined;
 
 	function rejectPending(error: Error): void {
 		for (const pending of pendingBridgeRequests.values()) pending.reject(error);
@@ -107,28 +109,56 @@ export function createExecBridgeClient(binaryPath: () => string | undefined = ()
 		return bridge;
 	}
 
-	return {
-		async request<T = unknown>(request: Record<string, unknown>): Promise<T> {
-			const requestId = nextBridgeRequestId++;
-			const child = getBridge();
-			const response = await new Promise<BridgeResponse<T>>((resolve, reject) => {
-				pendingBridgeRequests.set(requestId, { resolve: resolve as (value: BridgeResponse) => void, reject });
-				child.stdin.write(`${JSON.stringify({ ...request, request_id: requestId })}\n`, (error) => {
-					if (!error) return;
-					pendingBridgeRequests.delete(requestId);
-					reject(new Error(formatExecBridgeWriteError(error, bridgeStderr, !bridgeResponded)));
-				});
+	async function request<T = unknown>(value: Record<string, unknown>): Promise<T> {
+		const requestId = nextBridgeRequestId++;
+		const child = getBridge();
+		const response = await new Promise<BridgeResponse<T>>((resolve, reject) => {
+			pendingBridgeRequests.set(requestId, { resolve: resolve as (value: BridgeResponse) => void, reject });
+			child.stdin.write(`${JSON.stringify({ ...value, request_id: requestId })}\n`, (error) => {
+				if (!error) return;
+				pendingBridgeRequests.delete(requestId);
+				reject(new Error(formatExecBridgeWriteError(error, bridgeStderr, !bridgeResponded)));
 			});
-			if (!response.ok) throw new Error(response.error ?? "exec_bridge request failed");
-			return response.result as T;
-		},
-		shutdown() {
-			if (bridge && !bridge.killed) {
-				bridgeClosing = true;
-				bridge.kill();
-			}
-		},
+		});
+		if (!response.ok) throw new Error(response.error ?? "exec_bridge request failed");
+		return response.result as T;
+	}
+
+	async function shutdownBridge(): Promise<void> {
+		const child = bridge;
+		if (!child || child.exitCode !== null || child.signalCode !== null) return;
+		const shutdownRequest = request({ op: "shutdown" });
+		bridgeClosing = true;
+		try {
+			await withTimeout(shutdownRequest, BRIDGE_SHUTDOWN_TIMEOUT_MS, "exec_bridge shutdown timed out");
+			await waitForBridgeClose(child, BRIDGE_SHUTDOWN_TIMEOUT_MS);
+		} catch (error) {
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			throw error;
+		}
+	}
+
+	return {
+		request,
+		shutdown: () => bridgeShutdownPromise ??= shutdownBridge(),
 	};
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	return Promise.race([
+		promise,
+		new Promise<never>((_resolve, reject) => {
+			timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+		}),
+	]).finally(() => {
+		if (timeout) clearTimeout(timeout);
+	});
+}
+
+function waitForBridgeClose(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+	return withTimeout(new Promise<void>((resolve) => child.once("close", () => resolve())), timeoutMs, "exec_bridge did not exit after shutdown");
 }
 
 export function chunkToBytes(chunk: string): Buffer {

--- a/packages/pi-codex-conversion/src/tools/exec/bridge-session.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/bridge-session.ts
@@ -63,6 +63,7 @@ export interface BridgeSessionRuntime {
 
 export function createBridgeSessionRuntime(binaryPath?: () => string | undefined): BridgeSessionRuntime {
 	const bridge = createExecBridgeClient(binaryPath);
+	let pollQueue = Promise.resolve();
 
 	function setClosedExitCode(session: BridgeExecSession, code: number | null | undefined, signal?: string | null): void {
 		if (session.exitCode !== undefined && session.exitCode !== null) return;
@@ -74,6 +75,7 @@ export function createBridgeSessionRuntime(binaryPath?: () => string | undefined
 	}
 
 	async function poll(session: BridgeExecSession, hooks: BridgeSessionHooks, waitMs = 0, maxBytes?: number): Promise<void> {
+		if (!hooks.isOwned(session)) return;
 		const response = await bridge.request<BridgeReadResponse>({
 			op: "read",
 			process_id: session.processId,
@@ -104,10 +106,22 @@ export function createBridgeSessionRuntime(binaryPath?: () => string | undefined
 		}
 	}
 
+	async function pollBackground(session: BridgeExecSession, hooks: BridgeSessionHooks): Promise<void> {
+		const previous = pollQueue;
+		let release!: () => void;
+		pollQueue = new Promise<void>((resolve) => { release = resolve; });
+		await previous;
+		try {
+			await poll(session, hooks, 250);
+		} finally {
+			release();
+		}
+	}
+
 	async function pollLoop(session: BridgeExecSession, hooks: BridgeSessionHooks): Promise<void> {
 		while (hooks.isOwned(session) && (session.exitCode === undefined || session.exitCode === null)) {
 			try {
-				await poll(session, hooks, 250);
+				await pollBackground(session, hooks);
 			} catch (error) {
 				hooks.onOutput(session, `${error instanceof Error ? error.message : String(error)}\n`);
 				session.exitCode = 1;

--- a/packages/pi-codex-conversion/src/tools/exec/bridge-session.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/bridge-session.ts
@@ -58,7 +58,7 @@ export interface BridgeSessionRuntime {
 	waitForStartup(session: BridgeExecSession, signal?: AbortSignal): Promise<void>;
 	write(session: BridgeExecSession, chars: string): Promise<void>;
 	terminate(session: BridgeExecSession): Promise<void>;
-	shutdown(): void;
+	shutdown(): Promise<void>;
 }
 
 export function createBridgeSessionRuntime(binaryPath?: () => string | undefined): BridgeSessionRuntime {

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -313,6 +313,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			session.terminating = true;
 			void bridgeSessions.terminate(session).catch(() => {});
 			setTimeout(() => {
+				if (shuttingDown) return;
 				if (session.exitCode === undefined || session.exitCode === null) void bridgeSessions.terminate(session).catch(() => {});
 			}, TERMINATE_ESCALATE_MS).unref?.();
 			notify(session, "terminate");

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -59,7 +59,7 @@ export interface ExecSessionManager {
 	terminateSession(sessionId: number): boolean;
 	onSessionChange(listener: (reason: ExecSessionChangeReason) => void): () => void;
 	onSessionExit(listener: (sessionId: number, command: string) => void): () => void;
-	shutdown(): void;
+	shutdown(): Promise<void>;
 }
 
 export interface ExecSessionManagerOptions {
@@ -89,6 +89,8 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 	const changeListeners = new Set<(reason: ExecSessionChangeReason) => void>();
 	const exitListeners = new Set<(sessionId: number, command: string) => void>();
 	const bridgeSessions = createBridgeSessionRuntime(options.bridgeBinaryPath);
+	let shuttingDown = false;
+	let shutdownPromise: Promise<void> | undefined;
 	let baseEnv: NodeJS.ProcessEnv = { ...(options.env ?? process.env) };
 	const defaultExecYieldTimeMs = options.defaultExecYieldTimeMs ?? DEFAULT_EXEC_YIELD_TIME_MS;
 	const defaultWriteYieldTimeMs = options.defaultWriteYieldTimeMs ?? DEFAULT_WRITE_YIELD_TIME_MS;
@@ -186,7 +188,7 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 	}
 
 	const bridgeHooks: BridgeSessionHooks = {
-		isOwned: (session) => sessions.get(session.id) === session,
+		isOwned: (session) => !shuttingDown && sessions.get(session.id) === session,
 		onOutput: (session, text) => appendOutput(session, text),
 		onExit: (session) => finalizeSession(session),
 	};
@@ -324,15 +326,20 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 			exitListeners.add(listener);
 			return () => exitListeners.delete(listener);
 		},
-		shutdown: () => {
-			for (const session of sessions.values()) {
-				if (session.exitCode === undefined || session.exitCode === null) void bridgeSessions.terminate(session).catch(() => {});
+		shutdown: () => shutdownPromise ??= (async () => {
+			shuttingDown = true;
+			try {
+				const running = Array.from(sessions.values()).filter(
+					(session) => session.exitCode === undefined || session.exitCode === null,
+				);
+				await Promise.allSettled(running.map((session) => bridgeSessions.terminate(session)));
+				await bridgeSessions.shutdown();
+			} finally {
+				sessions.clear();
+				commandHistory.clear();
+				completedResults.clear();
 			}
-			bridgeSessions.shutdown();
-			sessions.clear();
-			commandHistory.clear();
-			completedResults.clear();
-		},
+		})(),
 	};
 }
 

--- a/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/exec/session-manager.ts
@@ -329,10 +329,6 @@ export function createExecSessionManager(options: ExecSessionManagerOptions = {}
 		shutdown: () => shutdownPromise ??= (async () => {
 			shuttingDown = true;
 			try {
-				const running = Array.from(sessions.values()).filter(
-					(session) => session.exitCode === undefined || session.exitCode === null,
-				);
-				await Promise.allSettled(running.map((session) => bridgeSessions.terminate(session)));
 				await bridgeSessions.shutdown();
 			} finally {
 				sessions.clear();

--- a/packages/pi-codex-conversion/tests/exec-wait.test.ts
+++ b/packages/pi-codex-conversion/tests/exec-wait.test.ts
@@ -52,7 +52,7 @@ test("sessions finish after the shell exits when a detached child retains stdio"
 		assert.equal(completed.session_id, undefined);
 		assert.equal(processIsRunning(childId), true);
 	} finally {
-		sessions.shutdown();
+		await sessions.shutdown();
 		if (childId !== undefined && processIsRunning(childId)) process.kill(childId);
 	}
 });


### PR DESCRIPTION
This PR makes Pi shutdown wait until owned exec process groups and their bridge are contained.

## Summary

- stop background poll ownership before shutdown begins
- let the bridge own one shutdown request that terminates only this Pi instance's process groups
- use the exec bridge's existing Rust `shutdown` request and wait for the helper to exit
- share one five-second deadline across graceful bridge shutdown, then hard-kill and surface the failure

## Validation

- reproduced the original leak before the fix: the shell exited while its child survived under PID 1
- repeated the same shell-child repro after the fix: the child was reaped before shutdown returned
- `bunx tsx --test packages/pi-codex-conversion/tests/exec-wait.test.ts`
- `bun run check:changed`
- `bun run changeset:check`

## Review focus

- No Rust source changed. Existing native termination already kills the process group; this layer fixes the TypeScript race that killed the bridge before that work completed.
- Graceful shutdown failures remain visible after the bounded hard-kill fallback.

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`

Closes #260
