### PR TITLE
Keep GipPity discovery available before custom app creation

### DIFF
--- a/.changeset/patch-msszycre-603be7.md
+++ b/.changeset/patch-msszycre-603be7.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-gippity-control": patch
+---
+
+Allow the LAN control server port to be set through lan.port and keep discovery available while a custom app is incomplete.

--- a/packages/pi-gippity-control/src/config-store.ts
+++ b/packages/pi-gippity-control/src/config-store.ts
@@ -41,8 +41,9 @@ function clearAbsentOwnedOptionals(
 ): void {
 	const lan = isObject(document["lan"]) ? document["lan"] : undefined;
 	const ownedLan = isObject(owned["lan"]) ? owned["lan"] : undefined;
-	if (lan && ownedLan && !("customWebAppPath" in ownedLan))
-		delete lan["customWebAppPath"];
+	if (lan && ownedLan)
+		for (const key of ["customWebAppPath", "port"])
+			if (!(key in ownedLan)) delete lan[key];
 	const voice = isObject(document["voice"]) ? document["voice"] : undefined;
 	const ownedVoice = isObject(owned["voice"]) ? owned["voice"] : undefined;
 	if (!voice || !ownedVoice) return;

--- a/packages/pi-gippity-control/src/config.ts
+++ b/packages/pi-gippity-control/src/config.ts
@@ -35,6 +35,7 @@ export interface GippityControlConfig {
 	lan: {
 		customWebApp: boolean;
 		customWebAppPath?: string | undefined;
+		port?: number | undefined;
 	};
 	voice: {
 		v3Voice: RealtimeV3Voice;
@@ -89,6 +90,15 @@ function optionalString(value: unknown): string | undefined {
 		: undefined;
 }
 
+function optionalPort(value: unknown): number | undefined {
+	return typeof value === "number" &&
+		Number.isInteger(value) &&
+		value >= 1 &&
+		value <= 65_535
+		? value
+		: undefined;
+}
+
 function normalizeVoiceContextModel(
 	value: unknown,
 ): VoiceContextModel | undefined {
@@ -122,6 +132,7 @@ export function normalizeGippityControlConfig(
 	const lan = isObject(value["lan"]) ? value["lan"] : {};
 	const voice = isObject(value["voice"]) ? value["voice"] : {};
 	const customWebAppPath = optionalString(lan["customWebAppPath"]);
+	const port = optionalPort(lan["port"]);
 	const inputDevice = optionalString(voice["inputDevice"]);
 	const outputDevice = optionalString(voice["outputDevice"]);
 	const contextModel = normalizeVoiceContextModel(voice["contextModel"]);
@@ -129,6 +140,7 @@ export function normalizeGippityControlConfig(
 		lan: {
 			customWebApp: lan["customWebApp"] === true,
 			...(customWebAppPath ? { customWebAppPath } : {}),
+			...(port ? { port } : {}),
 		},
 		voice: {
 			v3Voice:

--- a/packages/pi-gippity-control/src/voice/lan/controller.ts
+++ b/packages/pi-gippity-control/src/voice/lan/controller.ts
@@ -75,7 +75,7 @@ export class CodexLanVoiceServerController {
 			);
 			const config = this.getConfig();
 			const needsCustomApp =
-				config.lan.customWebApp && !config.lan.customWebAppPath;
+				config.lan.customWebApp && !this.server.customWebAppReady;
 			ctx.ui.notify(
 				`GipPity control server is running:\n${this.server.urls.join("\n")}\nAccept the local certificate on first visit.${needsCustomApp ? "\nNo custom web app is connected. Run /gippity create." : ""}`,
 				"info",

--- a/packages/pi-gippity-control/src/voice/lan/custom-app.ts
+++ b/packages/pi-gippity-control/src/voice/lan/custom-app.ts
@@ -34,18 +34,20 @@ const CONTENT_TYPES: Record<string, string> = {
 export function resolveLanRemoteCustomApp(
 	configuredPath: string,
 	cwd: string,
-): LanRemoteCustomApp {
+): LanRemoteCustomApp | undefined {
 	const candidate = isAbsolute(configuredPath)
 		? configuredPath
 		: resolve(cwd, configuredPath);
-	if (!existsSync(candidate) || !statSync(candidate).isDirectory())
-		throw new Error(
-			`Custom GipPity web app directory does not exist: ${candidate}`,
-		);
-	const root = realpathSync(candidate);
-	const index = join(root, "index.html");
-	if (!existsSync(index) || !statSync(index).isFile())
-		throw new Error(`Custom GipPity web app needs ${index}`);
+	let root: string;
+	try {
+		if (!existsSync(candidate) || !statSync(candidate).isDirectory())
+			return undefined;
+		root = realpathSync(candidate);
+		const index = join(root, "index.html");
+		if (!existsSync(index) || !statSync(index).isFile()) return undefined;
+	} catch {
+		return undefined;
+	}
 	return {
 		root,
 		asset(path) {

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -39,12 +39,13 @@ import {
 } from "./server-runtime.ts";
 import { createLanVoiceWebUi } from "./web-ui.ts";
 
-const PORT = 43_120;
+const DEFAULT_PORT = 43_120;
 const HEARTBEAT_MS = 15_000;
 
 export interface CodexLanVoiceServer {
 	readonly ownerSessionId: string;
 	readonly urls: string[];
+	readonly customWebAppReady: boolean;
 	agentStarted(): void;
 	agentSettled(text?: string): void;
 	piEvent(event: string, data: unknown): void;
@@ -81,7 +82,8 @@ export async function startCodexLanVoiceServer(options: {
 			}),
 		};
 	};
-	resolveWebApp(options.getConfig());
+	const initialConfig = options.getConfig();
+	const initialWebApp = resolveWebApp(initialConfig);
 	const certificate = resolveLanVoiceCertificate(options.certificateAgentDir);
 	const ownerIsActive = () =>
 		options.ctx.sessionManager.getSessionId() === options.ownerSessionId;
@@ -288,7 +290,10 @@ export async function startCodexLanVoiceServer(options: {
 	});
 	configureServer(server);
 	try {
-		await listen(server, options.port ?? PORT);
+		await listen(
+			server,
+			options.port ?? initialConfig.lan.port ?? DEFAULT_PORT,
+		);
 	} catch (error) {
 		removeInputMuteListener();
 		const clientsClosing = clients.close();
@@ -345,6 +350,7 @@ export async function startCodexLanVoiceServer(options: {
 	return {
 		ownerSessionId: options.ownerSessionId,
 		urls,
+		customWebAppReady: Boolean(initialWebApp.customApp),
 		agentStarted: () => activity.working(),
 		agentSettled: (text) => activity.settled(text),
 		piEvent(event, data) {


### PR DESCRIPTION
This PR keeps the GipPity control server usable while a custom remote app is being created and allows advanced users to choose its LAN port.

## Summary

- treat a missing, incomplete, or inaccessible custom app as discovery mode instead of failing server startup
- re-resolve the configured app on browser refresh so a newly created `index.html` activates without restarting the server
- accept a validated config-file-only `lan.port`, defaulting to 43120
- keep the create notice visible until a usable custom app is connected

## Validation

- `bun run check:changed`
- `bun run changeset:check`
- direct config normalization and incomplete-app fallback check

## Release

- Changeset: yes
- Packages: `@howaboua/pi-gippity-control`
- Aggregates: generated by release automation
