### PR TITLE
Make stacked release batches JJ-first

### DIFF
--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-issue-pr-flow
-description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/worktree batches, branches, commits, PRs, review, release hygiene. Use for filing or implementing issues, package changes, PR delivery, or feedback."
+description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/JJ workspace batches, branches, commits, PRs, review, release hygiene. Use for filing or implementing issues, package changes, PR delivery, or feedback."
 ---
 
 # GitHub Issue and PR Flow
@@ -21,7 +21,7 @@ description: "This repo's GitHub/Changesets workflow: issues, parallel Herdr/wor
 
 Before the first commit or push, verify `gh api user --jq .login`, `git config user.name`, and `git config user.email`. Do not silently switch accounts or attribute collaborator work to the repository owner.
 
-- If the checkout's branch or dirty state belongs to another task, create a dedicated worktree and focused branch from fetched `origin/main`.
+- If the checkout belongs to another task, create a dedicated Git worktree/branch or, for a release stack, the JJ coordinator clone/workspace required by `../gh-stack/SKILL.md`.
 - A collaborator with push permission uses a focused branch on `origin` and opens the PR as themself. Use a fork only when the repository does not grant branch push access.
 - Preserve imported authorship: cherry-pick supplied commits where possible; otherwise retain their author metadata. New integration, repair, release, and documentation commits use the active contributor identity.
 - The PR author may update but not approve their own work. Surface known product choices under `Review focus`; an eligible maintainer owns approval and explicit merge direction.
@@ -47,42 +47,50 @@ Before the first commit or push, verify `gh api user --jq .login`, `git config u
 
 ### Dispatch a parallel issue batch
 
-Use a native stack to review focused release-batch layers, but assemble them into a dedicated release
-branch outside the stack. That branch is based on `origin/main`, named for the release, and becomes the
-one ordinary aggregate PR to `main`. Never add it as a top cap layer. This repo runs PR CI for every
-layer and Changesets/npm release work only on `push` to `main`; merging the stack must update only the
-release branch, while merging its final ordinary PR is the single release action.
+Use the JJ-first umbrella workflow in `../gh-stack/SKILL.md`: focused revisions/bookmarks become a
+native stack rooted on a staging branch, while a separate ordinary draft umbrella PR shows the
+cumulative batch against `main`. The umbrella is not a stack member and is the only PR that ultimately
+merges to `main`. Use the Git-managed fallback only when JJ is unavailable.
 
 Dispatch is a handoff, not a supervision loop:
 
 1. Read every issue first. Keep all issues in the requested release batch, identify dependencies and overlapping files/packages, then choose a stable bottom-to-top order. Exclude only work that should release separately.
-2. Fetch `origin/main` once and record its SHA. In a dedicated coordinator worktree, create a clean
-   release branch from that SHA, name it for the target release (for example `<package>/<version>`),
-   and push it. Follow `../gh-stack/references/create.md` to create and track every worker branch in
-   stack order before implementation starts. The release branch is the stack trunk, not a member. Do
-   not create sibling branches and retrofit them later.
-3. Detach the coordinator worktree to free the stack's current branch. Check out each tracked stack branch into its own worker worktree under a sibling root such as `<repo-parent>/.worktrees/<repo>/issue-123`.
-4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per worktree, label it with the issue number and short title, and launch a named Pi session with `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr's JSON; do not guess IDs.
-5. Give each worker this ownership contract: read the issue and repository instructions; implement only that issue directly on the assigned stack branch; add its changeset for shipped package work; run focused validation; cull weak tests; commit all intended work; do not push, open a PR, run the umbrella gate, invoke `gh stack`, or touch another worktree. If blocked, ask in this panel and wait for the user. When finished, report commit SHA, changed surface, checks, and risks, then remain idle.
-6. Return the issue → branch → worktree → Herdr workspace/pane map and stop. Do not wait for, read, message, steer, review, or decide readiness for dispatched agents. Resume only after an explicit user signal such as “workers X, Y, Z are ready.”
+2. Record fetched `main@origin`. In a dedicated colocated JJ coordinator clone, create and publish the
+   staging bookmark, then create described focused revisions/bookmarks in planned order without
+   publishing empty PRs. Follow `../gh-stack/references/create.md`.
+3. Create one JJ workspace per focused revision under a sibling workspace root. Enter each workspace
+   and `jj edit <layer>` so the worker owns that revision; do not use `git worktree` for JJ workspaces.
+4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per JJ
+   workspace, label it with issue number/title, and launch a named Pi session with
+   `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr JSON.
+5. Give each worker this contract: read the issue and repo instructions; implement only that focused
+   revision; add its package changeset; run focused validation; cull weak tests; leave a described,
+   conflict-free revision; do not push, open PRs, reorder revisions, move bookmarks, invoke `gh stack`,
+   or touch another workspace. If blocked, ask in-panel and wait. Report change ID/commit, surface,
+   checks, and risks, then remain idle.
+6. Return issue → JJ revision/bookmark → workspace → Herdr workspace/pane and stop. Do not supervise or
+   decide readiness until the user explicitly names ready workers.
 
 ### Resume a dispatched issue batch
 
-1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready worktrees and commits. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
-2. Stop the ready panels and detach or remove their clean worktrees so Git can rewrite the checked-out branches. In the coordinator worktree, check out a stack branch, run the cascading `gh stack rebase`, resolve integration conflicts in the owning layer, and verify the complete order with `gh stack view --json`.
-3. Verify each shipped package layer owns its changeset, then apply the verification cull across the
-   complete stack and run the umbrella gate once from the cumulative top worker branch. Do not add the
-   release branch as a cap or create an empty placeholder commit.
-4. Run `gh stack submit --auto --open` to create native PRs and the stack object on GitHub.com. Verify the GitHub stack map, then edit every PR's title, body, issue linkage, base, and order. Use `Closes` only where the layer fully resolves its issue. Invoke configured review systems on each focused layer.
-5. Return the layer → PR map and stop again. Dispatch review-fix workers only when the user asks; each fix wave follows the same launch-and-handoff boundary. After the user declares review converged, rebase and push the affected upstack, run `gh stack submit --auto --open`, and report readiness.
-6. Assemble only on explicit user direction. Confirm every layer is approved and green and
-   `gh stack view --json` names the dedicated release branch as trunk, then merge the top layer with
-   `gh stack merge <top-layer-pr> --yes` and the repository's method. Verify `main` did not move, sync,
-   check out the release branch, run the umbrella gate, and open its ordinary aggregate PR to `main`.
-   Stop for its review and CI. Merge that final PR only on a separate explicit user direction; that
-   one ordinary merge triggers the release workflow.
+1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready JJ workspaces and revisions. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
+2. Stop ready panels. In the coordinator, integrate JJ operations, inspect revisions, resolve conflicts
+   in the owning layer, and verify planned order. Forget/delete clean worker workspaces only after their
+   revisions are safely bookmarked.
+3. Verify each shipping layer owns its changeset, apply the verification cull across the stack, and run
+   the umbrella gate once from the cumulative top.
+4. Move/create the umbrella bookmark at that top. Link focused bookmarks bottom to top with `gh stack
+   link --base <staging> --open ...`, push the umbrella bookmark, and open its ordinary draft PR to
+   `main`. Verify native order, every direct base, and the cumulative umbrella diff; edit titles,
+   bodies, issue linkage, focused `Part of` links, validation, and release context.
+5. Return layer → focused PR plus umbrella PR and stop. Dispatch review-fix workspaces only when asked.
+   After review converges, update owner revisions, relink focused heads, move/push umbrella to the new
+   top, and report readiness.
+6. Assemble only on explicit direction through `../gh-stack/references/merge.md`. Native merge updates
+   staging and marks focused PRs merged; then move the umbrella to assembled staging and stop for its
+   fresh aggregate CI/review. Merge the umbrella to `main` only on a separate explicit direction.
 
-Use one integration PR without layer PRs when slices do not merit separate review or stack support is
+Use one umbrella PR without layer PRs when slices do not merit separate review or stack support is
 unavailable. Use ordinary separate PRs when work should release independently.
 
 ### Open or update a PR for existing work
@@ -108,7 +116,7 @@ unavailable. Use ordinary separate PRs when work should release independently.
 - Fetch/prune before choosing a base or repairing history.
 - Before using long-lived `dev` for a PR, reset it onto `origin/main` and cherry-pick only intended pending commits. Never merge `main` into `dev`.
 - Do not stash, reset, overwrite, or include unrelated local changes merely for convenience.
-- Do not amend or rewrite published shared history. If a push is rejected, inspect divergence before choosing rebase, reset, merge, or lease-protected force push.
+- Do not rewrite published shared history except deliberate focused-stack evolution under `../gh-stack/SKILL.md`. If a push is rejected, inspect divergence before choosing rebase, reset, merge, or lease-protected force push.
 
 ## Verification cull
 

--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -163,6 +163,8 @@ This PR ...
 
 ## Codex review
 
+Manual Codex review requests are temporarily disabled while automatic review detection is tested. Do not post the request below.
+
 When opening a PR, post the standard review request unless the user says not to. Do not repost it after every update.
 
 ```text

