### PR TITLE
fix(pi-subagent-review): follow empty JJ cursors

### DIFF
--- a/.changeset/patch-msynhgw4-97800c.md
+++ b/.changeset/patch-msynhgw4-97800c.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subagent-review": patch
+---
+
+Review a focused JJ revision when its workspace cursor is an empty child commit.

--- a/packages/pi-subagent-review/src/messages.ts
+++ b/packages/pi-subagent-review/src/messages.ts
@@ -108,8 +108,17 @@ function buildJjReviewScopeText(
 			: "(root revision)";
 	return [
 		"for JJ workspace " + review.repoRoot,
-		"active change ID: " + review.changeId,
-		"active commit ID: " + review.commitId,
+		...(review.workspaceChangeId && review.workspaceCommitId
+			? [
+					"active empty workspace change ID: " + review.workspaceChangeId,
+					"active empty workspace commit ID: " + review.workspaceCommitId,
+					"review parent change ID: " + review.changeId,
+					"review parent commit ID: " + review.commitId,
+				]
+			: [
+					"active change ID: " + review.changeId,
+					"active commit ID: " + review.commitId,
+				]),
 		"direct parent change ID" +
 			(review.parentChangeIds.length === 1 ? "" : "s") +
 			": " +

--- a/packages/pi-subagent-review/src/review-command.ts
+++ b/packages/pi-subagent-review/src/review-command.ts
@@ -100,6 +100,15 @@ export function registerReviewCommand(
 				}
 			}
 
+			if (!review.hasAnyChanges) {
+				ctx.ui.notify(
+					review.vcs === "jj"
+						? "No changes found in the active JJ revision or its immediate parent."
+						: "No changes found relative to the selected base branch.",
+					"info",
+				);
+				return;
+			}
 			sendReviewPreface(pi, ctx, { freshLoop: parsedArgs.startLoop });
 
 			if (parsedArgs.startLoop) {
@@ -114,24 +123,6 @@ export function registerReviewCommand(
 					);
 					ctx.ui.notify("Review loop marker set", "info");
 				}
-			}
-
-			if (!review.hasAnyChanges) {
-				sendReviewFindings(
-					pi,
-					ctx,
-					review,
-					review.vcs === "jj"
-						? "No changes found in the active JJ revision."
-						: "No changes found relative to the selected base branch.",
-				);
-				ctx.ui.notify(
-					review.vcs === "jj"
-						? "No changes found in the active JJ revision; sent summary to the agent."
-						: `No changes found relative to ${review.baseBranch}; sent summary to the agent.`,
-					"info",
-				);
-				return;
 			}
 
 			reviewConfig ??= await resolveReviewConfig(pi, ctx);

--- a/packages/pi-subagent-review/src/review-context.ts
+++ b/packages/pi-subagent-review/src/review-context.ts
@@ -152,74 +152,135 @@ async function resolveSingleJjRevision(
 	return { changeId: lines[0], commitId: lines[1] };
 }
 
