### PR TITLE
Document realtime voice prompt API

### DIFF
--- a/packages/pi-codex-conversion/README.md
+++ b/packages/pi-codex-conversion/README.md
@@ -152,6 +152,21 @@ The visible realtime prompt lives at `~/.pi/agent/REALTIME-SYSTEM-PROMPT.md`. A 
 
 The package ships its current prompt template and cumulative schema changelog as raw Markdown. Realtime voice checks the global prompt marker when voice is engaged. If it is outdated, the extension points you and your agent to the changelog instead of rewriting personal customizations automatically. Both paths are shown in the Voice tab.
 
+Other Pi extensions can ask an active voice session to speak:
+
+```ts
+import { reportRealtimeVoicePrompt } from "@howaboua/pi-codex-conversion/realtime-voice";
+
+const announcement = {
+	id: "my-extension:finished",
+	prompt: "Briefly tell the user that the task finished.",
+};
+reportRealtimeVoicePrompt(pi, { ...announcement, active: true });
+reportRealtimeVoicePrompt(pi, { ...announcement, active: false });
+```
+
+For an ongoing state, send `active: true` when it begins and `active: false` when it ends. For a one-off announcement, send both immediately as above.
+
 Voice commands:
 
 ```text

--- a/packages/pi-gippity-control/README.md
+++ b/packages/pi-gippity-control/README.md
@@ -37,3 +37,18 @@ Settings live in `~/.pi/agent/pi-gippity-control.json`. Keybind changes take eff
 The LAN server includes a microphone mute button. The host retains the Realtime WebRTC call and relays 24 kHz mono audio to the active browser, so moving between devices does not restart the voice session. The server is unauthenticated by design for trusted networks, uses a local HTTPS certificate, belongs only to the Pi session that started it, and stops when that session changes.
 
 The global realtime prompt lives at `~/.pi/agent/REALTIME-SYSTEM-PROMPT.md`; trusted projects can append `.pi/REALTIME-SYSTEM-PROMPT.md`. GipPity ships its current template and cumulative schema changelog as raw Markdown. It checks the marker only when realtime voice is engaged and asks your agent to migrate outdated customized prompts instead of rewriting them automatically. Both paths are shown in `/gippity`.
+
+Other Pi extensions can ask an active voice session to speak:
+
+```ts
+import { reportRealtimeVoicePrompt } from "@howaboua/pi-gippity-control";
+
+const announcement = {
+	id: "my-extension:finished",
+	prompt: "Briefly tell the user that the task finished.",
+};
+reportRealtimeVoicePrompt(pi, { ...announcement, active: true });
+reportRealtimeVoicePrompt(pi, { ...announcement, active: false });
+```
+
+For an ongoing state, send `active: true` when it begins and `active: false` when it ends. For a one-off announcement, send both immediately as above.


### PR DESCRIPTION
## Summary
- show how Pi extensions send realtime voice prompts through Codex Conversion
- document the matching GipPity API

## Validation
- `git diff --check`
- `bun run check:changed` (documentation-only; no changed workspace packages)