--- a/.pi/skills/gh-issue-pr-flow/references/release-and-repository-hygiene.md
+++ b/.pi/skills/gh-issue-pr-flow/references/release-and-repository-hygiene.md
@@ -7,7 +7,7 @@ Read this reference only for shipped package work, release readiness, package ch
 - Workspace packages live under `packages/*` and remain separately installable.
 - Release tooling is Changesets. Do not manually bump package versions for normal feature or fix work.
 - Add a changeset when a change is meant to ship. Select only directly changed individual packages; patch is the normal fix/refinement bump.
-- In a release stack, each shipping layer owns its changeset; the top batch cap does not combine them. Multiple patch entries for one package coalesce into one version bump.
+- In a release stack, each shipping layer owns its changeset; the umbrella PR does not combine them. Multiple patch entries for one package coalesce into one version bump.
 - Do not manually add changesets or edit versions for aggregate packages: `@howaboua/pi-skills`, `@howaboua/pi-extensions`, or `@howaboua/pi-stuff`.
 - CI derives aggregate changesets with `bun run changeset:aggregates`.
 - Treat pending changesets on long-lived branches as suspect. Keep only changesets for changes intentionally present in the branch; remove files already consumed by `origin/main` release commits.

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -1,60 +1,72 @@
 ---
 name: gh-stack
-description: "Operate native GitHub stacked PRs with gh stack. Use when designing or creating a stack, updating or reviewing stacked branches and PRs, repairing stack state, approving layers, or merging part or all of a stack; not ordinary independent PRs."
+description: "Native GitHub stacks with live umbrella release PRs and JJ/Git history. Use for designing, creating/linking, updating, reviewing, assembling, or merging dependent PR stacks; not ordinary independent PRs."
 license: MIT
-compatibility: "Requires authenticated GitHub CLI and the github/gh-stack extension"
+compatibility: "Requires authenticated GitHub CLI and github/gh-stack; JJ is preferred for local stack history"
 ---
 
 # gh-stack
 
-A native stack is a trunk-rooted branch chain:
+A release stack has two GitHub surfaces:
 
 ```text
-(main) <- bottom <- middle <- top
+main <- umbrella PR (ordinary, cumulative, only main landing)
+
+staging trunk <- bottom <- middle <- top   (focused native stack)
 ```
 
-Left merges first. `up` moves away from trunk; `down` moves toward it. Each PR targets the branch
-immediately below, so its ordinary diff contains only that layer.
+The umbrella head follows the focused top during review but is not a native stack member. The native
+stack assembles into staging; staging then replaces the umbrella head for final aggregate review.
 
 ## Boundaries
 
 - Repository instructions and explicit user direction override this skill.
-- Never merge without explicit user approval. Readiness, green checks, approval requests, or submit
-  requests are not merge authorization.
-- Before the first write, verify GitHub and Git author identities and isolate a checkout owned by
-  another task. A collaborator authors and pushes as themself.
-- The stack author does not approve their own PRs or switch identities to bypass protection. An
-  eligible maintainer owns approval and explicit merge direction.
-- Treat native stack state as authoritative. Branch ancestry and PR bases do not prove GitHub stack
-  membership or order.
-- Keep stacks linear. Put each change on its lowest owning layer and keep unrelated release units in
-  another stack or PR.
-- For a release batch, create a dedicated integration branch from `main` and use it as the stack
-  trunk. It stays outside the stack and becomes the final ordinary PR to `main`; never add it as a
-  top cap layer.
-- Never merge a native stack member with `gh pr merge`. The final integration PR is ordinary and is
-  merged separately only after its own explicit authorization.
+- Never assemble or merge without explicit user approval. Readiness, green checks, approval requests,
+  and submit requests are not merge authorization. Final umbrella merge needs separate authorization
+  after assembly.
+- Before the first write, verify GitHub and author identities and isolate work owned by another task.
+- The author does not approve their own PRs or switch identities to bypass protection.
+- Keep focused layers linear and independently reviewable. Put each change on its lowest owner.
+- For one release unit, create a staging branch from `main`, root the native stack there, and keep a
+  separate ordinary umbrella PR to `main`. Neither staging nor umbrella belongs to the native stack.
+- The umbrella is the cumulative release view, stays draft until assembly, and is the only PR merged
+  to `main`. Never merge native members with `gh pr merge`.
+- Prefer JJ revisions/bookmarks/workspaces for local history. Use `gh stack link` for GitHub topology;
+  do not adopt the same stack into local `gh-stack` tracking or mix in `sync`, `rebase`, or `push`.
+- If JJ is unavailable, use the explicit Git-managed fallback. One local-history owner per stack.
+- Native GitHub stack state is authoritative for membership and order; ancestry and PR bases alone
+  are insufficient.
 
 ## Route
 
