### PR TITLE
Add terminal-native Unicode charts

### DIFF
--- a/.changeset/bright-charts-render.md
+++ b/.changeset/bright-charts-render.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-unicode-charts": patch
+---
+
+Add terminal-native Unicode bar, line, scatter, sparkline, and heatmap rendering for explicit `chart` Markdown blocks

--- a/.changeset/bright-charts-render.md
+++ b/.changeset/bright-charts-render.md
@@ -1,5 +1,5 @@
 ---
-"@howaboua/pi-unicode-charts": patch
+"@howaboua/pi-unicode-charts": minor
 ---
 
 Add terminal-native Unicode bar, line, scatter, sparkline, and heatmap rendering for explicit `chart` Markdown blocks

--- a/packages/pi-unicode-charts/.gitignore
+++ b/packages/pi-unicode-charts/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+coverage
+dist
+*.tgz

--- a/packages/pi-unicode-charts/AGENTS.md
+++ b/packages/pi-unicode-charts/AGENTS.md
@@ -1,0 +1,3 @@
+- `src/chart.ts` is the pure parser and Unicode layout engine; keep it independent of Pi.
+- `src/index.ts` owns the Markdown transformer and model-facing chart guidance.
+- Keep this package raster-free: charts render to width-bounded Unicode and ANSI-free text.

--- a/packages/pi-unicode-charts/LICENSE
+++ b/packages/pi-unicode-charts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Howaboua
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-unicode-charts/README.md
+++ b/packages/pi-unicode-charts/README.md
@@ -1,8 +1,7 @@
 # @howaboua/pi-unicode-charts
 
-Terminal-native Unicode charts for Pi. The extension transforms explicit
-`chart` Markdown fences into width-aware bars, lines, scatter plots, sparklines,
-and heatmaps. It uses no image, browser, Python, or raster dependencies.
+Terminal-native Unicode charts for Pi Markdown. No browser, image, Python, or
+raster dependencies.
 
 ## Install
 
@@ -10,51 +9,24 @@ and heatmaps. It uses no image, browser, Python, or raster dependencies.
 pi install npm:@howaboua/pi-unicode-charts
 ```
 
-The extension adds a small chart-format hint to the model prompt and renders
-completed chart fences in user and assistant Markdown. It leaves ordinary code
-blocks and invalid charts unchanged.
-
-## Format
-
-Use one data point per line. The value may be separated with whitespace,
-commas, tabs, or pipes.
+## Use
 
 ```chart
 type: bar
-title: Requests by endpoint
+title: Monthly net change
 data:
-GET /users 120
-POST /users 80
-GET /health 42
-```
-
-```chart
-type: line
-title: Latency
-data:
-Mon 42
-Tue 51
-Wed 47
-Thu 63
-Fri 58
-```
-
-```chart
-type: sparkline
-data:
-12 18 15 23 31 28 36 42 38 45
-```
-
-Heatmaps use one row label followed by numeric cells:
-
-```chart
-type: heatmap
-title: Activity
-data:
-Mon 1 2 4 3 1
-Tue 2 4 4 2 1
-Wed 1 3 2 1 0
+Jan -8
+Feb 5
+Mar 12
+Apr -3
 ```
 
 Supported types are `bar`, `line`, `scatter`, `sparkline`, and `heatmap`.
-`histogram` is accepted as an alias for `bar`.
+Bar, line, and scatter rows use `Label value`; sparklines accept a row of
+numbers; heatmap rows use `Label value value …`. Values may be separated by
+whitespace, commas, tabs, or pipes. `histogram` aliases `bar`.
+
+The extension gives the model a short format hint and renders completed
+`chart` fences up to 80 columns wide. Charts are display-only: ordinary,
+invalid, and unfinished fences remain unchanged, and original messages stay in
+the session and model context.

--- a/packages/pi-unicode-charts/README.md
+++ b/packages/pi-unicode-charts/README.md
@@ -1,0 +1,60 @@
+# @howaboua/pi-unicode-charts
+
+Terminal-native Unicode charts for Pi. The extension transforms explicit
+`chart` Markdown fences into width-aware bars, lines, scatter plots, sparklines,
+and heatmaps. It uses no image, browser, Python, or raster dependencies.
+
+## Install
+
+```bash
+pi install npm:@howaboua/pi-unicode-charts
+```
+
+The extension adds a small chart-format hint to the model prompt and renders
+completed chart fences in user and assistant Markdown. It leaves ordinary code
+blocks and invalid charts unchanged.
+
+## Format
+
+Use one data point per line. The value may be separated with whitespace,
+commas, tabs, or pipes.
+
+```chart
+type: bar
+title: Requests by endpoint
+data:
+GET /users 120
+POST /users 80
+GET /health 42
+```
+
+```chart
+type: line
+title: Latency
+data:
+Mon 42
+Tue 51
+Wed 47
+Thu 63
+Fri 58
+```
+
+```chart
+type: sparkline
+data:
+12 18 15 23 31 28 36 42 38 45
+```
+
+Heatmaps use one row label followed by numeric cells:
+
+```chart
+type: heatmap
+title: Activity
+data:
+Mon 1 2 4 3 1
+Tue 2 4 4 2 1
+Wed 1 3 2 1 0
+```
+
+Supported types are `bar`, `line`, `scatter`, `sparkline`, and `heatmap`.
+`histogram` is accepted as an alias for `bar`.

--- a/packages/pi-unicode-charts/biome.json
+++ b/packages/pi-unicode-charts/biome.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": ["**", "!node_modules", "!coverage"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/packages/pi-unicode-charts/package.json
+++ b/packages/pi-unicode-charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@howaboua/pi-unicode-charts",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"description": "Terminal-native Unicode charts for Pi Markdown",
 	"type": "module",
 	"main": "src/index.ts",
@@ -26,13 +26,17 @@
 		"format": "biome check --write ."
 	},
 	"keywords": [
-		"pi",
 		"pi-package",
 		"pi-extension",
+		"pi-coding-agent",
+		"pi",
 		"unicode",
 		"charts",
-		"data-visualization",
-		"terminal"
+		"terminal",
+		"markdown",
+		"sparkline",
+		"heatmap",
+		"data-visualization"
 	],
 	"author": "howaboua",
 	"license": "MIT",

--- a/packages/pi-unicode-charts/package.json
+++ b/packages/pi-unicode-charts/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@howaboua/pi-unicode-charts",
+	"version": "0.1.0",
+	"description": "Terminal-native Unicode charts for Pi Markdown",
+	"type": "module",
+	"main": "src/index.ts",
+	"exports": "./src/index.ts",
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "bun run lint && bun run typecheck && bun run test",
+		"prepack": "bun run check",
+		"test": "bun test",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write ."
+	},
+	"keywords": [
+		"pi",
+		"pi-package",
+		"pi-extension",
+		"unicode",
+		"charts",
+		"data-visualization",
+		"terminal"
+	],
+	"author": "howaboua",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-unicode-charts"
+	},
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-unicode-charts#readme",
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@types/node": "^24.10.0",
+		"typescript": "^5.9.3"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.84.1"
+	}
+}

--- a/packages/pi-unicode-charts/src/chart.ts
+++ b/packages/pi-unicode-charts/src/chart.ts
@@ -341,10 +341,15 @@ function verticalBar(
 
 function renderSparkline(points: ChartPoint[], width: number): string[] {
 	const values = points.map((point) => point.value);
-	const chartWidth = Math.max(4, width - 2);
-	const sampled = sample(values, chartWidth);
-	const minimum = Math.min(...sampled);
-	const maximum = Math.max(...sampled);
+	const minimum = Math.min(...values);
+	const maximum = Math.max(...values);
+	const minimumLabel = formatNumber(minimum);
+	const maximumLabel = formatNumber(maximum);
+	const chartWidth = Math.max(
+		4,
+		width - displayWidth(minimumLabel) - displayWidth(maximumLabel) - 2,
+	);
+	const sampled = resample(values, chartWidth);
 	const range = maximum - minimum || 1;
 	const spark = sampled
 		.map(
@@ -354,7 +359,7 @@ function renderSparkline(points: ChartPoint[], width: number): string[] {
 				] ?? "▁",
 		)
 		.join("");
-	return [`${formatNumber(minimum)} ${spark} ${formatNumber(maximum)}`];
+	return [`${minimumLabel} ${spark} ${maximumLabel}`];
 }
 
 function renderBraille(
@@ -391,7 +396,7 @@ function renderBraille(
 			const previous = coordinates[index - 1];
 			if (previous) drawLine(previous.x, previous.y, point.x, point.y, dots);
 		} else {
-			dots.add(`${point.x},${point.y}`);
+			drawPoint(point.x, point.y, dotWidth, dotHeight, dots);
 		}
 	}
 
@@ -458,29 +463,55 @@ function drawLine(
 	}
 }
 
+function drawPoint(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	dots: Set<string>,
+): void {
+	const startX = x >= width - 1 ? x - 1 : x;
+	const startY = y >= height - 1 ? y - 1 : y;
+	for (let offsetY = 0; offsetY < 2; offsetY += 1) {
+		for (let offsetX = 0; offsetX < 2; offsetX += 1) {
+			const dotX = startX + offsetX;
+			const dotY = startY + offsetY;
+			if (dotX < width && dotY < height) dots.add(`${dotX},${dotY}`);
+		}
+	}
+}
+
 function renderHeatmap(rows: HeatmapRow[], width: number): string[] {
 	const rowLabelWidth = Math.min(
 		14,
 		Math.max(3, ...rows.map((row) => displayWidth(row.label))),
 	);
 	const columns = Math.max(0, ...rows.map((row) => row.values.length));
-	const cellWidth = width - rowLabelWidth - 2;
-	if (columns === 0 || cellWidth < 1) return [];
+	const plotWidth = width - rowLabelWidth - 3;
+	if (columns === 0 || plotWidth < 1) return [];
 
 	const allValues = rows.flatMap((row) => row.values);
+	if (allValues.length === 0) return [];
 	const minimum = Math.min(...allValues);
 	const maximum = Math.max(...allValues);
 	const range = maximum - minimum || 1;
-	const visibleColumns = Math.min(columns, cellWidth);
+	const visibleColumns = Math.min(columns, plotWidth);
+	const columnWidths = Array.from(
+		{ length: visibleColumns },
+		(_, index) =>
+			Math.floor(plotWidth / visibleColumns) +
+			(index < plotWidth % visibleColumns ? 1 : 0),
+	);
 	const lines = rows.map((row) => {
-		const values = sample(row.values, visibleColumns);
+		const values = resample(row.values, visibleColumns);
 		const cells = values
-			.map(
-				(value) =>
+			.map((value, index) => {
+				const glyph =
 					HEAT_GLYPHS[
 						Math.min(3, Math.floor(((value - minimum) / range) * 4))
-					] ?? "░",
-			)
+					] ?? "░";
+				return glyph.repeat(columnWidths[index] ?? 1);
+			})
 			.join("");
 		return `${padEndWidth(truncate(row.label, rowLabelWidth), rowLabelWidth)} │ ${cells}`;
 	});
@@ -488,12 +519,18 @@ function renderHeatmap(rows: HeatmapRow[], width: number): string[] {
 	return lines;
 }
 
-function sample(values: number[], limit: number): number[] {
+function resample(values: number[], limit: number): number[] {
 	if (limit <= 1) return values.length > 0 ? [values[0] ?? 0] : [];
-	if (values.length <= limit) return values;
+	if (values.length === 0) return [];
+	if (values.length === 1)
+		return Array.from({ length: limit }, () => values[0] ?? 0);
 	return Array.from({ length: limit }, (_, index) => {
-		const sourceIndex = Math.round((index * (values.length - 1)) / (limit - 1));
-		return values[sourceIndex] ?? values[values.length - 1] ?? 0;
+		const sourcePosition = (index * (values.length - 1)) / (limit - 1);
+		const lowerIndex = Math.floor(sourcePosition);
+		const upperIndex = Math.ceil(sourcePosition);
+		const lower = values[lowerIndex] ?? values[values.length - 1] ?? 0;
+		const upper = values[upperIndex] ?? lower;
+		return lower + (upper - lower) * (sourcePosition - lowerIndex);
 	});
 }
 

--- a/packages/pi-unicode-charts/src/chart.ts
+++ b/packages/pi-unicode-charts/src/chart.ts
@@ -53,6 +53,7 @@ export function transformChartMarkdown(
 	markdown: string,
 	availableWidth: number,
 ): string {
+	const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
 	const lines = markdown.split(/\r?\n/u);
 	const output: string[] = [];
 
@@ -88,7 +89,7 @@ export function transformChartMarkdown(
 		index = close;
 	}
 
-	return output.join("\n");
+	return output.join(newline);
 }
 
 export function parseChartSource(source: string): ChartSpec | undefined {
@@ -219,9 +220,11 @@ function parseOpeningFence(
 	if (!match?.[1]) return undefined;
 	const fenceCharacter = match[1][0];
 	if (fenceCharacter !== "`" && fenceCharacter !== "~") return undefined;
+	const info = (match[2] ?? "").trim();
+	if (fenceCharacter === "`" && info.includes("`")) return undefined;
 	return {
 		fence: { character: fenceCharacter, length: match[1].length },
-		language: (match[2] ?? "").trim().split(/\s+/u, 1)[0]?.toLowerCase() ?? "",
+		language: info.split(/\s+/u, 1)[0]?.toLowerCase() ?? "",
 	};
 }
 

--- a/packages/pi-unicode-charts/src/chart.ts
+++ b/packages/pi-unicode-charts/src/chart.ts
@@ -40,6 +40,7 @@ const BRAILLE_DOTS = [
 	[0, 3, 64],
 	[1, 3, 128],
 ] as const;
