### PR TITLE
Fix first-turn setup for GipPity create

### DIFF
--- a/.changeset/patch-mst3l697-834277.md
+++ b/.changeset/patch-mst3l697-834277.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-gippity-control": patch
+---
+
+Route /gippity create through Pi's ordinary user-prompt lifecycle while preserving its custom transcript card

--- a/.changeset/patch-mst3l697-834277.md
+++ b/.changeset/patch-mst3l697-834277.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-gippity-control": patch
 ---
 
-Route /gippity create through Pi's ordinary user-prompt lifecycle while preserving its custom transcript card
+Route /gippity create through Pi's ordinary user-prompt lifecycle while preserving its custom transcript card, condense the settings details while showing the effective LAN port, and document custom web app paths and port configuration

--- a/packages/pi-gippity-control/README.md
+++ b/packages/pi-gippity-control/README.md
@@ -31,8 +31,12 @@ Commands:
 - `/gippity dictation`
 - `/gippity stop`
 - `/gippity server`
+- `/gippity create` — plan and build a custom LAN web app
+- `/gippity setup` — configure audio devices
 
 Settings live in `~/.pi/agent/pi-gippity-control.json`. Keybind changes take effect after `/reload`.
+
+`lan.customWebAppPath` may be absolute or relative to the Pi session cwd and must point to a static directory containing `index.html`. The running server rereads it on refresh. `lan.port` is optional and defaults to `43120`.
 
 The LAN server includes a microphone mute button. The host retains the Realtime WebRTC call and relays 24 kHz mono audio to the active browser, so moving between devices does not restart the voice session. The server is unauthenticated by design for trusted networks, uses a local HTTPS certificate, belongs only to the Pi session that started it, and stops when that session changes.
 