-Read the reference for the current phase before acting. Load another only when the operation crosses
-that boundary.
+Read the phase reference before acting; load another only when crossing its boundary.
 
-- **Plan, create, adopt, link, or submit:** `references/create.md`
-- **Inspect, update, rebase, push, or restructure:** `references/work.md`
-- **Review focused PRs, run review agents, or request bot reviews:** `references/review.md`
-- **Approve, partially merge, fully merge, or reconcile after merge:** `references/merge.md`
+- **Plan, create bookmarks/branches, link focused PRs, open umbrella:** `references/create.md`
+- **Inspect, edit, rebase, push, or restructure:** `references/work.md`
+- **Review focused PRs and cumulative umbrella:** `references/review.md`
+- **Approve, assemble into staging, refresh umbrella, or merge:** `references/merge.md`
 
 ## Command contract
 
-Use `gh stack <command> --help`; `gh stack help <command>` only prints top-level help. These contracts
-target v0.1.0, but installed command help wins.
+Use `gh stack <command> --help`; installed help wins. Run without a PTY. Bare commands may prompt or
+open a TUI.
 
-Run without a PTY. Bare `view`, `submit`, `init`, `add`, `checkout`, `merge`, and `switch` may prompt
-or open a TUI. Use explicit arguments and flags. `gh stack modify` is TUI-only; restructure through
-the documented noninteractive path instead.
+JJ route:
 
-Parse `gh stack view --json`, whose stable fields are:
+- `jj` owns revisions, order, conflicts, bookmarks, and workspaces.
+- Focused bookmarks are listed bottom to top in `gh stack link --base <staging> ...`.
+- A separate umbrella bookmark points at the cumulative top and is pushed with `jj git push`.
+- `gh stack link` and `merge` own remote topology and landing; never run locally mutating
+  `gh stack init/add/sync/rebase/push/submit` for that stack.
+- Inspect externally managed native order through `gh api
+  "repos/{owner}/{repo}/stacks?pull_request=<focused-pr>"`; bare `view` needs local tracking.
+
+Git fallback:
+
+- `gh stack init/add/sync/rebase/push/submit` owns local and remote focused stack state.
+- The umbrella remains a separate branch/ordinary PR and never enters `.git/gh-stack`.
+
+For the Git fallback, parse `gh stack view --json`. Stable fields:
 
 ```text
 trunk, currentBranch
@@ -62,5 +74,7 @@ branches[]: name, head, base, isCurrent, isMerged, isQueued, needsRebase
 branches[].pr: number, url, state (OPEN | MERGED | QUEUED)
 ```
 
-`base` is the saved parent SHA and can lag the parent's tip. `needsRebase` reports whether the parent
-tip is still an ancestor.
+`base` is the saved parent SHA and may lag the parent tip; `needsRebase` reports ancestry.
+
+The remote Stacks REST response is authoritative for JJ-linked stacks: `number`, `base.ref`, and
+ordered `pull_requests[]` entries with `number`, `state`, `draft`, `merged_at`, and `head.{ref,sha}`.

--- a/.pi/skills/gh-stack/references/create.md
+++ b/.pi/skills/gh-stack/references/create.md
@@ -10,7 +10,7 @@ Name four kinds of ref:
 ```text
 <batch>/staging        remote native-stack trunk; no PR
 <topic>/<layer>        one bookmark/branch per focused PR
-<batch>                ordinary umbrella PR head; never a stack member
+<batch>/umbrella       ordinary umbrella PR head; never a stack member
 main                   umbrella PR base; only release target
 ```
 
@@ -79,6 +79,7 @@ Link only focused bookmarks, bottom to top. `link` pushes them, creates or retar
 creates the native GitHub stack without local `gh-stack` tracking:
 
 ```bash
+jj git push --remote origin --bookmark <bottom> --bookmark <next> --bookmark <top>
 jj git export --ignore-working-copy
 gh stack link --base <staging> --open <bottom> <next> <top>
 jj git push --remote origin --bookmark <umbrella>

--- a/.pi/skills/gh-stack/references/create.md
+++ b/.pi/skills/gh-stack/references/create.md
@@ -1,92 +1,128 @@
-# Create a stack
+# Create an umbrella stack
 
-Use this phase to choose layers, establish the chain, and create the native PR stack before parallel
-or dependent implementation begins.
+Plan one cumulative ordinary PR plus focused native stack layers. Use one ordinary PR instead when
+the slices do not merit separate review; use separate release units when work may ship independently.
 
-## Choose the landing shape
+## Plan bottom to top
 
-Use a stack when concerns merit focused PRs but deliberately land together: code dependencies or a
-repository-defined issue/release batch. Use one ordinary PR when slices do not merit separate review.
-Use separate PRs or stacks when work should release independently.
+Name four kinds of ref:
 
-For a release batch, create a dedicated integration branch from the current target branch and keep it
-outside the native stack. Name it for the release or batch, such as `<package>/<version>`. Stack every
-focused layer on that branch, atomically assemble the reviewed stack into it, then open its one ordinary
-PR to `main`. This preserves a cumulative final diff and one release-triggering merge. Never use a top
-stack cap as the final integration PR.
+```text
+<batch>/staging        remote native-stack trunk; no PR
+<topic>/<layer>        one bookmark/branch per focused PR
+<batch>                ordinary umbrella PR head; never a stack member
+main                   umbrella PR base; only release target
+```
 
-Base a stack directly on `main` only when every selected prefix is independently safe to ship and a
-push to `main` is intended at stack-merge time.
-
-Plan bottom to top before writing code. Dependencies go in the same or a lower layer. Give each layer
-one sentence of ownership and use repository branch conventions; otherwise prefer
-`<topic>/<concern>`.
+Dependencies belong in the same or a lower focused layer. Give each layer one ownership sentence.
+The umbrella owns only cumulative release context, not implementation or a fake cap change.
 
 ## Preconditions
 
 ```bash
 gh stack --version