+const BRAILLE_BAR_ROWS = [9, 18, 36, 192] as const;
 const SPARK_GLYPHS = "▁▂▃▄▅▆▇█";
 const HEAT_GLYPHS = "░▒▓█";
 
@@ -58,7 +59,7 @@ export function transformChartMarkdown(
 	for (let index = 0; index < lines.length; index += 1) {
 		const line = lines[index] ?? "";
 		const opening = parseOpeningFence(line);
-		if (!opening || opening.language !== "chart") {
+		if (!opening) {
 			output.push(line);
 			continue;
 		}
@@ -67,6 +68,11 @@ export function transformChartMarkdown(
 		if (close === undefined) {
 			output.push(...lines.slice(index));
 			break;
+		}
+		if (opening.language !== "chart") {
+			output.push(...lines.slice(index, close + 1));
+			index = close;
+			continue;
 		}
 
 		const source = lines.slice(index + 1, close).join("\n");
@@ -182,6 +188,7 @@ export function parseChartSource(source: string): ChartSpec | undefined {
 export function renderChart(spec: ChartSpec, availableWidth: number): string[] {
 	if (!Number.isFinite(availableWidth) || availableWidth < MINIMUM_WIDTH)
 		return [];
+	if (spec.type !== "heatmap" && spec.points.length === 0) return [];
 
 	const width = Math.floor(availableWidth);
 	const body =
@@ -280,13 +287,33 @@ function parseNumber(value: string | undefined): number | undefined {
 }
 
 function renderBars(points: ChartPoint[], width: number): string[] {
-	const values = points.map((point) => Math.max(0, point.value));
-	const maximum = Math.max(1, ...values);
-	const yLabelWidth = Math.max(3, displayWidth(formatNumber(maximum)));
+	const values = points.map((point) => point.value);
+	const minimum = Math.min(0, ...values);
+	let maximum = Math.max(0, ...values);
+	const zeroOnly = minimum === maximum;
+	if (zeroOnly) maximum = 1;
+	const range = maximum - minimum;
+	const zeroRow = Math.min(
+		PLOT_ROWS - 1,
+		Math.floor((PLOT_ROWS * maximum) / range),
+	);
+	const tickRows = new Set(zeroOnly ? [zeroRow] : [0, PLOT_ROWS - 1, zeroRow]);
+	if (!zeroOnly && (zeroRow === 0 || zeroRow === PLOT_ROWS - 1)) {
+		tickRows.add(Math.floor(PLOT_ROWS / 2));
+	}
+	const tickLabels = Array.from({ length: PLOT_ROWS }, (_, row) =>
+		tickRows.has(row)
+			? formatNumber(barAxisValue(row, minimum, maximum, zeroRow))
+			: "",
+	);
+	const yLabelWidth = Math.max(
+		3,
+		...tickLabels.map((label) => displayWidth(label)),
+	);
 	const plotWidth = width - yLabelWidth - 3;
 	if (plotWidth < points.length) return [];
 
-	const gap = points.length <= plotWidth ? 1 : 0;
+	const gap = points.length * 2 - 1 <= plotWidth ? 1 : 0;
 	const barWidth = Math.max(
 		1,
 		Math.floor((plotWidth - gap * (points.length - 1)) / points.length),
@@ -295,23 +322,13 @@ function renderBars(points: ChartPoint[], width: number): string[] {
 	const lines: string[] = [];
 
 	for (let row = 0; row < PLOT_ROWS; row += 1) {
-		const distanceFromBottom = PLOT_ROWS - row;
-		const label =
-			row === 0 || row === Math.floor(PLOT_ROWS / 2) || row === PLOT_ROWS - 1
-				? formatNumber(
-						row === PLOT_ROWS - 1
-							? 0
-							: row === Math.floor(PLOT_ROWS / 2)
-								? maximum / 2
-								: maximum,
-					)
-				: "";
+		const label = tickLabels[row] ?? "";
 		const bars = values
-			.map((value) =>
-				verticalBar(value / maximum, distanceFromBottom, barWidth),
-			)
+			.map((value) => barCell(value, row, barWidth, minimum, maximum))
 			.join(" ".slice(0, gap));
-		lines.push(`${label.padStart(yLabelWidth)} ┤${bars}`);
+		lines.push(
+			`${label.padStart(yLabelWidth)} ${row === zeroRow ? "┼" : "┤"}${bars}`,
+		);
 	}
 
 	lines.push(`${"".padStart(yLabelWidth)} └${"─".repeat(usedWidth)}`);
@@ -324,19 +341,51 @@ function renderBars(points: ChartPoint[], width: number): string[] {
 	return lines;
 }
 
-function verticalBar(
-	ratio: number,
-	distanceFromBottom: number,
+function barCell(
+	value: number,
+	row: number,
 	width: number,
+	minimum: number,
+	maximum: number,
 ): string {
-	const height = ratio * PLOT_ROWS;
-	if (height < distanceFromBottom - 1) return " ".repeat(width);
-	if (height >= distanceFromBottom) return "█".repeat(width);
-	const fraction = Math.max(
-		1,
-		Math.min(8, Math.ceil((height - (distanceFromBottom - 1)) * 8)),
-	);
-	return SPARK_GLYPHS[fraction - 1]?.repeat(width) ?? " ".repeat(width);
+	if (value === 0) return " ".repeat(width);
+	const range = maximum - minimum;
+	const subrows = PLOT_ROWS * BRAILLE_BAR_ROWS.length;
+	const zeroPosition = (maximum / range) * subrows;
+	const valuePosition = ((maximum - value) / range) * subrows;
+	const start = Math.min(zeroPosition, valuePosition);
+	const end = Math.max(zeroPosition, valuePosition);
+	let bits = 0;
+
+	for (let subrow = 0; subrow < BRAILLE_BAR_ROWS.length; subrow += 1) {
+		const center = row * BRAILLE_BAR_ROWS.length + subrow + 0.5;
+		if (center >= start && center < end) bits |= BRAILLE_BAR_ROWS[subrow] ?? 0;
+	}
+	if (bits === 0) {
+		const marker = Math.max(
+			0,
+			Math.min(subrows - 1, Math.floor((start + end) / 2)),
+		);
+		if (Math.floor(marker / BRAILLE_BAR_ROWS.length) === row) {
+			bits = BRAILLE_BAR_ROWS[marker % BRAILLE_BAR_ROWS.length] ?? 0;
+		}
+	}
+	if (bits === 0) return " ".repeat(width);
+
+	const glyph = bits === 255 ? "█" : String.fromCodePoint(0x2800 + bits);
+	return glyph.repeat(width);
+}
+
+function barAxisValue(
+	row: number,
+	minimum: number,
+	maximum: number,
+	zeroRow: number,
+): number {
+	if (row === zeroRow) return 0;
+	if (row === 0) return maximum;
+	if (row === PLOT_ROWS - 1) return minimum;
+	return (maximum + minimum) / 2;
 }
 
 function renderSparkline(points: ChartPoint[], width: number): string[] {
@@ -371,7 +420,16 @@ function renderBraille(
 	const minimum = Math.min(...yValues);
 	const maximum = Math.max(...yValues);
 	const range = maximum - minimum || 1;
-	const yLabelWidth = Math.max(3, displayWidth(formatNumber(maximum)));
+	const middleRow = Math.floor(PLOT_ROWS / 2);
+	const tickLabels = [
+		formatNumber(maximum),
+		formatNumber(maximum - ((maximum - minimum) * middleRow) / (PLOT_ROWS - 1)),
+		formatNumber(minimum),
+	];
+	const yLabelWidth = Math.max(
+		3,
+		...tickLabels.map((label) => displayWidth(label)),
+	);
 	const plotColumns = width - yLabelWidth - 3;
 	if (plotColumns < 4) return [];
 
@@ -403,9 +461,13 @@ function renderBraille(
 	const lines: string[] = [];
 	for (let row = 0; row < PLOT_ROWS; row += 1) {
 		const label =
-			row === 0 || row === Math.floor(PLOT_ROWS / 2) || row === PLOT_ROWS - 1
-				? formatNumber(maximum - ((maximum - minimum) * row) / (PLOT_ROWS - 1))
-				: "";
+			row === 0
+				? (tickLabels[0] ?? "")
+				: row === middleRow
+					? (tickLabels[1] ?? "")
+					: row === PLOT_ROWS - 1
+						? (tickLabels[2] ?? "")
+						: "";
 		let chart = "";
 		for (let column = 0; column < plotColumns; column += 1) {
 			let bits = 0;
@@ -536,9 +598,13 @@ function resample(values: number[], limit: number): number[] {
 
 function formatNumber(value: number): string {
 	if (Math.abs(value) >= 1000)
-		return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1).replace(/\.0$/u, "")}k`;
+		return `${(value / 1000).toFixed(Math.abs(value) >= 10000 ? 0 : 1).replace(/\.0$/u, "")}k`;
 	if (Number.isInteger(value)) return String(value);
-	return value.toFixed(1).replace(/\.0$/u, "");
+	const absolute = Math.abs(value);
+	if (absolute >= 1) return value.toFixed(1).replace(/\.0$/u, "");
+	if (absolute >= 0.01)
+		return value.toFixed(2).replace(/0+$/u, "").replace(/\.$/u, "");
+	return value.toExponential(1).replace(/\.0e/u, "e");
 }
 
 function codeSpan(line: string): string {

--- a/packages/pi-unicode-charts/src/chart.ts
+++ b/packages/pi-unicode-charts/src/chart.ts
@@ -26,6 +26,7 @@ export interface ChartSpec {
 }
 
 const MINIMUM_WIDTH = 24;
+const MAXIMUM_WIDTH = 80;
 const MAX_POINTS = 64;
 const MAX_HEATMAP_ROWS = 32;
 const MAX_SOURCE_LENGTH = 12_000;
@@ -40,7 +41,6 @@ const BRAILLE_DOTS = [
 	[0, 3, 64],
 	[1, 3, 128],
 ] as const;
-const BRAILLE_BAR_ROWS = [9, 18, 36, 192] as const;
 const SPARK_GLYPHS = "▁▂▃▄▅▆▇█";
 const HEAT_GLYPHS = "░▒▓█";
 
@@ -191,7 +191,7 @@ export function renderChart(spec: ChartSpec, availableWidth: number): string[] {
 		return [];
 	if (spec.type !== "heatmap" && spec.points.length === 0) return [];
 
-	const width = Math.floor(availableWidth);
+	const width = Math.min(MAXIMUM_WIDTH, Math.floor(availableWidth));
 	const body =
 		spec.type === "bar"
 			? renderBars(spec.points, width)
@@ -353,29 +353,29 @@ function barCell(
 ): string {
 	if (value === 0) return " ".repeat(width);
 	const range = maximum - minimum;
-	const subrows = PLOT_ROWS * BRAILLE_BAR_ROWS.length;
-	const zeroPosition = (maximum / range) * subrows;
-	const valuePosition = ((maximum - value) / range) * subrows;
+	const zeroPosition = (PLOT_ROWS * maximum) / range;
+	const valuePosition = (PLOT_ROWS * (maximum - value)) / range;
 	const start = Math.min(zeroPosition, valuePosition);
 	const end = Math.max(zeroPosition, valuePosition);
-	let bits = 0;
+	const overlapStart = Math.max(start, row);
+	const overlapEnd = Math.min(end, row + 1);
+	const fraction = overlapEnd - overlapStart;
+	if (fraction <= 0) return " ".repeat(width);
 
-	for (let subrow = 0; subrow < BRAILLE_BAR_ROWS.length; subrow += 1) {
-		const center = row * BRAILLE_BAR_ROWS.length + subrow + 0.5;
-		if (center >= start && center < end) bits |= BRAILLE_BAR_ROWS[subrow] ?? 0;
-	}
-	if (bits === 0) {
-		const marker = Math.max(
-			0,
-			Math.min(subrows - 1, Math.floor((start + end) / 2)),
-		);
-		if (Math.floor(marker / BRAILLE_BAR_ROWS.length) === row) {
-			bits = BRAILLE_BAR_ROWS[marker % BRAILLE_BAR_ROWS.length] ?? 0;
-		}
-	}
-	if (bits === 0) return " ".repeat(width);
-
-	const glyph = bits === 255 ? "█" : String.fromCodePoint(0x2800 + bits);
+	const touchesTop = overlapStart <= row;
+	const touchesBottom = overlapEnd >= row + 1;
+	const glyph =
+		fraction >= 0.875
+			? "█"
+			: touchesTop
+				? fraction < 0.375
+					? "▔"
+					: "▀"
+				: touchesBottom
+					? (SPARK_GLYPHS[Math.max(0, Math.ceil(fraction * 8) - 1)] ?? "▁")
+					: (overlapStart + overlapEnd) / 2 < row + 0.5
+						? "▀"
+						: "▄";
 	return glyph.repeat(width);
 }
 
@@ -617,7 +617,13 @@ function codeSpan(line: string): string {
 		...Array.from(content.matchAll(/`+/gu), (match) => match[0].length),
 	);
 	const fence = "`".repeat(longestBacktickRun + 1);
-	const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
+	const padding =
+		content.startsWith("`") ||
+		content.endsWith("`") ||
+		content.startsWith(" ") ||
+		content.endsWith(" ")
+			? " "
+			: "";
 	return `${fence}${padding}${content}${padding}${fence}`;
 }
 

--- a/packages/pi-unicode-charts/src/chart.ts
+++ b/packages/pi-unicode-charts/src/chart.ts
@@ -1,0 +1,562 @@
+export const CHART_TYPES = [
+	"bar",
+	"line",
+	"scatter",
+	"sparkline",
+	"heatmap",
+] as const;
+
+export type ChartType = (typeof CHART_TYPES)[number];
+
+export interface ChartPoint {
+	label: string;
+	value: number;
+}
+
+export interface HeatmapRow {
+	label: string;
+	values: number[];
+}
+
+export interface ChartSpec {
+	type: ChartType;
+	title?: string;
+	points: ChartPoint[];
+	rows?: HeatmapRow[];
+}
+
+const MINIMUM_WIDTH = 24;
+const MAX_POINTS = 64;
+const MAX_HEATMAP_ROWS = 32;
+const MAX_SOURCE_LENGTH = 12_000;
+const PLOT_ROWS = 8;
+const BRAILLE_DOTS = [
+	[0, 0, 1],
+	[0, 1, 2],
+	[0, 2, 4],
+	[1, 0, 8],
+	[1, 1, 16],
+	[1, 2, 32],
+	[0, 3, 64],
+	[1, 3, 128],
+] as const;
+const SPARK_GLYPHS = "▁▂▃▄▅▆▇█";
+const HEAT_GLYPHS = "░▒▓█";
+
+interface Fence {
+	character: "`" | "~";
+	length: number;
+}
+
+export function transformChartMarkdown(
+	markdown: string,
+	availableWidth: number,
+): string {
+	const lines = markdown.split(/\r?\n/u);
+	const output: string[] = [];
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		const opening = parseOpeningFence(line);
+		if (!opening || opening.language !== "chart") {
+			output.push(line);
+			continue;
+		}
+
+		const close = findClosingFence(lines, index + 1, opening.fence);
+		if (close === undefined) {
+			output.push(...lines.slice(index));
+			break;
+		}
+
+		const source = lines.slice(index + 1, close).join("\n");
+		const spec = parseChartSource(source);
+		const rendered = spec ? renderChart(spec, availableWidth) : [];
+		if (rendered.length === 0) {
+			output.push(...lines.slice(index, close + 1));
+		} else {
+			output.push(
+				...rendered.map((renderedLine) => `${codeSpan(renderedLine)}  `),
+			);
+		}
+		index = close;
+	}
+
+	return output.join("\n");
+}
+
+export function parseChartSource(source: string): ChartSpec | undefined {
+	if (source.length > MAX_SOURCE_LENGTH) return undefined;
+	const sourceLines = source.split(/\r?\n/u);
+	let type: ChartType | undefined;
+	let title: string | undefined;
+	const dataLines: string[] = [];
+
+	for (const sourceLine of sourceLines) {
+		const line = sourceLine.trim();
+		if (!line || line.startsWith("#")) continue;
+
+		const typeMatch = /^type\s*:\s*([a-z]+)\s*$/iu.exec(line);
+		if (typeMatch) {
+			const parsedType = normalizeChartType(typeMatch[1]);
+			if (!parsedType) return undefined;
+			type = parsedType;
+			continue;
+		}
+		if (
+			/^(?:bar|histogram|line|scatter|sparkline|heatmap)$/iu.test(line) &&
+			!type
+		) {
+			type = normalizeChartType(line);
+			continue;
+		}
+
+		const titleMatch = /^title\s*:\s*(.*?)\s*$/iu.exec(line);
+		if (titleMatch) {
+			title = titleMatch[1]?.trim() || undefined;
+			continue;
+		}
+		if (/^data\s*:\s*$/iu.test(line)) {
+			continue;
+		}
+		if (
+			/^(?:width|height|x[-_ ]?min|x[-_ ]?max|y[-_ ]?min|y[-_ ]?max)\s*:/iu.test(
+				line,
+			)
+		) {
+			continue;
+		}
+		dataLines.push(sourceLine);
+	}
+
+	if (!type) type = "bar";
+	if (type === "heatmap") {
+		const rows = dataLines
+			.map(parseHeatmapRow)
+			.filter((row): row is HeatmapRow => row !== undefined);
+		return rows.length > 0
+			? {
+					type,
+					...(title ? { title } : {}),
+					points: [],
+					rows: rows.slice(0, MAX_HEATMAP_ROWS),
+				}
+			: undefined;
+	}
+
+	if (type === "sparkline") {
+		const values = dataLines.flatMap((dataLine, lineIndex) => {
+			const fields = dataLine
+				.trim()
+				.split(/[\s,|\t]+/u)
+				.filter(Boolean);
+			const numericFields = fields.map(parseNumber);
+			if (
+				numericFields.every((value): value is number => value !== undefined)
+			) {
+				return numericFields.map((value, valueIndex) => ({
+					label: String(lineIndex + valueIndex + 1),
+					value,
+				}));
+			}
+			const point = parsePoint(dataLine, lineIndex);
+			return point ? [point] : [];
+		});
+		return values.length > 0
+			? {
+					type,
+					...(title ? { title } : {}),
+					points: values.slice(0, MAX_POINTS),
+				}
+			: undefined;
+	}
+
+	const points = dataLines
+		.map(parsePoint)
+		.filter((point): point is ChartPoint => point !== undefined);
+	return points.length > 0
+		? { type, ...(title ? { title } : {}), points: points.slice(0, MAX_POINTS) }
+		: undefined;
+}
+
+export function renderChart(spec: ChartSpec, availableWidth: number): string[] {
+	if (!Number.isFinite(availableWidth) || availableWidth < MINIMUM_WIDTH)
+		return [];
+
+	const width = Math.floor(availableWidth);
+	const body =
+		spec.type === "bar"
+			? renderBars(spec.points, width)
+			: spec.type === "sparkline"
+				? renderSparkline(spec.points, width)
+				: spec.type === "heatmap"
+					? renderHeatmap(spec.rows ?? [], width)
+					: renderBraille(spec.points, spec.type === "line", width);
+	if (body.length === 0) return [];
+
+	const lines = spec.title ? [spec.title, ...body] : body;
+	return lines.map((line) => truncate(line, width));
+}
+
+function normalizeChartType(value: string | undefined): ChartType | undefined {
+	const normalized = value?.trim().toLowerCase();
+	return normalized === "histogram"
+		? "bar"
+		: CHART_TYPES.find((type) => type === normalized);
+}
+
+function parseOpeningFence(
+	line: string,
+): { fence: Fence; language: string } | undefined {
+	const match = /^(?: {0,3})(`{3,}|~{3,})[^\S\r\n]*(.*)$/u.exec(line);
+	if (!match?.[1]) return undefined;
+	const fenceCharacter = match[1][0];
+	if (fenceCharacter !== "`" && fenceCharacter !== "~") return undefined;
+	return {
+		fence: { character: fenceCharacter, length: match[1].length },
+		language: (match[2] ?? "").trim().split(/\s+/u, 1)[0]?.toLowerCase() ?? "",
+	};
+}
+
+function findClosingFence(
+	lines: string[],
+	start: number,
+	fence: Fence,
+): number | undefined {
+	for (let index = start; index < lines.length; index += 1) {
+		const trimmed = (lines[index] ?? "").replace(/^ {0,3}/u, "").trimEnd();
+		if (
+			trimmed.length < fence.length ||
+			trimmed.split("").some((character) => character !== fence.character)
+		) {
+			continue;
+		}
+		return index;
+	}
+	return undefined;
+}
+
+function parsePoint(sourceLine: string, index: number): ChartPoint | undefined {
+	const line = sourceLine.trim();
+	if (!line || /^[-|]+$/u.test(line)) return undefined;
+
+	const delimited = line.split(/\s*[|,\t]\s*/u).filter(Boolean);
+	if (delimited.length >= 2) {
+		const value = parseNumber(delimited[delimited.length - 1]);
+		const label = delimited.slice(0, -1).join(" ").trim();
+		if (value !== undefined && label) return { label, value };
+	}
+
+	const pair = /^(.*?)\s+(-?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?%?)$/iu.exec(
+		line,
+	);
+	if (pair?.[1] && pair[2]) {
+		const value = parseNumber(pair[2]);
+		if (value !== undefined) return { label: pair[1].trim(), value };
+	}
+
+	const value = parseNumber(line);
+	return value === undefined ? undefined : { label: String(index + 1), value };
+}
+
+function parseHeatmapRow(sourceLine: string): HeatmapRow | undefined {
+	const line = sourceLine.trim();
+	if (!line || /^[-|]+$/u.test(line)) return undefined;
+	const fields = line.split(/\s*[|,\t]\s*/u).filter(Boolean);
+	const cells = fields.length >= 2 ? fields : line.split(/\s+/u);
+	if (cells.length < 2) return undefined;
+	const label = cells[0]?.trim();
+	if (!label) return undefined;
+	const values = cells.slice(1).map(parseNumber);
+	return values.every((value): value is number => value !== undefined)
+		? { label, values }
+		: undefined;
+}
+
+function parseNumber(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const number = Number(value.trim().replace(/%$/u, ""));
+	return Number.isFinite(number) ? number : undefined;
+}
+
+function renderBars(points: ChartPoint[], width: number): string[] {
+	const values = points.map((point) => Math.max(0, point.value));
+	const maximum = Math.max(1, ...values);
+	const yLabelWidth = Math.max(3, displayWidth(formatNumber(maximum)));
+	const plotWidth = width - yLabelWidth - 3;
+	if (plotWidth < points.length) return [];
+
+	const gap = points.length <= plotWidth ? 1 : 0;
+	const barWidth = Math.max(
+		1,
+		Math.floor((plotWidth - gap * (points.length - 1)) / points.length),
+	);
+	const usedWidth = points.length * barWidth + gap * (points.length - 1);
+	const lines: string[] = [];
+
+	for (let row = 0; row < PLOT_ROWS; row += 1) {
+		const distanceFromBottom = PLOT_ROWS - row;
+		const label =
+			row === 0 || row === Math.floor(PLOT_ROWS / 2) || row === PLOT_ROWS - 1
+				? formatNumber(
+						row === PLOT_ROWS - 1
+							? 0
+							: row === Math.floor(PLOT_ROWS / 2)
+								? maximum / 2
+								: maximum,
+					)
+				: "";
+		const bars = values
+			.map((value) =>
+				verticalBar(value / maximum, distanceFromBottom, barWidth),
+			)
+			.join(" ".slice(0, gap));
+		lines.push(`${label.padStart(yLabelWidth)} ┤${bars}`);
+	}
+
+	lines.push(`${"".padStart(yLabelWidth)} └${"─".repeat(usedWidth)}`);
+	const labels = points
+		.map((point) =>
+			center(truncate(point.label, barWidth), barWidth).padEnd(barWidth + gap),
+		)
+		.join("");
+	lines.push(`${"".padStart(yLabelWidth + 2)}${labels.trimEnd()}`);
+	return lines;
+}
+
+function verticalBar(
+	ratio: number,
+	distanceFromBottom: number,
+	width: number,
+): string {
+	const height = ratio * PLOT_ROWS;
+	if (height < distanceFromBottom - 1) return " ".repeat(width);
+	if (height >= distanceFromBottom) return "█".repeat(width);
+	const fraction = Math.max(
+		1,
+		Math.min(8, Math.ceil((height - (distanceFromBottom - 1)) * 8)),
+	);
+	return SPARK_GLYPHS[fraction - 1]?.repeat(width) ?? " ".repeat(width);
+}
+
+function renderSparkline(points: ChartPoint[], width: number): string[] {
+	const values = points.map((point) => point.value);
+	const chartWidth = Math.max(4, width - 2);
+	const sampled = sample(values, chartWidth);
+	const minimum = Math.min(...sampled);
+	const maximum = Math.max(...sampled);
+	const range = maximum - minimum || 1;
+	const spark = sampled
+		.map(
+			(value) =>
+				SPARK_GLYPHS[
+					Math.min(7, Math.floor(((value - minimum) / range) * 8))
+				] ?? "▁",
+		)
+		.join("");
+	return [`${formatNumber(minimum)} ${spark} ${formatNumber(maximum)}`];
+}
+
+function renderBraille(
+	points: ChartPoint[],
+	connect: boolean,
+	width: number,
+): string[] {
+	const yValues = points.map((point) => point.value);
+	const minimum = Math.min(...yValues);
+	const maximum = Math.max(...yValues);
+	const range = maximum - minimum || 1;
+	const yLabelWidth = Math.max(3, displayWidth(formatNumber(maximum)));
+	const plotColumns = width - yLabelWidth - 3;
+	if (plotColumns < 4) return [];
+
+	const dotWidth = plotColumns * 2;
+	const dotHeight = PLOT_ROWS * 4;
+	const dots = new Set<string>();
+	const coordinates = points.map((point, index) => ({
+		x:
+			points.length === 1
+				? 0
+				: Math.round((index * (dotWidth - 1)) / (points.length - 1)),
+		y:
+			dotHeight -
+			1 -
+			Math.round(((point.value - minimum) / range) * (dotHeight - 1)),
+	}));
+
+	for (let index = 0; index < coordinates.length; index += 1) {
+		const point = coordinates[index];
+		if (!point) continue;
+		if (connect && index > 0) {
+			const previous = coordinates[index - 1];
+			if (previous) drawLine(previous.x, previous.y, point.x, point.y, dots);
+		} else {
+			dots.add(`${point.x},${point.y}`);
+		}
+	}
+
+	const lines: string[] = [];
+	for (let row = 0; row < PLOT_ROWS; row += 1) {
+		const label =
+			row === 0 || row === Math.floor(PLOT_ROWS / 2) || row === PLOT_ROWS - 1
+				? formatNumber(maximum - ((maximum - minimum) * row) / (PLOT_ROWS - 1))
+				: "";
+		let chart = "";
+		for (let column = 0; column < plotColumns; column += 1) {
+			let bits = 0;
+			for (const [dotX, dotY, bit] of BRAILLE_DOTS) {
+				if (dots.has(`${column * 2 + dotX},${row * 4 + dotY}`)) bits |= bit;
+			}
+			chart += String.fromCodePoint(0x2800 + bits);
+		}
+		lines.push(`${label.padStart(yLabelWidth)} ┤${chart}`);
+	}
+
+	lines.push(`${"".padStart(yLabelWidth)} └${"─".repeat(plotColumns)}`);
+	const first = truncate(points[0]?.label ?? "", Math.floor(plotColumns / 2));
+	const last = truncate(
+		points[points.length - 1]?.label ?? "",
+		Math.floor(plotColumns / 2),
+	);
+	const spacer = Math.max(
+		1,
+		plotColumns - displayWidth(first) - displayWidth(last),
+	);
+	lines.push(
+		`${"".padStart(yLabelWidth + 2)}${first}${" ".repeat(spacer)}${last}`,
+	);
+	return lines;
+}
+
+function drawLine(
+	x0: number,
+	y0: number,
+	x1: number,
+	y1: number,
+	dots: Set<string>,
+): void {
+	let x = x0;
+	let y = y0;
+	const dx = Math.abs(x1 - x0);
+	const sx = x0 < x1 ? 1 : -1;
+	const dy = -Math.abs(y1 - y0);
+	const sy = y0 < y1 ? 1 : -1;
+	let error = dx + dy;
+
+	while (true) {
+		dots.add(`${x},${y}`);
+		if (x === x1 && y === y1) return;
+		const twice = 2 * error;
+		if (twice >= dy) {
+			error += dy;
+			x += sx;
+		}
+		if (twice <= dx) {
+			error += dx;
+			y += sy;
+		}
+	}
+}
+
+function renderHeatmap(rows: HeatmapRow[], width: number): string[] {
+	const rowLabelWidth = Math.min(
+		14,
+		Math.max(3, ...rows.map((row) => displayWidth(row.label))),
+	);
+	const columns = Math.max(0, ...rows.map((row) => row.values.length));
+	const cellWidth = width - rowLabelWidth - 2;
+	if (columns === 0 || cellWidth < 1) return [];
+
+	const allValues = rows.flatMap((row) => row.values);
+	const minimum = Math.min(...allValues);
+	const maximum = Math.max(...allValues);
+	const range = maximum - minimum || 1;
+	const visibleColumns = Math.min(columns, cellWidth);
+	const lines = rows.map((row) => {
+		const values = sample(row.values, visibleColumns);
+		const cells = values
+			.map(
+				(value) =>
+					HEAT_GLYPHS[
+						Math.min(3, Math.floor(((value - minimum) / range) * 4))
+					] ?? "░",
+			)
+			.join("");
+		return `${padEndWidth(truncate(row.label, rowLabelWidth), rowLabelWidth)} │ ${cells}`;
+	});
+	lines.push(`${"".padStart(rowLabelWidth + 3)}${HEAT_GLYPHS}  low → high`);
+	return lines;
+}
+
+function sample(values: number[], limit: number): number[] {
+	if (limit <= 1) return values.length > 0 ? [values[0] ?? 0] : [];
+	if (values.length <= limit) return values;
+	return Array.from({ length: limit }, (_, index) => {
+		const sourceIndex = Math.round((index * (values.length - 1)) / (limit - 1));
+		return values[sourceIndex] ?? values[values.length - 1] ?? 0;
+	});
+}
+
+function formatNumber(value: number): string {
+	if (Math.abs(value) >= 1000)
+		return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1).replace(/\.0$/u, "")}k`;
+	if (Number.isInteger(value)) return String(value);
+	return value.toFixed(1).replace(/\.0$/u, "");
+}
+
+function codeSpan(line: string): string {
+	const content = line || "\u00a0";
+	const longestBacktickRun = Math.max(
+		0,
+		...Array.from(content.matchAll(/`+/gu), (match) => match[0].length),
+	);
+	const fence = "`".repeat(longestBacktickRun + 1);
+	const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
+	return `${fence}${padding}${content}${padding}${fence}`;
+}
+
+function displayWidth(value: string): number {
+	return Array.from(value).reduce((width, character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		if (
+			(codePoint >= 0x300 && codePoint <= 0x36f) ||
+			(codePoint >= 0xfe00 && codePoint <= 0xfe0f)
+		)
+			return width;
+		if (
+			codePoint >= 0x1100 &&
+			(codePoint <= 0x115f ||
+				codePoint === 0x2329 ||
+				codePoint === 0x232a ||
+				(codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+				(codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+				(codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+				(codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+				(codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+				(codePoint >= 0xff00 && codePoint <= 0xff60) ||
+				(codePoint >= 0xffe0 && codePoint <= 0xffe6))
+		)
+			return width + 2;
+		return width + 1;
+	}, 0);
+}
+
+function truncate(value: string, width: number): string {
+	if (displayWidth(value) <= width) return value;
+	if (width <= 1) return "…";
+	let output = "";
+	for (const character of value) {
+		if (displayWidth(`${output}${character}…`) > width) break;
+		output += character;
+	}
+	return `${output}…`;
+}
+
+function padEndWidth(value: string, width: number): string {
+	return `${value}${" ".repeat(Math.max(0, width - displayWidth(value)))}`;
+}
+
+function center(value: string, width: number): string {
+	const remaining = Math.max(0, width - displayWidth(value));
+	return `${" ".repeat(Math.floor(remaining / 2))}${value}${" ".repeat(Math.ceil(remaining / 2))}`;
+}

--- a/packages/pi-unicode-charts/src/index.ts
+++ b/packages/pi-unicode-charts/src/index.ts
@@ -1,0 +1,29 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { transformChartMarkdown } from "./chart.js";
+
+const CHART_PROMPT = [
+	"This session renders explicit fenced `chart` blocks as terminal-native Unicode charts.",
+	"Use them only when a compact visual communicates data better than prose or a table.",
+	"Format a fenced `chart` block with `type: bar|line|scatter|sparkline|heatmap`, optional `title:`, `data:`, and rows such as `Label 42`.",
+	"Charts are display-only and should stay small enough to read in a terminal.",
+].join("\n");
+
+export default function unicodeCharts(pi: ExtensionAPI): void {
+	pi.registerMarkdownTransformer((markdown, context) => {
+		if (context.messageType === "assistant-thinking") return markdown;
+		return transformChartMarkdown(markdown, context.availableWidth);
+	});
+
+	pi.on("before_agent_start", (event, ctx) => {
+		if (!ctx.hasUI) return;
+		if (event.systemPrompt.includes(CHART_PROMPT)) return;
+		return { systemPrompt: `${event.systemPrompt}\n\n${CHART_PROMPT}` };
+	});
+}
+
+export {
+	type ChartSpec,
+	type ChartType,
+	renderChart,
+	transformChartMarkdown,
+} from "./chart.js";

--- a/packages/pi-unicode-charts/tests/chart.test.ts
+++ b/packages/pi-unicode-charts/tests/chart.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "bun:test";
-import {
-	parseChartSource,
-	renderChart,
-	transformChartMarkdown,
-} from "../src/chart.js";
+import { parseChartSource, transformChartMarkdown } from "../src/chart.js";
 
 test("parses chart rows with labels containing spaces", () => {
 	const spec = parseChartSource(`
@@ -35,17 +31,21 @@ test("replaces closed chart fences and preserves other Markdown", () => {
 		"B 5",
 		"```",
 		"",
-		"```ts",
-		"const value = 1;",
+		"````md",
+		"```chart",
+		"type: scatter",
+		"data:",
+		"Example 1",
 		"```",
+		"````",
 	].join("\n");
 
 	const transformed = transformChartMarkdown(source, 48);
 
 	expect(transformed).toContain("┤");
 	expect(transformed).toContain("█");
-	expect(transformed).toContain("```ts");
-	expect(transformed).toContain("const value = 1;");
+	expect(transformed).toContain("```chart");
+	expect(transformed).toContain("type: scatter");
 	expect(transformed).not.toContain("type: bar");
 });
 
@@ -55,28 +55,4 @@ test("keeps invalid and unfinished chart fences as source", () => {
 
 	expect(transformChartMarkdown(invalid, 48)).toBe(invalid);
 	expect(transformChartMarkdown(unfinished, 48)).toBe(unfinished);
-});
-
-test("keeps rendered chart rows within the requested width", () => {
-	const cases = [
-		parseChartSource("type: line\ndata:\nA 2\nB 9\nC 4"),
-		parseChartSource("type: scatter\ndata:\nA 2\nB 9\nC 4"),
-		parseChartSource("type: sparkline\ndata:\n2 9 4 8 3"),
-		parseChartSource("type: heatmap\ndata:\nA 1 2 3\nB 3 2 1"),
-	].filter((spec) => spec !== undefined);
-
-	for (const spec of cases) {
-		const rendered = renderChart(spec, 40);
-		expect(rendered.length).toBeGreaterThan(0);
-		expect(rendered.every((line) => Array.from(line).length <= 40)).toBe(true);
-	}
-
-	const line = renderChart(cases[0]!, 40).join("\n");
-	expect(/[\u2800-\u28ff]/u.test(line)).toBe(true);
-
-	const sparkline = renderChart(cases[2]!, 40)[0] ?? "";
-	expect(sparkline.length).toBe(40);
-
-	const heatmap = renderChart(cases[3]!, 40)[0] ?? "";
-	expect(heatmap.length).toBe(40);
 });

--- a/packages/pi-unicode-charts/tests/chart.test.ts
+++ b/packages/pi-unicode-charts/tests/chart.test.ts
@@ -73,4 +73,10 @@ test("keeps rendered chart rows within the requested width", () => {
 
 	const line = renderChart(cases[0]!, 40).join("\n");
 	expect(/[\u2800-\u28ff]/u.test(line)).toBe(true);
+
+	const sparkline = renderChart(cases[2]!, 40)[0] ?? "";
+	expect(sparkline.length).toBe(40);
+
+	const heatmap = renderChart(cases[3]!, 40)[0] ?? "";
+	expect(heatmap.length).toBe(40);
 });

--- a/packages/pi-unicode-charts/tests/chart.test.ts
+++ b/packages/pi-unicode-charts/tests/chart.test.ts
@@ -50,7 +50,7 @@ test("replaces closed chart fences and preserves other Markdown", () => {
 });
 
 test("keeps invalid and unfinished chart fences as source", () => {
-	const invalid = "```chart\ntype: pie\ndata:\nA 1\n```";
+	const invalid = "```chart\r\ntype: pie\r\ndata:\r\nA 1\r\n```";
 	const unfinished = "```chart\ntype: line\ndata:\nA 1";
 
 	expect(transformChartMarkdown(invalid, 48)).toBe(invalid);

--- a/packages/pi-unicode-charts/tests/chart.test.ts
+++ b/packages/pi-unicode-charts/tests/chart.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import {
+	parseChartSource,
+	renderChart,
+	transformChartMarkdown,
+} from "../src/chart.js";
+
+test("parses chart rows with labels containing spaces", () => {
+	const spec = parseChartSource(`
+		type: bar
+		title: Requests
+		data:
+		GET /users 120
+		POST /users | 80
+	`);
+
+	expect(spec).toEqual({
+		type: "bar",
+		title: "Requests",
+		points: [
+			{ label: "GET /users", value: 120 },
+			{ label: "POST /users", value: 80 },
+		],
+	});
+});
+
+test("replaces closed chart fences and preserves other Markdown", () => {
+	const source = [
+		"Before",
+		"",
+		"```chart",
+		"type: bar",
+		"data:",
+		"A 10",
+		"B 5",
+		"```",
+		"",
+		"```ts",
+		"const value = 1;",
+		"```",
+	].join("\n");
+
+	const transformed = transformChartMarkdown(source, 48);
+
+	expect(transformed).toContain("┤");
+	expect(transformed).toContain("█");
+	expect(transformed).toContain("```ts");
+	expect(transformed).toContain("const value = 1;");
+	expect(transformed).not.toContain("type: bar");
+});
+
+test("keeps invalid and unfinished chart fences as source", () => {
+	const invalid = "```chart\ntype: pie\ndata:\nA 1\n```";
+	const unfinished = "```chart\ntype: line\ndata:\nA 1";
+
+	expect(transformChartMarkdown(invalid, 48)).toBe(invalid);
+	expect(transformChartMarkdown(unfinished, 48)).toBe(unfinished);
+});
+
+test("keeps rendered chart rows within the requested width", () => {
+	const cases = [
+		parseChartSource("type: line\ndata:\nA 2\nB 9\nC 4"),
+		parseChartSource("type: scatter\ndata:\nA 2\nB 9\nC 4"),
+		parseChartSource("type: sparkline\ndata:\n2 9 4 8 3"),
+		parseChartSource("type: heatmap\ndata:\nA 1 2 3\nB 3 2 1"),
+	].filter((spec) => spec !== undefined);
+
+	for (const spec of cases) {
+		const rendered = renderChart(spec, 40);
+		expect(rendered.length).toBeGreaterThan(0);
+		expect(rendered.every((line) => Array.from(line).length <= 40)).toBe(true);
+	}
+
+	const line = renderChart(cases[0]!, 40).join("\n");
+	expect(/[\u2800-\u28ff]/u.test(line)).toBe(true);
+});

--- a/packages/pi-unicode-charts/tsconfig.json
+++ b/packages/pi-unicode-charts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
This PR adds compact terminal-native charts to Pi Markdown.

## Summary

- render explicit `chart` fences as width-bounded Unicode bar, line, scatter, sparkline, and heatmap charts
- preserve ordinary, invalid, nested, and unfinished Markdown fences
- add signed bar rendering and a concise model format hint without changing message context
- publish a dependency-free Pi extension with npm and gallery discovery metadata

## Validation

- `bun run check:changed`
- `bun run changeset:check`
- `npm publish --dry-run --json`
- verified the packed release resolves to `@howaboua/pi-unicode-charts@0.1.0` through Changesets

## Release

- Changeset: yes (minor, initial `0.1.0` release)
- Packages: `@howaboua/pi-unicode-charts`
- Aggregates: generated by release automation
