### PR TITLE
Show blocked Codex request codes

### DIFF
--- a/.changeset/codex-invalid-prompt.md
+++ b/.changeset/codex-invalid-prompt.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Show the exact provider code when OpenAI blocks a Codex request without identifying the reason.

--- a/packages/pi-codex-conversion/src/providers/openai-codex/errors.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/errors.ts
@@ -128,6 +128,10 @@ export function isRetryableStreamStatus(status: number): boolean {
 
 export function buildProviderErrorMessage(error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);
+	const code = isRecord(error) ? asString(error["code"]!) : undefined;
+	if (code === "invalid_prompt") {
+		return "OpenAI blocked this request (invalid_prompt - reason unknown).";
+	}
 	const usageLimitMessage = formatCodexUsageLimitError(message);
 	if (usageLimitMessage) return usageLimitMessage;
 	if (/^(?:WebSocket (?:error|closed|connect timeout|idle timeout)|WebSocket stream closed before response\.completed|Stream closed before response\.completed)/.test(message)) {

--- a/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-transport.test.ts
@@ -10,13 +10,21 @@ import {
 	websocketSuccess,
 } from "./openai-codex-test-support.ts";
 
-test("fatal Codex API errors survive stream start without SSE fallback", async () => {
+test("fatal Codex API errors survive both event shapes without SSE fallback", async () => {
 	const restoreWebSocket = installScriptedWebSocket([
 		(socket) => {
 			socket.emitJson({ type: "response.created", response: { id: "resp_failed" } });
 			socket.emitJson({
 				type: "response.failed",
 				response: { status: "failed", error: { type: "context_length_exceeded", status_code: 400, message: "context_length_exceeded" } },
+			});
+		},
+		(socket) => {
+			socket.emitJson({ type: "response.created", response: { id: "resp_blocked" } });
+			socket.emitJson({
+				type: "error",
+				code: "invalid_prompt",
+				message: "Request blocked.",
 			});
 		},
 		websocketSuccess,
@@ -30,12 +38,19 @@ test("fatal Codex API errors survive stream start without SSE fallback", async (
 	try {
 		const registered = createRegisteredCodexProvider();
 		const request = codexStreamRequest("api-error-session");
-		const failed = await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
-		assert.equal((failed.at(-1) as { type?: string }).type, "error");
-		assert.match((failed.at(-1) as { error?: { errorMessage?: string } }).error?.errorMessage ?? "", /context_length_exceeded/);
+		const overflow = await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+		assert.equal((overflow.at(-1) as { type?: string }).type, "error");
+		assert.match((overflow.at(-1) as { error?: { errorMessage?: string } }).error?.errorMessage ?? "", /context_length_exceeded/);
+
+		const blocked = await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
+		assert.equal((blocked.at(-1) as { type?: string }).type, "error");
+		assert.equal(
+			(blocked.at(-1) as { error?: { errorMessage?: string } }).error?.errorMessage,
+			"OpenAI blocked this request (invalid_prompt - reason unknown).",
+		);
 		await collectStream(registered.provider.streamSimple(request.model, request.context, request.options));
 
-		assert.equal(ScriptedWebSocket.opened, 2);
+		assert.equal(ScriptedWebSocket.opened, 3);
 		assert.equal(fetchCalls, 0);
 	} finally {
 		globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

- preserve `invalid_prompt` after a streamed Codex API failure
- show `OpenAI blocked this request (invalid_prompt - reason unknown).`
- keep the provider error authoritative instead of replacing it with generic stream recovery copy

## Validation

- `bun run check:changed`
- Codex conversion: 76 tests
- Changeset included