-git config rerere.enabled true
 gh api user --jq .login
 git config user.name
 git config user.email
 git status --short --branch
-git fetch --prune origin
 ```
 
-Inspect existing branches and PRs before adopting them. With several remotes, pass `--remote` where
-supported or configure one unambiguous remote.
+For JJ, also verify `jj --version`, `jj root`, `jj status`, `jj workspace list`, `jj config get
+user.name`, and `jj config get user.email`. JJ identity is separate from Git identity; configure the
+verified active contributor before creating changes. Use an existing colocated JJ repository or a
+dedicated `jj git clone --colocate`; do not retrofit JJ into a shared checkout/worktree. Run `jj git
+fetch --remote origin` before selecting `main@origin`.
 
-## Create the chain
+Inspect existing PRs, bookmarks/branches, and remote names before creating refs. Configure an explicit
+remote when more than one is plausible.
 
-For a release batch, create and publish its clean integration trunk first, then create all planned
-stack branches above it:
+## Preferred JJ route
+
+Create and publish a staging bookmark at the selected `main` revision:
 
 ```bash
-git switch --create <integration-branch> origin/main
-git push --set-upstream origin <integration-branch>
-gh stack init --base <integration-branch> <bottom> <next> <top>
+jj bookmark create <staging> --revision main@origin
+jj git push --remote origin --bookmark <staging>
 ```
 
-Arguments are bottom to top; existing branches are adopted, missing branches are created, and the
-last branch is checked out. For sequential implementation, create the bottom and add layers from the
-current top:
+Create focused changes bottom to top. A bookmark points to each completed change; `@` advances to the
+next layer:
 
 ```bash
-gh stack init --base <integration-branch> <bottom>
-# edit, validate, stage deliberately, commit
+jj new <staging> -m "<bottom description>"
+# edit and validate the bottom layer
+jj bookmark create <bottom> --revision @
+
+jj new -m "<next description>"
+# edit and validate the next layer
+jj bookmark create <next> --revision @
+```
+
+For a parallel batch, create the described/bookmarked layer skeleton without publishing it, then move
+the coordinator working copy away so workers can edit those revisions:
+
+```bash
+jj new <staging>
+```
+
+Create worker workspaces and `jj edit <layer>` as specified in `work.md`. Empty skeleton revisions are
+local planning state only; do not link or push them.
+
+Before publishing, require every focused revision to be non-empty, described, conflict-free, and to
+own only its layer. Create the umbrella bookmark at the focused top:
+
+```bash
+jj bookmark create <umbrella> --revision <top>
+```
+
+Link only focused bookmarks, bottom to top. `link` pushes them, creates or retargets focused PRs, and
+creates the native GitHub stack without local `gh-stack` tracking:
+
+```bash
+jj git export --ignore-working-copy
+gh stack link --base <staging> --open <bottom> <next> <top>
+jj git push --remote origin --bookmark <umbrella>
+```
+
+Open the cumulative umbrella as an ordinary draft PR:
+
+```bash
+gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
+```
+
+GitHub cannot open an empty PR. Create the umbrella after the first real focused change exists; never
+seed it with placeholder code or metadata. Its body lists focused PRs and release-level validation.
+Each focused PR links back with `Part of #<umbrella-pr>`.
+
+## Git-managed fallback
+
+Use only when JJ is unavailable. Create staging from the selected target, then let `gh-stack` own the
+focused branch chain:
+
+```bash
+git switch --create <staging> origin/main
+git push --set-upstream origin <staging>
+gh stack init --base <staging> <bottom>
+# edit, validate, commit
 gh stack add <next>
 ```
 
-`add` carries uncommitted changes onto the new branch. Avoid its commit shortcuts: use `git add` and
-`git commit` directly so each layer owns only its concern. `add` from a middle branch exits 5; move to
-the top first.
-
-For branches owned by another manager or worktree layout, link without creating local tracking:
-
-```bash
-gh stack link --base <integration-branch> <bottom-branch-or-pr> <next> <top>
-```
-
-`link` is additive, accepts branches or PRs bottom to top, may push branch arguments and create or
-retarget PRs, and never removes members. Use `gh stack checkout <stack-or-pr>` later if local tracking
-is needed.
-
-## Submit
-
-From the top after every layer is committed and the complete stack validates:
+After all focused layers are committed:
 
 ```bash
 gh stack submit --auto --open
-gh stack view --json
+gh stack top
+git branch <umbrella>
+git push --set-upstream origin <umbrella>
+gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
 ```
 
-Omit `--open` only when drafts were explicitly requested. Submit pushes active branches, creates or
-updates PRs, bases each on its active ancestor, and links the GitHub stack. It is not atomic: earlier
-pushes and PR changes survive a later failure, so repair the rejected branch and rerun. Exit 9 means
-stacked PRs are unavailable.
+`add` carries uncommitted changes; avoid its commit shortcuts. `submit` is not atomic, so repair a
+rejected branch and rerun. Keep the umbrella branch outside local stack tracking. Do not run the JJ
+export command in this fallback route.
 
-`--auto` derives titles from commits or branch names. Use `gh pr edit` afterward for accurate title,
-body, issue linkage, validation, and release information. Verify the GitHub stack order rather than
-inferring it from ancestry alone. Do not open the integration PR until the reviewed stack has been
-assembled into its branch; an empty placeholder PR is not the release gate.
+## Verify publication
+
+Inspect each focused PR's direct base and current head, the remote native order, and the umbrella's
+`main..umbrella` cumulative diff. Do not infer native membership from ancestry alone. Record focused
+PR numbers, stack number, staging ref, umbrella PR, and umbrella head SHA.

--- a/.pi/skills/gh-stack/references/merge.md
+++ b/.pi/skills/gh-stack/references/merge.md
@@ -1,112 +1,117 @@
-# Merge a stack
+# Assemble and land an umbrella stack
 
-Use this phase for maintainer approvals, atomic assembly into the integration branch, the final
-integration PR, and reconciliation afterward.
+Assembly and final landing are separate irreversible boundaries:
 
-## Authorization and readiness
+1. Native focused stack -> staging branch.
+2. Ordinary umbrella PR -> `main`.
 