-async function detectJjReviewContext(
+interface JjRevision {
+	changeId: string;
+	commitId: string;
+	parentChangeIds: string[];
+	parentCommitIds: string[];
+}
+
+async function readJjRevision(
 	pi: ExtensionAPI,
-	repoRoot: string,
-	stackBase?: string,
-): Promise<JjReviewContext> {
-	const active = await jjString(pi, repoRoot, [
+	cwd: string,
+	revision: string,
+): Promise<JjRevision> {
+	const output = await jjString(pi, cwd, [
 		"log",
 		"-r",
-		"@",
+		revision,
 		"--no-graph",
 		"--template",
 		'change_id ++ "\\n" ++ commit_id ++ "\\n" ++ parents.map(|p| p.change_id()).join(",") ++ "\\n" ++ parents.map(|p| p.commit_id()).join(",") ++ "\\n" ++ if(conflict, "true", "false") ++ "\\n"',
 	]);
 	const [changeId, commitId, parentChanges = "", parentCommits = "", conflict] =
-		active.split("\n");
-	if (!changeId || !commitId || !conflict)
-		throw new Error("Could not identify the active JJ revision for /review.");
+		output.split("\n");
+	if (!changeId || !commitId || !conflict) {
+		throw new Error("Could not identify the selected JJ revision for /review.");
+	}
 	if (conflict === "true") {
 		throw new Error(
-			`Active JJ revision ${changeId} (${commitId}) has conflicts. Resolve them before running /review.`,
+			"JJ revision " +
+				changeId +
+				" (" +
+				commitId +
+				") has conflicts. Resolve them before running /review.",
 		);
 	}
+	return {
+		changeId,
+		commitId,
+		parentChangeIds: parentChanges ? parentChanges.split(",") : [],
+		parentCommitIds: parentCommits ? parentCommits.split(",") : [],
+	};
+}
 
-	const parentChangeIds = parentChanges ? parentChanges.split(",") : [];
-	const parentCommitIds = parentCommits ? parentCommits.split(",") : [];
+async function jjDiffSummary(
+	pi: ExtensionAPI,
+	cwd: string,
+	commitId: string,
+	baseCommitId?: string,
+): Promise<string> {
+	return jjString(
+		pi,
+		cwd,
+		baseCommitId
+			? ["diff", "--from", baseCommitId, "--to", commitId, "--summary"]
+			: ["diff", "-r", commitId, "--summary"],
+	);
+}
+
+async function detectJjReviewContext(
+	pi: ExtensionAPI,
+	repoRoot: string,
+	stackBase?: string,
+): Promise<JjReviewContext> {
+	const active = await readJjRevision(pi, repoRoot, "@");
+	let target = active;
 	let base:
 		| { revision: string; changeId: string; commitId: string }
 		| undefined;
 	if (stackBase) {
 		const resolved = await resolveSingleJjRevision(pi, repoRoot, stackBase);
-		if (resolved.commitId === commitId) {
+		if (resolved.commitId === active.commitId) {
 			throw new Error(
-				`JJ review stack base ${JSON.stringify(stackBase)} is the active revision. Choose an ancestor instead.`,
+				"JJ review stack base " +
+					JSON.stringify(stackBase) +
+					" is the active revision. Choose an ancestor instead.",
 			);
 		}
 		const ancestor = await jjString(pi, repoRoot, [
 			"log",
 			"-r",
-			`ancestors(${commitId}) & ${resolved.commitId}`,
+			["ancestors(", active.commitId, ") & ", resolved.commitId].join(""),
 			"--no-graph",
 			"--template",
 			"commit_id",
 		]);
 		if (ancestor !== resolved.commitId) {
 			throw new Error(
-				`JJ review stack base ${JSON.stringify(stackBase)} must be an ancestor of active revision ${changeId}.`,
+				"JJ review stack base " +
+					JSON.stringify(stackBase) +
+					" must be an ancestor of active revision " +
+					active.changeId +
+					".",
 			);
 		}
 		base = { revision: stackBase, ...resolved };
 	}
 
-	const changedFiles = await jjString(
+	let changedFiles = await jjDiffSummary(
 		pi,
 		repoRoot,
-		base
-			? ["diff", "--from", base.commitId, "--to", commitId, "--summary"]
-			: ["diff", "-r", commitId, "--summary"],
+		target.commitId,
+		base?.commitId,
 	);
+	if (!base && !changedFiles && active.parentCommitIds.length === 1) {
+		const parentCommitId = active.parentCommitIds[0];
+		if (parentCommitId) {
+			const parent = await readJjRevision(pi, repoRoot, parentCommitId);
+			const parentChanges = await jjDiffSummary(pi, repoRoot, parent.commitId);
+			if (parentChanges) {
+				target = parent;
+				changedFiles = parentChanges;
+			}
+		}
+	}
 
 	return {
 		vcs: "jj",
 		repoRoot,
-		currentRef: changeId,
+		currentRef: target.changeId,
 		scope: base ? "jj-base" : "jj-parent",
-		changeId,
-		commitId,
-		parentChangeIds,
-		parentCommitIds,
+		changeId: target.changeId,
+		commitId: target.commitId,
+		parentChangeIds: target.parentChangeIds,
+		parentCommitIds: target.parentCommitIds,
+		...(target.commitId !== active.commitId
+			? {
+					workspaceChangeId: active.changeId,
+					workspaceCommitId: active.commitId,
+				}
+			: {}),
 		...(base
 			? {
 					baseRevision: base.revision,
@@ -232,7 +293,6 @@ async function detectJjReviewContext(
 		hasAnyChanges: changedFiles.length > 0,
 	};
 }
-
 async function detectGitReviewContext(
 	pi: ExtensionAPI,
 	cwd: string,

--- a/packages/pi-subagent-review/src/review-task.ts
+++ b/packages/pi-subagent-review/src/review-task.ts
@@ -125,8 +125,17 @@ function buildJjReviewTask(
 			: "(root revision)";
 	const sections = [
 		"JJ workspace root: " + review.repoRoot,
-		"Active change ID: " + review.changeId,
-		"Active commit ID: " + review.commitId,
+		...(review.workspaceChangeId && review.workspaceCommitId
+			? [
+					"Active empty workspace change ID: " + review.workspaceChangeId,
+					"Active empty workspace commit ID: " + review.workspaceCommitId,
+					"Review parent change ID: " + review.changeId,
+					"Review parent commit ID: " + review.commitId,
+				]
+			: [
+					"Active change ID: " + review.changeId,
+					"Active commit ID: " + review.commitId,
+				]),
 		"Direct parent commit ID" +
 			(review.parentCommitIds.length === 1 ? "" : "s") +
 			": " +

--- a/packages/pi-subagent-review/src/types.ts
+++ b/packages/pi-subagent-review/src/types.ts
@@ -86,6 +86,8 @@ export interface JjReviewContext {
 	commitId: string;
 	parentChangeIds: string[];
 	parentCommitIds: string[];
+	workspaceChangeId?: string;
+	workspaceCommitId?: string;
 	baseRevision?: string;
 	baseChangeId?: string;
 	baseCommitId?: string;


### PR DESCRIPTION
This PR makes plain `/review` follow an empty JJ workspace cursor to the focused parent revision.

## Summary

- Review the immediate parent when active `@` has no changes
- Keep genuine no-change JJ reviews UI-only
- Preserve the pinned revision context in returned findings

## Validation

- `bun run check:changed`
- `bun run changeset:check`

## Release

- Changeset: yes
- Packages: `@howaboua/pi-subagent-review`
- Aggregates: generated by release automation

Refs #311
