### PR TITLE
Diagnose native compaction cache misses

### DIFF
--- a/.changeset/patch-msx9n87r-b2fe3f.md
+++ b/.changeset/patch-msx9n87r-b2fe3f.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Report native compaction cache misses with replay and transport diagnostics

--- a/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
@@ -18,8 +18,9 @@ import { executeRemoteCompactionV2 } from "./remote-v2-client.ts";
 import { buildRemoteCompactionV2Window } from "./remote-v2-history.ts";
 import { CODE_MODE_EXEC_GRAMMAR_INPUTS } from "../../tools/code-mode/exec-contract.ts";
 import { getActiveToolsInActiveOrder } from "../active-tools.ts";
-import { canonicalCompactionPromptInput } from "../../providers/openai-codex/session-continuity.ts";
+import { resolveCanonicalCompactionPromptInput } from "../../providers/openai-codex/session-continuity.ts";
 import { extractAccountId, resolveCodexWebSocketUrl } from "../../providers/openai-codex/headers.ts";
+import type { CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
@@ -229,17 +230,26 @@ async function handleCodexSessionBeforeCompactInner(event: SessionBeforeCompactE
 		ctx.ui.notify("OpenAI native compaction could not clone the previous compacted window; Pi compaction was not run.", "error");
 		return { cancel: true };
 	}
-	const canonicalInput = runtime.codexTransport && runtime.apiKey
-		? canonicalCompactionPromptInput(ctx.sessionManager.getSessionId(), runtime.model, {
+	const canonicalReplay = runtime.codexTransport && runtime.apiKey
+		? resolveCanonicalCompactionPromptInput(ctx.sessionManager.getSessionId(), runtime.model, {
 			url: resolveCodexWebSocketUrl(runtime.baseUrl),
 			accountId: extractAccountId(runtime.apiKey),
 		}, builtInput.input)
-		: undefined;
-	const validatedCanonicalInput = canonicalInput?.every(isRecord)
-		? canonicalInput as ResponsesInputItem[]
+		: { decision: "not_applicable" as const };
+	const validatedCanonicalInput = canonicalReplay.input?.every(isRecord)
+		? canonicalReplay.input as ResponsesInputItem[]
 		: undefined;
 	const input = validatedCanonicalInput ?? builtInput.input;
 	const { compactedKeptWindow } = builtInput;
+	const compactionDiagnostic: CodexCompactionDiagnostic = {
+		model: runtime.model,
+		inputSource: validatedCanonicalInput ? "canonical" : "reconstructed",
+		canonicalReplay: canonicalReplay.decision,
+		checkpointReused: latestNativeCompaction.ok,
+		...(latestNativeCompaction.ok && latestNativeCompaction.entry.details?.model
+			? { checkpointModel: latestNativeCompaction.entry.details.model }
+			: {}),
+	};
 
 	if (input.length === 0) {
 		ctx.ui.notify("OpenAI native compaction had no serializable conversation items; Pi compaction was not run.", "error");
@@ -261,7 +271,8 @@ async function handleCodexSessionBeforeCompactInner(event: SessionBeforeCompactE
 		modelRegistry: ctx.modelRegistry,
 		context,
 		promptInput: input,
-		promptInputSource: validatedCanonicalInput ? "canonical" : "reconstructed",
+		promptInputSource: compactionDiagnostic.inputSource,
+		compactionDiagnostic,
 		requestOptions,
 		tokensBefore: event.preparation.tokensBefore,
 		sessionId: ctx.sessionManager.getSessionId(),

--- a/packages/pi-codex-conversion/src/adapter/compaction/diagnostics.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/diagnostics.ts
@@ -1,0 +1,122 @@
+export type CodexCompactionInputSource = "canonical" | "reconstructed";
+
+export type CodexCompactionContinuation =
+	| "disabled"
+	| "no_session_cache_entry"
+	| "no_continuation"
+	| "body_mismatch"
+	| "input_shorter_than_baseline"
+	| "input_prefix_mismatch"
+	| "missing_previous_response_id"
+	| "delta";
+
+export type CodexCompactionReplayDecision =
+	| "validated"
+	| "not_applicable"
+	| "no_state"
+	| "model_mismatch"
+	| "identity_mismatch"
+	| "input_shorter_than_baseline"
+	| "request_prefix_mismatch"
+	| "response_prefix_mismatch";
+
+export type CodexCompactionDiagnostic = {
+	model?: string | undefined;
+	inputSource: CodexCompactionInputSource;
+	canonicalReplay: CodexCompactionReplayDecision;
+	checkpointReused: boolean;
+	checkpointModel?: string | undefined;
+	transport?: "websocket" | "sse" | undefined;
+	continuation?: CodexCompactionContinuation | undefined;
+	previousResponseId?: boolean | undefined;
+	fullInputItems?: number | undefined;
+	sentInputItems?: number | undefined;
+	rewrittenToolOutputs?: number | undefined;
+};
+
+const COMPACTION_INPUT_SOURCES = ["canonical", "reconstructed"] as const;
+const COMPACTION_CONTINUATIONS = [
+	"disabled",
+	"no_session_cache_entry",
+	"no_continuation",
+	"body_mismatch",
+	"input_shorter_than_baseline",
+	"input_prefix_mismatch",
+	"missing_previous_response_id",
+	"delta",
+] as const;
+const COMPACTION_REPLAY_DECISIONS = [
+	"validated",
+	"not_applicable",
+	"no_state",
+	"model_mismatch",
+	"identity_mismatch",
+	"input_shorter_than_baseline",
+	"request_prefix_mismatch",
+	"response_prefix_mismatch",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOneOf<T extends string>(values: readonly T[], value: unknown): value is T {
+	return typeof value === "string" && values.includes(value as T);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function isOptionalNonNegativeNumber(value: unknown): value is number | undefined {
+	return value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0);
+}
+
+export function isCodexCompactionDiagnostic(value: unknown): value is CodexCompactionDiagnostic {
+	if (!isRecord(value)) return false;
+	return isOneOf(COMPACTION_INPUT_SOURCES, value["inputSource"])
+		&& isOneOf(COMPACTION_REPLAY_DECISIONS, value["canonicalReplay"])
+		&& typeof value["checkpointReused"] === "boolean"
+		&& isOptionalString(value["model"])
+		&& isOptionalString(value["checkpointModel"])
+		&& (value["transport"] === undefined || value["transport"] === "websocket" || value["transport"] === "sse")
+		&& (value["continuation"] === undefined || isOneOf(COMPACTION_CONTINUATIONS, value["continuation"]))
+		&& (value["previousResponseId"] === undefined || typeof value["previousResponseId"] === "boolean")
+		&& isOptionalNonNegativeNumber(value["fullInputItems"])
+		&& isOptionalNonNegativeNumber(value["sentInputItems"])
+		&& isOptionalNonNegativeNumber(value["rewrittenToolOutputs"]);
+}
+
+export const COMPACTION_CACHE_DIAGNOSTIC_THRESHOLD = 0.8;
+
+function readable(value: string): string {
+	return value.replaceAll("_", " ");
+}
+
+export function formatCompactionCacheDiagnostic(
+	usage: { inputTokens: number; cachedInputTokens: number },
+	diagnostic: CodexCompactionDiagnostic | undefined,
+): string | undefined {
+	if (!isCodexCompactionDiagnostic(diagnostic) || usage.inputTokens <= 0) return undefined;
+	if (usage.cachedInputTokens / usage.inputTokens >= COMPACTION_CACHE_DIAGNOSTIC_THRESHOLD) return undefined;
+
+	const reasons: string[] = [];
+	if (diagnostic.inputSource === "reconstructed") {
+		reasons.push(`reconstructed history: ${readable(diagnostic.canonicalReplay)}`);
+	} else {
+		reasons.push("canonical replay");
+	}
+	if (diagnostic.transport === "sse") {
+		reasons.push("SSE full request");
+	} else if (diagnostic.transport === "websocket") {
+		if (diagnostic.continuation === "delta") reasons.push("WS delta");
+		else reasons.push(`WS full: ${readable(diagnostic.continuation ?? "no_continuation")}`);
+	}
+	if (diagnostic.checkpointReused) {
+		reasons.push(`checkpoint reused${diagnostic.checkpointModel ? ` (recorded model ${diagnostic.checkpointModel})` : ""}`);
+	}
+	if (diagnostic.rewrittenToolOutputs) {
+		reasons.push(`${diagnostic.rewrittenToolOutputs} tool output${diagnostic.rewrittenToolOutputs === 1 ? "" : "s"} shortened`);
+	}
+	return `(${reasons.join("; ")})`;
+}

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
@@ -10,6 +10,7 @@ import { sleep } from "../../providers/openai-codex/sse.ts";
 import { isWebSocketSseFallbackActive } from "../../providers/openai-codex/websocket.ts";
 import { canonicalCompactionPromptInput, canonicalCompactionRequestBody } from "../../providers/openai-codex/session-continuity.ts";
 import { extractAccountId, resolveCodexWebSocketUrl } from "../../providers/openai-codex/headers.ts";
+import type { CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 const MAX_STREAM_RETRIES = 2;
 type V2Stream = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AsyncIterable<unknown>;
@@ -23,6 +24,7 @@ export type RemoteCompactionV2Usage = {
 	cachedInputTokens: number;
 	cacheWriteInputTokens: number;
 	outputTokens: number;
+	diagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 export type ExecuteRemoteCompactionV2Options = {
@@ -37,6 +39,7 @@ export type ExecuteRemoteCompactionV2Options = {
 	transport?: Transport | undefined;
 	retryDelayMs?: number | undefined;
 	promptInputSource?: "canonical" | "reconstructed" | undefined;
+	compactionDiagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 function resolveStream(options: ExecuteRemoteCompactionV2Options): V2Stream | undefined {
@@ -65,14 +68,18 @@ function shouldRetry(result: Extract<RemoteCompactionV2Result, { ok: false }>): 
 	return !/\b(?:401|403)\b|unauthori[sz]ed|forbidden|usage limit|quota|not included|invalid request|context window|unsupported parameter/i.test(result.errorMessage);
 }
 
-function compactionUsage(message: AssistantMessage): RemoteCompactionV2Usage | undefined {
+function compactionUsage(message: AssistantMessage, diagnostic: CodexCompactionDiagnostic): RemoteCompactionV2Usage | undefined {
 	const inputTokens = message.usage.input + message.usage.cacheRead + message.usage.cacheWrite;
 	const cachedInputTokens = message.usage.cacheRead;
 	const cacheWriteInputTokens = message.usage.cacheWrite;
 	const outputTokens = message.usage.output;
 	if (![inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens].every((value) => Number.isFinite(value) && value >= 0)) return undefined;
 	if (inputTokens + outputTokens === 0) return undefined;
-	return { inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens };
+	return { inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens, diagnostic: structuredClone(diagnostic) };
+}
+
+function diagnosticTransport(transport: Transport | undefined): "websocket" | "sse" {
+	return transport === "websocket" || transport === "websocket-cached" ? "websocket" : "sse";
 }
 
 function canonicalSessionIdentity(options: ExecuteRemoteCompactionV2Options): { url: string; accountId: string } | undefined {
@@ -113,6 +120,14 @@ function withCurrentCompactionControls(
 async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimple: V2Stream): Promise<RemoteCompactionV2Result> {
 	const outputItems: unknown[] = [];
 	let responseStatus: number | undefined;
+	const compactionDiagnostic = options.compactionDiagnostic ?? {
+		inputSource: options.promptInputSource ?? "reconstructed",
+		canonicalReplay: "not_applicable" as const,
+		checkpointReused: false,
+	};
+	if (!options.runtime.codexTransport) {
+		compactionDiagnostic.transport = diagnosticTransport(options.transport);
+	}
 	const canonicalIdentity = canonicalSessionIdentity(options);
 	const canonicalInput = options.promptInputSource === "canonical"
 		? options.promptInput
@@ -129,6 +144,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 		...(options.signal ? { signal: options.signal } : {}),
 		...(options.transport ? { transport: options.transport } : {}),
 		...(options.runtime.codexTransport ? { canonicalCompaction: true } : {}),
+		compactionDiagnostics: compactionDiagnostic,
 		maxRetries: options.runtime.codexTransport ? MAX_STREAM_RETRIES : 0,
 		...(typeof options.requestOptions.service_tier === "string" ? { serviceTier: options.requestOptions.service_tier as never } : {}),
 		...(options.requestOptions.text?.verbosity ? { textVerbosity: options.requestOptions.text.verbosity } : {}),
@@ -149,6 +165,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 				model: options.runtime.model,
 				contextWindow: options.runtime.currentModel.contextWindow,
 			}), tokensBefore: options.tokensBefore });
+			compactionDiagnostic.rewrittenToolOutputs = request.rewrittenOutputs;
 			return {
 				...requestBody,
 				input: [...request.request.input, { type: "compaction_trigger" }],
@@ -182,7 +199,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 	if (compactions.length !== 1) {
 		return { ok: false, reason: "invalid-output", errorMessage: `Responses compaction v2 expected exactly one compaction output item, got ${compactions.length} from ${outputItems.length} output items` };
 	}
-	return { ok: true, compaction: compactions[0]!, responseId: completed.responseId, createdAt: new Date().toISOString(), usage: compactionUsage(completed) };
+	return { ok: true, compaction: compactions[0]!, responseId: completed.responseId, createdAt: new Date().toISOString(), usage: compactionUsage(completed, compactionDiagnostic) };
 }
 
 export async function executeRemoteCompactionV2(options: ExecuteRemoteCompactionV2Options): Promise<RemoteCompactionV2Result> {

--- a/packages/pi-codex-conversion/src/adapter/compaction/types.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/types.ts
@@ -1,4 +1,5 @@
 import type { CompactionEntry, CompactionResult } from "@earendil-works/pi-coding-agent";
+import { isCodexCompactionDiagnostic, type CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 const LEGACY_NATIVE_COMPACTION_STRATEGY = "openai-native-compact-v1";
 export const NATIVE_COMPACTION_STRATEGY = "openai-responses-compaction-v2";
@@ -31,6 +32,7 @@ export type NativeCompactionUsage = {
 	cachedInputTokens: number;
 	cacheWriteInputTokens: number;
 	outputTokens: number;
+	diagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 export type NativeCompactionIdentity = {
@@ -155,7 +157,8 @@ export function isNativeCompactionRequestMeta(value: unknown): value is NativeCo
 
 export function isNativeCompactionUsage(value: unknown): value is NativeCompactionUsage {
 	if (!isRecord(value)) return false;
-	return [value["inputTokens"], value["cachedInputTokens"], value["cacheWriteInputTokens"], value["outputTokens"]].every(isFiniteNonNegativeNumber);
+	return [value["inputTokens"], value["cachedInputTokens"], value["cacheWriteInputTokens"], value["outputTokens"]].every(isFiniteNonNegativeNumber)
+		&& (value["diagnostic"] === undefined || isCodexCompactionDiagnostic(value["diagnostic"]));
 }
 
 export function isNativeCompactionDetails(value: unknown): value is NativeCompactionDetails {

--- a/packages/pi-codex-conversion/src/diagnostics/logger.ts
+++ b/packages/pi-codex-conversion/src/diagnostics/logger.ts
@@ -61,6 +61,12 @@ function eventFields(event: CodexDiagnosticsEvent): Array<string | undefined> {
 		field("previous_response_id", event.previousResponseId),
 		field("full_input_items", event.fullInputItems),
 		field("sent_input_items", event.sentInputItems),
+		field("model", event.model),
+		field("compaction_source", event.compaction?.inputSource),
+		field("compaction_replay", event.compaction?.canonicalReplay),
+		field("checkpoint_reused", event.compaction?.checkpointReused),
+		field("checkpoint_model", event.compaction?.checkpointModel),
+		field("rewritten_tool_outputs", event.compaction?.rewrittenToolOutputs),
 	];
 	if (event.type === "usage") {
 		const totalInput = event.inputTokens + event.cachedInputTokens + event.cacheWriteInputTokens;

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -17,6 +17,7 @@ import { parseRealtimeVoicePrompt, REALTIME_VOICE_PROMPT_CHANNEL } from "../real
 import { initializeBashParser } from "../shell/bash.ts";
 import { prepareVoiceDelegation } from "../voice/delegation-preflight.ts";
 import { appendNotebookTreeEpoch } from "../tools/notebook-mode/session-identity.ts";
+import { formatCompactionCacheDiagnostic } from "../adapter/compaction/diagnostics.ts";
 import type { CodexExtensionRuntime } from "./runtime.ts";
 import type { CodexToolRegistration } from "./tools.ts";
 import type { CodexUiController } from "./ui.ts";
@@ -24,7 +25,8 @@ import type { CodexUiController } from "./ui.ts";
 function formatCompactionUsage(usage: NativeCompactionUsage): string {
 	const ratio = usage.inputTokens > 0 ? `${((usage.cachedInputTokens / usage.inputTokens) * 100).toFixed(1)}%` : "0%";
 	const tokens = (value: number) => Math.round(value).toLocaleString("en-US");
-	return `Compaction V2 · input ${tokens(usage.inputTokens)} · cache read ${tokens(usage.cachedInputTokens)} (${ratio}) · cache write ${tokens(usage.cacheWriteInputTokens)} · output ${tokens(usage.outputTokens)}`;
+	const diagnostic = formatCompactionCacheDiagnostic(usage, usage.diagnostic);
+	return `Compaction V2 · input ${tokens(usage.inputTokens)} · cache read ${tokens(usage.cachedInputTokens)} (${ratio}) · cache write ${tokens(usage.cacheWriteInputTokens)} · output ${tokens(usage.outputTokens)}${diagnostic ? ` ${diagnostic}` : ""}`;
 }
 
 function commandArg(args: unknown): string | undefined {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/session-continuity.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/session-continuity.ts
@@ -1,5 +1,6 @@
 import type { CanonicalHistoryDecision, ResponsesBody } from "./types.ts";
 import { responseInputsEqual } from "./websocket-continuation.ts";
+import type { CodexCompactionReplayDecision } from "../../adapter/compaction/diagnostics.ts";
 
 export type CanonicalSessionToken = {
 	laneIdentity: symbol;
@@ -126,15 +127,29 @@ export function canonicalCompactionPromptInput(
 	identity?: { url: string; accountId: string } | undefined,
 	reconstructedInput?: readonly unknown[] | undefined,
 ): unknown[] | undefined {
+	return resolveCanonicalCompactionPromptInput(sessionId, model, identity, reconstructedInput).input;
+}
+
+export function resolveCanonicalCompactionPromptInput(
+	sessionId: string,
+	model: string,
+	identity?: { url: string; accountId: string } | undefined,
+	reconstructedInput?: readonly unknown[] | undefined,
+): { input?: unknown[] | undefined; decision: CodexCompactionReplayDecision } {
 	const state = canonicalSessions.get(sessionId);
-	if (!state || state.requestBody.model !== model) return undefined;
-	if (identity && (state.url !== identity.url || state.accountId !== identity.accountId)) return undefined;
-	if (!reconstructedInput) return structuredClone(materializedInput(state));
-	return replayCanonicalInput(
+	if (!state) return { decision: "no_state" };
+	if (state.requestBody.model !== model) return { decision: "model_mismatch" };
+	if (identity && (state.url !== identity.url || state.accountId !== identity.accountId)) return { decision: "identity_mismatch" };
+	if (!reconstructedInput) return { input: structuredClone(materializedInput(state)), decision: "validated" };
+	const replay = replayCanonicalInput(
 		state,
 		reconstructedInput,
 		responsesLiteRequestPrefixLength(state.reconstructedRequestInput),
-	).input;
+	);
+	return {
+		...(replay.input ? { input: replay.input } : {}),
+		decision: replay.decision === "compaction" ? "validated" : replay.decision,
+	};
 }
 
 export function canonicalCompactionRequestBody(

--- a/packages/pi-codex-conversion/src/providers/openai-codex/transport-recovery.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/transport-recovery.ts
@@ -369,6 +369,15 @@ export function createCodexTransportStream<TApi extends Api>(
 				if (attempt > 0) output = createInitialAssistantMessage(model);
 				const responseItems: unknown[] = [];
 				try {
+					if (effectiveOptions?.compactionDiagnostics) {
+						Object.assign(effectiveOptions.compactionDiagnostics, {
+							transport: "sse",
+							continuation: undefined,
+							previousResponseId: false,
+							fullInputItems: body.input.length,
+							sentInputItems: body.input.length,
+						});
+					}
 					diagnostics?.({
 						type: "request",
 						lane,
@@ -376,7 +385,9 @@ export function createCodexTransportStream<TApi extends Api>(
 						attempt: attempt + 1,
 						fullInputItems: body.input.length,
 						sentInputItems: body.input.length,
+						model: body.model,
 						...(canonicalHistory ? { canonicalHistory } : {}),
+						...(effectiveOptions?.compactionDiagnostics ? { compaction: structuredClone(effectiveOptions.compactionDiagnostics) } : {}),
 					});
 					const response = await openCodexSSE(model, sseBody, baseSseHeaders, effectiveOptions, deps.turnState);
 					if (!response.body) throw new Error("No response body");

--- a/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import type { CodexCompactionDiagnostic } from "../../adapter/compaction/diagnostics.ts";
 
 export interface WebSocketLike {
 	readyState?: number | undefined;
@@ -78,9 +79,11 @@ export type CodexDiagnosticsEvent =
 			attempt: number;
 			fullInputItems: number;
 			sentInputItems: number;
+			model?: string | undefined;
 			socketReused?: boolean | undefined;
 			continuation?: WebSocketContinuationDecision | undefined;
 			canonicalHistory?: CanonicalHistoryDecision | undefined;
+			compaction?: CodexCompactionDiagnostic | undefined;
 			previousResponseId?: boolean | undefined;
 	  }
 	| {
@@ -143,6 +146,7 @@ export type OpenAICodexStreamOptions = CodexProviderStreamOptions & {
 	websocketConnectTimeoutMs?: number | undefined;
 	env?: ProviderEnv | undefined;
 	canonicalCompaction?: boolean | undefined;
+	compactionDiagnostics?: CodexCompactionDiagnostic | undefined;
 };
 
 export interface ResponsesBody {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -45,6 +45,15 @@ export async function processWebSocketStream<TApi extends Api>(
 		: { body: fullBody, decision: useCachedContext ? "no_session_cache_entry" : "disabled" } satisfies CachedWebSocketRequestBodyResult;
 	const requestBody = cachedRequest.body;
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics?.record);
+	if (options?.compactionDiagnostics) {
+		Object.assign(options.compactionDiagnostics, {
+			transport: "websocket",
+			continuation: cachedRequest.decision,
+			previousResponseId: Boolean(requestBody.previous_response_id),
+			fullInputItems: fullBody.input.length,
+			sentInputItems: requestBody.input.length,
+		});
+	}
 
 	const releaseOnce = (releaseOptions?: { keep?: boolean | undefined }) => {
 		if (released) return;
@@ -61,9 +70,11 @@ export async function processWebSocketStream<TApi extends Api>(
 				attempt: diagnostics.attempt,
 				fullInputItems: fullBody.input.length,
 				sentInputItems: requestBody.input.length,
+				model: fullBody.model,
 				socketReused: reused,
 				continuation: cachedRequest.decision,
 				...(canonical?.decision ? { canonicalHistory: canonical.decision } : {}),
+				...(options?.compactionDiagnostics ? { compaction: structuredClone(options.compactionDiagnostics) } : {}),
 				previousResponseId: Boolean(requestBody.previous_response_id),
 			});
 		}

--- a/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
+++ b/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
@@ -58,9 +58,18 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 			attempt: 1,
 			fullInputItems: 43,
 			sentInputItems: 43,
+			model: "gpt-5.6-sol",
 			socketReused: false,
 			continuation: "no_continuation",
 			canonicalHistory: "validated",
+			compaction: {
+				model: "gpt-5.6-sol",
+				inputSource: "reconstructed",
+				canonicalReplay: "response_prefix_mismatch",
+				checkpointReused: true,
+				checkpointModel: "gpt-5.6-luna",
+				rewrittenToolOutputs: 2,
+			},
 			previousResponseId: false,
 		});
 		log.record({
@@ -76,6 +85,8 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 		assert.match(contents, /event="request" lane="compaction" transport="websocket"/);
 		assert.match(contents, /canonical_history="validated"/);
 		assert.match(contents, /full_input_items=43 sent_input_items=43/);
+		assert.match(contents, /model="gpt-5.6-sol"/);
+		assert.match(contents, /compaction_source="reconstructed" compaction_replay="response_prefix_mismatch" checkpoint_reused=true checkpoint_model="gpt-5.6-luna" rewritten_tool_outputs=2/);
 		assert.match(contents, /failure="authentication" code="invalid_token" status=401/);
 		assert.doesNotMatch(contents, /error=|resp_secret|echoed_prompt|Bearer/);
 		assert.deepEqual(errors, []);
@@ -134,6 +145,7 @@ test("provider diagnostics are authoritative and cannot alter or leak the stream
 			attempt: 1,
 			fullInputItems: 1,
 			sentInputItems: 1,
+			model: "gpt-5.6-luna",
 			socketReused: false,
 			continuation: "no_continuation",
 			previousResponseId: false,


### PR DESCRIPTION
This PR adds bounded diagnostics for native compaction cache misses and transport continuity.

Part of #325.

## Summary

- report replay and transport state when native compaction misses its expected cache lane
- keep provider diagnostics readable without exposing raw payloads
- preserve authoritative stream behavior

## Validation

- cumulative `bun run check:changed`
- cache diagnostics contracts passed

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