-Assemble only after explicit user direction names or unambiguously selects the intended boundary. A
-PR target merges that PR and every unmerged PR below it; a stack target merges every unmerged member.
-Never broaden the target to satisfy a rule. Confirm `gh stack view --json` names the dedicated
-integration branch—not `main`—as trunk before merging a release stack.
+Each requires explicit user direction. Never infer authorization from approval, CI, or the other step.
 
-Before stack approval, check out the top layer and validate the cumulative filesystem state:
+## Focused-stack readiness
+
+An explicit PR target selects that PR and every unmerged native member below it; a stack target selects
+all unmerged members. Never broaden the boundary to satisfy a rule.
+
+Refresh `main` before final focused approval. If staging is not at current `main@origin`, update the
+base and rewrite the focused chain before treating any head/check/approval as final:
 
 ```bash
-gh stack checkout <top-pr>
-gh stack top
-git status --short --branch
-# run the repository umbrella gate once
+jj git fetch --remote origin
+jj bookmark move <staging> --to main@origin --allow-backwards
+jj rebase --source <bottom> --onto <staging>
+# resolve every recorded conflict
+jj bookmark move <umbrella> --to <top> --allow-backwards
+jj git push --remote origin --bookmark <staging>
+jj git export --ignore-working-copy
+gh stack link --base <staging> <bottom> <next> <top>
+jj git push --remote origin --bookmark <umbrella>
 ```
 
-The top stack branch contains every layer by ancestry, so it is the candidate assembled into the
-integration trunk. The integration branch itself stays outside the stack and later supplies the
-aggregate `main` diff.
+Rerun focused and cumulative checks/reviews on rewritten heads. For the Git fallback, fast-forward the
+still-empty staging branch to `origin/main`, push it, then cascade-rebase/push the locally tracked stack
+and update the umbrella. If staging cannot fast-forward because it already contains assembled work,
+stop and reassess the selected release boundary instead of merging `main` into it.
 
-Before merging, inspect the native range and confirm every included PR is open, non-draft, approved,
-green, and free of unresolved required threads:
+Before approval/assembly:
+
+- Native trunk is the dedicated staging branch, not `main` or umbrella.
+- Every selected focused PR is open, non-draft, approved, green, and free of unresolved required
+  threads.
+- JJ graph or Git ancestry matches native order and contains no conflicts or unrelated changes.
+- Umbrella bookmark/branch points at the selected cumulative top.
+- Cumulative umbrella check passes once from that top.
+
+For a colocated JJ route, record the candidate tree before assembly:
 
 ```bash
-gh stack view --json
-gh pr view <pr> --json state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup
-gh stack merge --help
+jj git export --ignore-working-copy
+candidate_tree=$(git rev-parse '<umbrella>^{tree}')
 ```
 
-The stack author cannot approve their own work. When the user has established an eligible maintainer
-login, use that account's token only for the approval command; never switch the active `gh` account:
+The author cannot approve their own work. When an eligible reviewer is established, use that account's
+token for approval only; never switch the active `gh` account:
 
 ```bash
-: "${pr:?set PR to approve}"
+: "${pr:?set focused PR}"
 : "${reviewer:?set eligible reviewer login}"
-review_token=$(gh auth token --user "$reviewer")
-test "$(GH_TOKEN="$review_token" gh api user --jq .login)" = "$reviewer"
-GH_TOKEN="$review_token" gh pr review "$pr" --approve
+token=$(gh auth token --user "$reviewer")
+test "$(GH_TOKEN="$token" gh api user --jq .login)" = "$reviewer"
+GH_TOKEN="$token" gh pr review "$pr" --approve
 ```
 
-Approvals attach to current heads and may be dismissed by a later push or cascade rebase.
+## Assemble into staging
 
-## Assemble the chosen range
-
-State the method and suppress prompts:
+State the boundary and method, then suppress prompts:
 
 ```bash
-# Assemble the whole stack into its integration trunk
-gh stack merge <top-pr> --yes --squash
-
-# Assemble a prefix; upper layers remain open
-gh stack merge <highest-pr-to-land> --yes --squash
+gh stack merge <highest-focused-pr> --yes --squash
 ```
 
-Use `--merge` or `--rebase` only when deliberately selected. The operation prints its exact PR list and
-is all-or-nothing: if one member fails repository rules, none merge. A merge queue overrides the method
-and may land members in separate groups. Native stacks do not support bypassing repository rules. The
-assembly changes only the configured integration trunk; it must not push `main`.
+Use another method only when deliberately selected. The native operation is all-or-nothing unless a
+merge queue controls grouping. Never substitute serial `gh pr merge` calls. If the endpoint requires
+a code owner despite valid approvals, confirm nothing merged, then retry the exact same boundary with
+that code owner's token; never include an unrelated upper PR.
 
-## Code-owner rejection
-
-GitHub's atomic endpoint can report `Waiting on code owner review from <login>` even when every PR in
-the requested range is clean and approved by that owner. First confirm the failure merged nothing and
-the intended PR boundary was correct. Do not add or approve an integration cap as a stack member merely
-to widen the operation, and do not fall back to serial `gh pr merge` calls.
-
-If the failed mutation ran as the stack author, retry the exact target with the required code owner's
-token for this command only:
+When a merge queue accepts the stack, queued is not assembled. Wait at a reasonable interval until
+every selected focused PR reports merged and the Stacks REST response shows staging advanced; stop on
+queue cancellation or failure. Only then verify `main` did not move and refresh the umbrella. For JJ:
 
 ```bash
-: "${target_pr:?set the highest PR that should merge}"
-: "${code_owner:?set the required code-owner login}"
-owner_token=$(gh auth token --user "$code_owner")
-test "$(GH_TOKEN="$owner_token" gh api user --jq .login)" = "$code_owner"
-GH_TOKEN="$owner_token" gh stack merge "$target_pr" --yes --squash
+jj git fetch --remote origin
+jj bookmark move <umbrella> --to '<staging>@origin' --allow-backwards
+jj git push --remote origin --bookmark <umbrella>
+jj git export --ignore-working-copy
+test "$(git rev-parse '<umbrella>^{tree}')" = "$candidate_tree"
 ```
 
-Observed behavior: approving an out-of-range upper PR and retrying as the stack author still failed;
-the same target succeeded when submitted by the code owner. Treat this as endpoint behavior, not proof
-that an excluded PR needs approval.
+For the Git fallback, fetch staging, force the separate umbrella branch to its tip, and push with
+`--force-with-lease`; never add umbrella to local stack tracking. A tree mismatch means assembly did
+not preserve the reviewed cumulative state: stop before final review.
 