--- a/packages/pi-gippity-control/src/command.ts
+++ b/packages/pi-gippity-control/src/command.ts
@@ -11,7 +11,7 @@ import {
 import { openGippitySettings } from "./settings.ts";
 import type { CodexVoiceControls } from "./voice/controls.ts";
 import type { CodexLanVoiceServerController } from "./voice/lan/controller.ts";
-import { lanRemoteCreatePrompt } from "./voice/lan/create.ts";
+import { startLanRemoteCreateTurn } from "./voice/lan/create.ts";
 
 const ACTIONS = [
 	"realtime",
@@ -86,14 +86,11 @@ export function registerGippityCommand(options: {
 					const status = await lanVoice.setEnabled(true, ctx);
 					const baseUrl = status.urls[0];
 					if (!baseUrl) throw new Error("Control server has no reachable URL");
-					pi.sendMessage(
-						lanRemoteCreatePrompt({
-							appDirectory: ctx.cwd,
-							configPath: getGippityControlConfigPath(),
-							discoveryUrl: `${baseUrl}/api/discovery`,
-						}),
-						{ triggerTurn: true },
-					);
+					startLanRemoteCreateTurn(pi, {
+						appDirectory: ctx.cwd,
+						configPath: getGippityControlConfigPath(),
+						discoveryUrl: `${baseUrl}/api/discovery`,
+					});
 				} catch (error) {
 					ctx.ui.notify(
 						`Could not create a GipPity web app: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/pi-gippity-control/src/config.ts
+++ b/packages/pi-gippity-control/src/config.ts
@@ -1,5 +1,7 @@
 type DictationShortcutMode = "push" | "toggle";
 
+export const DEFAULT_GIPPITY_LAN_PORT = 43_120;
+
 export const VOICE_CONTEXT_REASONING_LEVELS = [
 	"off",
 	"minimal",

--- a/packages/pi-gippity-control/src/settings.ts
+++ b/packages/pi-gippity-control/src/settings.ts
@@ -6,6 +6,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { SettingsList, truncateToWidth } from "@earendil-works/pi-tui";
 import {
+	DEFAULT_GIPPITY_LAN_PORT,
 	type GippityControlConfig,
 	normalizeRealtimeV3Voice,
 	normalizeVoiceContextReasoning,
@@ -21,8 +22,6 @@ import {
 	getCodexVoiceSystemPromptPath,
 	REALTIME_SYSTEM_PROMPT_BASENAME,
 } from "./voice/system-prompt.ts";
-
-const DEFAULT_LAN_PORT = 43_120;
 
 interface Setting {
 	id: string;
@@ -262,7 +261,7 @@ function details(
 			`           dictation ${formatVoiceShortcut(config.voice.dictationShortcut)} · server ${formatVoiceShortcut(config.voice.serverShortcut)}`,
 		),
 		dim(
-			`Web app: ${webApp} · port ${config.lan.port ?? DEFAULT_LAN_PORT} (set lan.port in config)${config.lan.customWebApp ? ` · ${config.lan.customWebAppPath ?? "app discovery JSON"}` : ""}`,
+			`Web app: ${webApp} · port ${config.lan.port ?? DEFAULT_GIPPITY_LAN_PORT} (set lan.port in config)${config.lan.customWebApp ? ` · ${config.lan.customWebAppPath ?? "app discovery JSON"}` : ""}`,
 		),
 		dim(
 			`Config (/reload after keybind/device/port edits): ${getGippityControlConfigPath()}`,

--- a/packages/pi-gippity-control/src/settings.ts
+++ b/packages/pi-gippity-control/src/settings.ts
@@ -22,6 +22,8 @@ import {
 	REALTIME_SYSTEM_PROMPT_BASENAME,
 } from "./voice/system-prompt.ts";
 
+const DEFAULT_LAN_PORT = 43_120;
+
 interface Setting {
 	id: string;
 	label: string;
@@ -246,65 +248,42 @@ function details(
 	lanVoice: CodexLanVoiceServerController,
 ): string[] {
 	const status = lanVoice.status();
+	const dim = (text: string) => theme.fg("dim", `  ${text}`);
+	const webApp = config.lan.customWebApp ? "custom" : "bundled GipPity";
 	return [
 		"",
-		theme.fg(
-			"dim",
-			`  Audio input: ${config.voice.inputDevice ?? "system default"}`,
+		dim(
+			`Audio: input ${config.voice.inputDevice ?? "system default"} · output ${config.voice.outputDevice ?? "system default"}`,
 		),
-		theme.fg(
-			"dim",
-			`  Audio output: ${config.voice.outputDevice ?? "system default"}`,
+		dim(
+			`Shortcuts: realtime ${formatVoiceShortcut(config.voice.realtimeShortcut)} · mute ${formatVoiceShortcut(config.voice.muteShortcut)}`,
 		),
-		theme.fg(
-			"dim",
-			`  Realtime voice: ${formatVoiceShortcut(config.voice.realtimeShortcut)}`,
+		dim(
+			`           dictation ${formatVoiceShortcut(config.voice.dictationShortcut)} · server ${formatVoiceShortcut(config.voice.serverShortcut)}`,
 		),
-		theme.fg(
-			"dim",
-			`  Mute microphone: ${formatVoiceShortcut(config.voice.muteShortcut)}`,
+		dim(
+			`Web app: ${webApp} · port ${config.lan.port ?? DEFAULT_LAN_PORT} (set lan.port in config)${config.lan.customWebApp ? ` · ${config.lan.customWebAppPath ?? "app discovery JSON"}` : ""}`,
 		),
-		theme.fg(
-			"dim",
-			`  Dictation: ${formatVoiceShortcut(config.voice.dictationShortcut)}`,
+		dim(
+			`Config (/reload after keybind/device/port edits): ${getGippityControlConfigPath()}`,
 		),
-		theme.fg(
-			"dim",
-			`  Control server: ${formatVoiceShortcut(config.voice.serverShortcut)}`,
-		),
-		theme.fg(
-			"dim",
-			`  Web app: ${config.lan.customWebApp ? (config.lan.customWebAppPath ?? "custom app discovery JSON") : "bundled GipPity"}`,
-		),
-		theme.fg(
-			"dim",
-			`  Change keybinds/devices: ${getGippityControlConfigPath()} (/reload to apply)`,
-		),
-		"",
 		...(status.running
 			? [
-					theme.fg("accent", "  Control server is running"),
-					...status.urls.map((url) => theme.fg("dim", `  ${url}`)),
-				]
-			: [
 					theme.fg(
-						"dim",
-						"  Control server belongs to this Pi session and stops when it changes",
+						"accent",
+						"  Control server running · stops when this Pi session changes",
 					),
-				]),
+					...status.urls.map((url) => dim(url)),
+				]
+			: [dim("Control server is session-owned · stops with this Pi session")]),
 		"",
-		theme.fg(
-			"dim",
-			`  Realtime system prompt: ${getCodexVoiceSystemPromptPath()}`,
+		dim(`Realtime prompt: ${getCodexVoiceSystemPromptPath()}`),
+		dim(
+			`Project prompt append: ${CONFIG_DIR_NAME}/${REALTIME_SYSTEM_PROMPT_BASENAME}`,
 		),
-		theme.fg(
-			"dim",
-			`  Folder-level: create ${CONFIG_DIR_NAME}/${REALTIME_SYSTEM_PROMPT_BASENAME} (appends to global)`,
-		),
-		theme.fg("dim", "  Realtime system prompt changelog:"),
-		theme.fg("dim", `  ${getCodexVoiceSystemPromptChangelogPath()}`),
+		dim(`Prompt changelog: ${getCodexVoiceSystemPromptChangelogPath()}`),
 		"",
-		theme.fg("dim", "  Enter/Space to change · Esc to close"),
+		dim("Enter/Space to change · Esc to close"),
 	];
 }
 

--- a/packages/pi-gippity-control/src/voice/lan/create.ts
+++ b/packages/pi-gippity-control/src/voice/lan/create.ts
@@ -3,6 +3,17 @@ import { Box, Text } from "@earendil-works/pi-tui";
 
 const CREATE_NOTICE_TYPE = "gippity-remote-create-notice";
 const CREATE_PROMPT_TYPE = "gippity-remote-create-prompt";
+const CREATE_PROMPT_HEADER =
+	"GipPity custom remote web app creation was requested.";
+const CREATE_PROMPT_GUIDANCE = [
+	"First fetch that discovery document (the local certificate may require curl -k) and familiarize yourself with its browser client, events, audio, draft, and Pi/context JSON-RPC contracts. Treat the live document as authoritative.",
+	"This first turn is research and product discovery only. Inspect the existing project and the read-only GET documentation, but do not create or edit files, install dependencies, change config, or begin implementation.",
+	"After investigating, quiz the user about what they want the app to do and feel like: its purpose, desired controls and status, visual direction, target devices/layout, and genuine non-negotiables. Do not burden them with implementation choices you can infer yourself. Then stop and wait for their answer.",
+	"Only after the user answers should you implement a polished static web app. Use the hosted GippityRemote browser client so it retains GipPity's synchronization, audio, reconnection, and handoff behavior. Do not start or require another web server; GipPity hosts the static output.",
+	"When implementation is complete, set lan.customWebApp to true and lan.customWebAppPath to the absolute directory containing the finished index.html in the config file. Preserve every unrelated config value. The running GipPity server discovers a valid new path automatically; ask the user to refresh or open its URL.",
+	"Important: the live server is wired to this exact Pi session. Do not call its RPC endpoint, GippityRemote.call, send/draft controls, audio controls, or other live operations while implementing—the calls would target your own session and may interrupt or replace it. You may inspect GET discovery and client-script resources. Rely on the user to open the app, test operations, and report behavior.",
+	"Build and statically validate the app. When it is ready, tell the user what changed, ask them to refresh or open the GipPity URL, and have them perform the live checks you need.",
+] as const;
 
 interface CreateNoticeDetails {
 	discoveryUrl: string;
@@ -22,14 +33,17 @@ export function registerLanRemoteCreateRenderers(pi: ExtensionAPI): void {
 				`No custom web app is connected.\nRun /gippity create to have Pi build one.\nDiscovery: ${entry.data?.discoveryUrl ?? "unavailable"}`,
 			),
 	);
-	pi.registerMessageRenderer<CreatePromptDetails>(
+	pi.registerEntryRenderer<CreatePromptDetails>(
 		CREATE_PROMPT_TYPE,
-		(message, _options, theme) =>
+		(entry, _options, theme) =>
 			remoteBox(
 				theme,
 				"GipPity Web App",
-				`Planning a custom remote in ${message.details?.appDirectory ?? "the current project"}.\nContract: ${message.details?.discoveryUrl ?? "unavailable"}\nPi will inspect the contract, then ask what you want.`,
+				`Planning a custom remote in ${entry.data?.appDirectory ?? "the current project"}.\nContract: ${entry.data?.discoveryUrl ?? "unavailable"}\nPi will inspect the contract, then ask what you want.`,
 			),
+	);
+	pi.registerMarkdownTransformer((markdown, { messageType }) =>
+		messageType === "user" && isLanRemoteCreatePrompt(markdown) ? "" : markdown,
 	);
 }
 
@@ -40,33 +54,46 @@ export function appendLanRemoteCreateNotice(
 	pi.appendEntry<CreateNoticeDetails>(CREATE_NOTICE_TYPE, { discoveryUrl });
 }
 
-export function lanRemoteCreatePrompt(options: {
+export function startLanRemoteCreateTurn(
+	pi: ExtensionAPI,
+	options: {
+		appDirectory: string;
+		configPath: string;
+		discoveryUrl: string;
+	},
+): void {
+	pi.appendEntry<CreatePromptDetails>(CREATE_PROMPT_TYPE, {
+		appDirectory: options.appDirectory,
+		discoveryUrl: options.discoveryUrl,
+	});
+	pi.sendUserMessage(lanRemoteCreatePrompt(options));
+}
+
+function lanRemoteCreatePrompt(options: {
 	appDirectory: string;
 	configPath: string;
 	discoveryUrl: string;
-}) {
-	const instructions = [
-		"GipPity custom remote web app creation was requested.",
+}): string {
+	return [
+		CREATE_PROMPT_HEADER,
 		`Project directory: ${options.appDirectory}`,
 		`Config file: ${options.configPath}`,
 		`Live discovery and protocol documentation: ${options.discoveryUrl}`,
-		"First fetch that discovery document (the local certificate may require curl -k) and familiarize yourself with its browser client, events, audio, draft, and Pi/context JSON-RPC contracts. Treat the live document as authoritative.",
-		"This first turn is research and product discovery only. Inspect the existing project and the read-only GET documentation, but do not create or edit files, install dependencies, change config, or begin implementation.",
-		"After investigating, quiz the user about what they want the app to do and feel like: its purpose, desired controls and status, visual direction, target devices/layout, and genuine non-negotiables. Do not burden them with implementation choices you can infer yourself. Then stop and wait for their answer.",
-		"Only after the user answers should you implement a polished static web app. Use the hosted GippityRemote browser client so it retains GipPity's synchronization, audio, reconnection, and handoff behavior. Do not start or require another web server; GipPity hosts the static output.",
-		"When implementation is complete, set lan.customWebApp to true and lan.customWebAppPath to the absolute directory containing the finished index.html in the config file. Preserve every unrelated config value. The running GipPity server discovers a valid new path automatically; ask the user to refresh or open its URL.",
-		"Important: the live server is wired to this exact Pi session. Do not call its RPC endpoint, GippityRemote.call, send/draft controls, audio controls, or other live operations while implementing—the calls would target your own session and may interrupt or replace it. You may inspect GET discovery and client-script resources. Rely on the user to open the app, test operations, and report behavior.",
-		"Build and statically validate the app. When it is ready, tell the user what changed, ask them to refresh or open the GipPity URL, and have them perform the live checks you need.",
+		...CREATE_PROMPT_GUIDANCE,
 	].join("\n");
-	return {
-		customType: CREATE_PROMPT_TYPE,
-		content: instructions,
-		display: true,
-		details: {
-			appDirectory: options.appDirectory,
-			discoveryUrl: options.discoveryUrl,
-		} satisfies CreatePromptDetails,
-	};
+}
+
+function isLanRemoteCreatePrompt(markdown: string): boolean {
+	const lines = markdown.split("\n");
+	return (
+		lines.length === CREATE_PROMPT_GUIDANCE.length + 4 &&
+		lines[0] === CREATE_PROMPT_HEADER &&
+		lines[1]?.startsWith("Project directory: ") === true &&
+		lines[2]?.startsWith("Config file: ") === true &&
+		lines[3]?.startsWith("Live discovery and protocol documentation: ") ===
+			true &&
+		CREATE_PROMPT_GUIDANCE.every((line, index) => lines[index + 4] === line)
+	);
 }
 
 function remoteBox(theme: Theme, labelText: string, bodyText: string): Box {

--- a/packages/pi-gippity-control/src/voice/lan/server.ts
+++ b/packages/pi-gippity-control/src/voice/lan/server.ts
@@ -5,7 +5,10 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { WebSocketServer } from "ws";
-import type { GippityControlConfig } from "../../config.ts";
+import {
+	DEFAULT_GIPPITY_LAN_PORT,
+	type GippityControlConfig,
+} from "../../config.ts";
 import { getGippityControlConfigPath } from "../../config-store.ts";
 import type { CodexVoiceAuth } from "../auth.ts";
 import type { CodexVoiceController } from "../controller.ts";
@@ -39,7 +42,6 @@ import {
 } from "./server-runtime.ts";
 import { createLanVoiceWebUi } from "./web-ui.ts";
 
-const DEFAULT_PORT = 43_120;
 const HEARTBEAT_MS = 15_000;
 
 export interface CodexLanVoiceServer {
@@ -292,7 +294,7 @@ export async function startCodexLanVoiceServer(options: {
 	try {
 		await listen(
 			server,
-			options.port ?? initialConfig.lan.port ?? DEFAULT_PORT,
+			options.port ?? initialConfig.lan.port ?? DEFAULT_GIPPITY_LAN_PORT,
 		);
 	} catch (error) {
 		removeInputMuteListener();


### PR DESCRIPTION
This PR makes `/gippity create` use Pi's ordinary user-prompt lifecycle and trims the settings footer while keeping its operational details visible.

## Summary

- keep the GipPity creation card as display-only transcript presentation while delivering the unchanged instructions through `sendUserMessage`
- avoid lifecycle fallback machinery in `pi-codex-conversion`
- group audio, shortcut, web-app, effective LAN port, config/reload, server ownership, URL, prompt, and changelog details into a shorter settings block
- document `/gippity create`, `/gippity setup`, custom web-app path rules, refresh discovery, and the optional `lan.port` default

## Validation

- focused Biome and type checks
- 64-column settings preview; stopped and running detail blocks each reduced by five lines
- `bun run check:changed`
- `bun run changeset:check`
- `git diff --check origin/main...HEAD`

## Review focus

The settings change is presentation-only: selectable settings and server behavior are unchanged. Pi input handlers may intentionally transform or consume extension-origin user messages; the create flow deliberately uses that ordinary lifecycle.

## Release

- Changeset: yes
- Package: `@howaboua/pi-gippity-control`
- Aggregates: generated by release automation
