### PR TITLE
fix(pi-pet): validate generated changelog runtime

### DIFF
--- a/packages/pi-pet/biome.json
+++ b/packages/pi-pet/biome.json
@@ -130,6 +130,20 @@
   },
   "overrides": [
     {
+      "includes": ["changelog.ts"],
+      "formatter": {
+        "indentStyle": "tab",
+        "indentWidth": 2,
+        "lineWidth": 80
+      },
+      "linter": {
+        "rules": {
+          "complexity": { "noExcessiveCognitiveComplexity": "off" },
+          "performance": { "useTopLevelRegex": "off" }
+        }
+      }
+    },
+    {
       "includes": ["**/*.d.ts", "**/*.config.{js,ts,mjs,cjs}", "**/scripts/**"],
       "linter": {
         "rules": {


### PR DESCRIPTION
This PR lets Pi Pet validate the shared changelog extension generated during versioning.

## Summary

- apply the shared runtime's canonical formatting only to generated `changelog.ts`
- leave opinionated complexity and regex rules to the source template while retaining all other Pi Pet checks

## Validation

- generated `packages/pi-pet/changelog.ts` from the release template
- `bun run --cwd packages/pi-pet lint:strict`
- `bun run check:changed`
- `bun run changeset:check`

## Release

- Changeset: no; development-only validation configuration
- Packages: none