-## Open the final integration PR
+## Final umbrella gate
 
-A squash replaces original commits. Let the stack tool reconcile merged layers, then check out and
-refresh the integration trunk:
+The umbrella head rewrite intentionally reruns aggregate CI and may dismiss old approval. Update its
+body with the focused PR list, actual changesets/packages, validation, and resolved risks. Mark it
+ready only after assembly:
 
 ```bash
-gh stack sync
-gh stack view --json
-gh stack trunk
-git pull --ff-only
+gh pr ready <umbrella-pr>
+gh pr view <umbrella-pr> --json baseRefName,headRefOid,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup
 ```
 
-Verify every intended layer is `MERGED`, `main` did not move, and the integration branch contains the
-cumulative result. Run the umbrella gate once, then open one ordinary PR:
+Require base `main`, final assembled head, green aggregate checks, fresh eligible approval, and no
+unresolved required threads. This is release-level review; focused line review stays on the merged
+sub-PRs.
+
+## Land on main
+
+Only a separate explicit instruction authorizes the ordinary umbrella merge:
 
 ```bash
-gh pr create --base main --head <integration-branch> --title <release-title> --body-file <body>
-gh pr view <integration-pr> \
-  --json state,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup
-git status --short --branch
+gh pr merge <umbrella-pr> --squash
 ```
 
-This PR is the sole aggregate release gate and is not a stack member. Request its normal review and CI.
-Merge it with ordinary `gh pr merge` only after a separate explicit instruction; that is the operation
-that lands on `main` and triggers release automation. If `sync` conflicts, it restores the stack;
-follow the rebase recovery in `work.md`.
+Use the repository-selected method. This is the sole operation that moves `main` and triggers release
+automation. Afterward verify the umbrella merged, `main` contains the reviewed tree, focused PRs remain
+recorded as merged into staging, and no open native stack member was bypassed. Clean remote/local refs
+only when repository policy or the user requests it.

--- a/.pi/skills/gh-stack/references/merge.md
+++ b/.pi/skills/gh-stack/references/merge.md
@@ -22,6 +22,7 @@ jj rebase --source <bottom> --onto <staging>
 # resolve every recorded conflict
 jj bookmark move <umbrella> --to <top> --allow-backwards
 jj git push --remote origin --bookmark <staging>
+jj git push --remote origin --bookmark <bottom> --bookmark <next> --bookmark <top>
 jj git export --ignore-working-copy
 gh stack link --base <staging> <bottom> <next> <top>
 jj git push --remote origin --bookmark <umbrella>
@@ -108,10 +109,11 @@ sub-PRs.
 Only a separate explicit instruction authorizes the ordinary umbrella merge:
 
 ```bash
-gh pr merge <umbrella-pr> --squash
+gh pr merge <umbrella-pr> <--squash|--merge|--rebase>
 ```
 
-Use the repository-selected method. This is the sole operation that moves `main` and triggers release
+Use `--squash` by default in this repository; replace it only when repository policy or explicit user
+direction selects another method. This is the sole operation that moves `main` and triggers release
 automation. Afterward verify the umbrella merged, `main` contains the reviewed tree, focused PRs remain
 recorded as merged into staging, and no open native stack member was bypassed. Clean remote/local refs
 only when repository policy or the user requests it.

--- a/.pi/skills/gh-stack/references/review.md
+++ b/.pi/skills/gh-stack/references/review.md
@@ -1,77 +1,65 @@
-# Review a stack
+# Review an umbrella stack
 
-Use this phase to audit each focused PR, dispatch local reviewers, request GitHub bot reviews, triage
-findings, and converge fixes without turning the stack into one aggregate diff.
+Review focused PRs as layers; use the umbrella for cumulative release scope, integration, and final
+landing confidence. Do not duplicate line review across both surfaces.
 
-## Establish review boundaries
+## Establish boundaries
 
-Refresh native state and record every selected layer's PR number, head SHA, and direct parent SHA:
+Record native order, every focused head/direct parent, and umbrella head:
 
 ```bash
-gh stack view --json
-gh pr view <pr> --json number,title,body,baseRefName,headRefName,headRefOid,state,reviews,statusCheckRollup
+gh api "repos/{owner}/{repo}/stacks?pull_request=<focused-pr>"
+gh pr view <focused-pr> --json number,title,body,baseRefName,headRefName,headRefOid,state,reviews,statusCheckRollup
+gh pr view <umbrella-pr> --json number,title,body,baseRefName,headRefName,headRefOid,isDraft,state,reviews,statusCheckRollup
 ```
 
-A focused PR is `parent head..layer head`, never `trunk..top`. If a reviewer tool scopes a supplied
-base against the current checkout, check out the intended PR head and pass its direct parent. The
-reviewer does not switch branches. Aggregate review is a separate explicit request.
+For Git-local fallback, use `gh stack view --json`; for JJ, inspect `jj log -r
+'<staging>::<umbrella>'`. Require the umbrella bookmark to point at the cumulative focused top before
+assembly. A focused diff is direct parent..layer; umbrella diff is main..top. Reviewer tools do not
+switch revisions for you.
 
 ## Audit with the user
 
-When walking the release together, inspect one PR at a time in the user's chosen order; use top to
-bottom when deciding what can be removed before final landing. For each layer:
+Walk focused PRs in the user's order; prefer top to bottom when deciding what can be removed. For each:
 
-1. Read its issue, PR body, comments, exact direct-base diff, and owning implementation paths.
-2. State its goal, changed line/file count, and whether the implementation actually solves the
-   reported or intended problem.
+1. Read its issue, PR body, comments, direct-base diff, and owning paths.
+2. State goal, changed lines/files, and whether it solves the intended problem.
 3. Separate required behavior from unrelated work, speculative hardening, and over-engineering.
-4. Run the test cull below.
-5. Record the verdict and agreed edit, then continue. After the pass, repair owning layers bottom to
-   top and cascade once. Do not bury unresolved product choices in mechanical cleanup.
+4. Cull tests below.
+5. Record verdict and owning-layer edit.
 
-Keep explanations concrete and short. Do not repeat stack mechanics the user already understands.
+After focused review, inspect the umbrella once for cumulative conflicts, release composition,
+changesets, package effects, and user-visible summary. Do not use umbrella review to relitigate every
+focused line. Repair focused owners bottom to top, update the cumulative head once, then revalidate.
 
 ## Cull tests
 
-Inspect every added or changed test with deletion as the default. The full gate is
+Inspect every added or changed test with deletion as default. Follow
 `../../gh-issue-pr-flow/SKILL.md#verification-cull`. Keep only a minimal independent contract spine
-for plausible future faults: protocol parsing or serialization, hazardous routing or isolation,
-persisted migration, or another stable boundary with an oracle independent of the implementation.
+for plausible future faults: protocol parsing/serialization, hazardous routing/isolation, persisted
+migration, or another stable boundary with an oracle independent of the implementation.
 
-Delete complete feature tours, presentation and copy locks, replica duplicates, setting-exists cases,
-and tests that merely prove a feature currently works. A fake provider cannot prove provider-dependent
-model semantics. A mocked external event bus or library cannot prove that extension integration works;
-exercise simple extensions in action instead. Do not replace deleted theatre with new cases unless the
-user explicitly asks for more permanent coverage.
-
-After deletion, remove fixtures, helpers, and exports that existed only for tests. Report complete test
-cases deleted separately from assertions or sub-scenarios removed; assertion cleanup is not a test
-cull.
+Delete feature tours, presentation/copy locks, duplicates, setting-exists cases, and tests that only
+prove current behavior. A fake provider cannot prove provider-dependent semantics; mocked event buses
+cannot prove integration. Remove fixtures/helpers/exports left test-only. Report complete test cases
+deleted, not assertion cleanup.
 
 ## Dispatch local reviewers
 
-Assign one distinct PR to each agent unless the user explicitly requests overlapping coverage. Give
-each assignment the exact head, direct base, PR goal, and any narrow risk focus. Agents are read-only
-unless a separate fix task is requested.
+Assign one focused PR per reviewer unless overlap is explicit. Supply exact head, direct parent, goal,
+and narrow risks. Reviewers are read-only unless separately assigned fixes. Review the umbrella only
+as a distinct cumulative/release task after focused passes converge.
 
-Let reviewers finish. Triage their findings yourself before involving the user: reproduce plausible
-faults, trace real product reachability, reject theoretical lifecycle states that cannot occur, and
-collapse duplicates. Fix mechanical owner-layer faults directly. Ask only for the few findings that
-require a product or scope decision; never dump raw reviewer bookkeeping into a large disposition
-form.
+Triage findings before involving the user: reproduce plausible faults, trace product reachability,
+reject impossible states, and collapse duplicates. Fix mechanical owner-layer faults. Ask only about
+material product/scope choices; never dump raw review bookkeeping.
 
 ## Request bot reviews
 
-Finalize PR titles, bodies, bases, order, and heads first. Post one request to each selected focused PR,
-bottom to top. The standard body, configured commenter account, and exact token-only command are owned
-by `../../gh-issue-pr-flow/SKILL.md#codex-review`; never switch the active `gh` account merely to
-comment.
+Finalize focused titles, bodies, order, and heads, then post one configured request bottom to top.
+The exact command/body/account contract lives in `../../gh-issue-pr-flow/SKILL.md#codex-review`.
+Do not repost after routine pushes.
 
-Do not repost after routine pushes. If the user explicitly requests a fresh pass after a completed
-repair cascade, verify every selected head and post once to each selected PR. Give the bot a useful
-interval before checking; do not poll constantly.
-
-Triage bot findings against the current code and owning layer, not the stale reviewed SHA alone. Reply
-to each thread with the fix or dismissal evidence, resolve settled threads, then apply owner-layer
-fixes and cascade once. Revalidate the complete stack after review converges; approval and merge belong
-to `merge.md`.
+After focused repairs converge and the stack is assembled, request a separate normal review on the
+umbrella's final assembled head. Reply to settled threads with evidence and resolve them. Revalidate
+the cumulative state once; approval and landing belong to `merge.md`.

--- a/.pi/skills/gh-stack/references/work.md
+++ b/.pi/skills/gh-stack/references/work.md
@@ -1,81 +1,98 @@
-# Work with a stack
+# Work with an umbrella stack
 
-Use this phase for inspection, changes to an existing layer, cascading rebases, pushes, and topology
-repair. Use `review.md` for human, agent, or bot review passes.
+Keep one local-history owner. Determine whether the stack is JJ-linked or locally tracked by
+`gh-stack` before changing commits, refs, PR bases, or native topology.
 
-## Establish current state
-
-For read-only inspection:
+## Inspect a JJ-linked stack
 
 ```bash
-gh stack view --json
+jj git fetch --remote origin
+jj status
+jj workspace list
+jj log -r '<staging>::<umbrella>'
+gh api "repos/{owner}/{repo}/stacks?pull_request=<focused-pr>"
+gh pr view <umbrella-pr> --json baseRefName,headRefName,headRefOid,isDraft,state,statusCheckRollup
 ```
 
-Before changing a stacked branch, PR, base, or history:
+The Stacks REST array must contain exactly one matching stack. Inspect each focused PR as needed.
+Treat native membership/order and JJ's graph as separate facts; both must match the intended plan.
+Stop on conflicted bookmarks, unexpected remote movement, or a workspace owned by another task.
+
+## Edit a JJ layer
+
+```bash
+jj edit <owning-layer>
+# edit and validate
+jj describe -m "<accurate layer description>"
+jj status
+```
+
+JJ automatically rebases descendants when an ancestor is rewritten. Inspect every descendant and
+resolve recorded conflicts before publishing; never push conflict-bearing revisions. Move the
+umbrella explicitly to the current focused top when needed:
+
+```bash
+jj bookmark move <umbrella> --to <top> --allow-backwards
+jj git export --ignore-working-copy
+gh stack link --base <staging> <bottom> <next> <top>
+jj git push --remote origin --bookmark <umbrella>
+```
+
+JJ workspaces can leave the coordinator's colocated Git refs stale; forced export makes `gh stack
+link` see current bookmarks. `jj git push` uses remote-state safety equivalent to force-with-lease.
+Fetch and inspect bookmark conflicts rather than bypassing a rejected update. Rerun `link` with the
+complete focused order when heads or PR bases changed. Never include staging or umbrella in the list.
+
+## Parallel JJ workspaces
+
+Create each worker workspace from its intended parent revision:
+
+```bash
+jj workspace add <path> --name <worker> --revision <parent> -m "<layer description>"
+# in the new workspace
+jj edit <layer>
+```
+
+The worker edits its pre-bookmarked layer; JJ moves its bookmark and rebases descendants as the
+revision changes. Workers do not push, link, reorder, or move the umbrella. After explicit readiness,
+the coordinator integrates concurrent operations, inspects the graph, resolves conflicts in the
+owning layer, and reorders with `jj rebase` only when the planned chain changed.
+
+When a workspace is no longer needed, delete its directory only after its intended change is safely
+bookmarked, then run `jj workspace forget <worker>`. A workspace path is not a Git worktree; do not
+manage it with `git worktree`.
+
+## Restructure a JJ-linked stack
+
+Use `jj rebase --revisions`, `--insert-after`, or `--insert-before` to change local order, then inspect
+the exact graph and cumulative tree. `gh stack link` is additive and cannot remove or reorder existing
+remote members. For a real topology change:
+
+1. Record stack number, PR numbers, heads, bases, staging, and umbrella SHA.
+2. Rewrite and verify the JJ graph.
+3. `gh stack unstack <stack-number>` to remove only native grouping; keep branches and PRs.
+4. Relink the complete focused order with `gh stack link --base <staging> ...`.
+5. Verify every focused base, native order, and umbrella cumulative diff.
+
+Do not fake restructuring by changing PR bases alone; commits and JJ bookmarks must agree first.
+
+## Git-managed fallback
+
+For a stack created with local `gh-stack` tracking:
 
 ```bash
 gh stack sync
 # Treat "Sync aborted" as failure even when exit status is 0.
-gh stack view --json
-```
-
-`sync` fetches, reconciles GitHub membership, fast-forwards trunk, cascade-rebases when needed,
-atomically pushes active branches, refreshes PRs, and updates the stack object. It does not create PRs.
-If the target is absent or local and remote topology diverged, stop before rewriting.
-
-## Edit a layer
-
-```bash
 gh stack checkout <owning-pr-or-branch>
-# edit, validate, stage deliberately, commit
+# edit, validate, stage, commit
 gh stack rebase --upstack
 gh stack top
 gh stack push
+git branch --force <umbrella> HEAD
+git push --force-with-lease origin <umbrella>
 gh stack view --json
 ```
 
-`push` updates every active branch with per-branch force-with-lease and never updates PR metadata. It
-is not atomic: repair a rejected branch and rerun. Use `submit --auto --open` when PR creation or stack
-linkage also needs repair.
-
-Navigation commands `up`, `down`, `top`, `bottom`, and `trunk` are noninteractive. `checkout` accepts a
-stack number, PR number or URL, or locally tracked branch. A bare number resolves as stack first, then
-PR. Use a PR or stack number to fetch untracked remote state.
-
-## Rebase recovery
-
-`sync` restores all branches after a rebase conflict and exits 3. Recreate the conflict with `rebase`,
-resolve and stage it, then continue:
-
-```bash
-gh stack rebase
-git add <resolved-paths>
-gh stack rebase --continue
-```
-
-Repeat as needed. `gh stack rebase --abort` restores the entire stack. `--upstack` starts at the
-current branch; `--downstack` ends there; `--no-trunk` aligns stack branches without rebasing trunk.
-Starting while another rebase is active exits 7.
-
-## Divergence and restructuring
-
-When `sync` reports different local and GitHub chains, choose one authority deliberately:
-
-```bash
-# Keep remote composition
-gh stack unstack --local
-gh stack checkout <stack-or-pr>
-
-# Keep verified local ancestry
-gh stack unstack
-# Recreate from the recorded trunk and order through create.md.
-```
-
-`unstack` removes grouping, never branches or PRs. There is no noninteractive reorder or removal.
-For a structural change, record boundary SHAs, rewrite Git ancestry bottom to top, unstack, then rebuild
-through `create.md`; changing PR bases or metadata alone does not move commits.
-
-If a branch belongs to several stacks, commands may exit 6. Check out a branch unique to the intended
-stack or use an explicit stack number. A stale stack lock exits 8; wait for the owning process. An
-interrupted TUI modify exits 10 and may be cleared with `gh stack modify --abort`, but never start a
-new modify session noninteractively.
+On rebase conflict, run `gh stack rebase`, resolve and stage, then `gh stack rebase --continue`; abort
+restores the stack. Use the existing `gh-stack` divergence controls. Never introduce JJ midway through
+a locally tracked stack.

--- a/.pi/skills/gh-stack/references/work.md
+++ b/.pi/skills/gh-stack/references/work.md
@@ -33,15 +33,17 @@ umbrella explicitly to the current focused top when needed:
 
 ```bash
 jj bookmark move <umbrella> --to <top> --allow-backwards
+jj git push --remote origin --bookmark <bottom> --bookmark <next> --bookmark <top>
 jj git export --ignore-working-copy
 gh stack link --base <staging> <bottom> <next> <top>
 jj git push --remote origin --bookmark <umbrella>
 ```
 
-JJ workspaces can leave the coordinator's colocated Git refs stale; forced export makes `gh stack
-link` see current bookmarks. `jj git push` uses remote-state safety equivalent to force-with-lease.
-Fetch and inspect bookmark conflicts rather than bypassing a rejected update. Rerun `link` with the
-complete focused order when heads or PR bases changed. Never include staging or umbrella in the list.
+Push rewritten focused bookmarks through JJ first because `link` only performs a non-force Git push.
+JJ workspaces can also leave the coordinator's colocated Git refs stale; forced export makes `link`
+see current bookmarks. `jj git push` uses remote-state safety equivalent to force-with-lease. Fetch
+and inspect bookmark conflicts rather than bypassing a rejected update. Rerun `link` with the complete
+focused order when heads or PR bases changed. Never include staging or umbrella in the list.
 
 ## Parallel JJ workspaces
 


### PR DESCRIPTION
This PR makes release stacks JJ-first and gives every batch a live cumulative umbrella PR alongside its focused native GitHub stack.

## Summary

- use JJ revisions, bookmarks, and workspaces for local stack history
- bridge focused bookmarks through `gh stack link` without adopting local `gh-stack` tracking
- keep staging and the ordinary umbrella PR outside the native stack
- show the cumulative release diff throughout focused review
- assemble focused PRs into staging, refresh the umbrella to the reviewed tree, then require a separate final merge to `main`
- retain an explicit Git-managed fallback
- temporarily pause manual Codex review requests while automatic detection is tested
- handle stale colocated Git refs, current-`main` rebases, merge queues, and separate focused/aggregate review gates

## Validation

- exercised JJ 0.43.0 bookmarks, descendant rewrites, parallel workspaces, and forced Git export against a disposable local origin
- verified `gh stack link`, Stacks REST inspection, and merge contracts against installed `gh-stack` 0.1.0 and current upstream source/docs
- skill efficiency checks: no issues or warnings
- `bun run check:changed`
- `bun run changeset:check`

## Release

- Changeset: no
- Packages: none


