### PR TITLE
Bound Responses V2 retained history

### DIFF
--- a/.changeset/patch-v2-retention-budget-308.md
+++ b/.changeset/patch-v2-retention-budget-308.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep oversized Responses V2 user turns out of the retained compaction window

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-history.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-history.ts
@@ -128,7 +128,7 @@ export function buildRemoteCompactionV2Window(
 	for (let index = retained.length - 1; index >= 0; index--) {
 		const item = retained[index]!;
 		const tokens = Math.max(1, messageTextTokenCount(item));
-		if (tokens <= remaining || reversed.length === 0) {
+		if (tokens <= remaining) {
 			reversed.push(item);
 			remaining = Math.max(0, remaining - tokens);
 		} else break;

--- a/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
+++ b/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
@@ -24,3 +24,13 @@ test("Responses compaction v2 retains real turns and reconciles tool history", (
 	assert.match(JSON.stringify(window), /remember this exactly/);
 	assert.equal(window.at(-1)?.["encrypted_content"], "sealed");
 });
+
+test("Responses compaction v2 does not retain an oversized newest user turn", () => {
+	const compaction = { type: "compaction", encrypted_content: "sealed" };
+	const window = buildRemoteCompactionV2Window([
+		{ role: "user", content: [{ type: "input_text", text: "older turn" }] },
+		{ role: "user", content: [{ type: "input_text", text: "x".repeat(12) }] },
+	], compaction, 2);
+
+	assert.deepEqual(window, [compaction]);
+});


### PR DESCRIPTION
This PR prevents Responses V2 compaction from retaining a newest user turn larger than its retention budget.

Part of #325.

Closes #308.

## Summary

- enforce the retained-history budget even when the newest eligible message is oversized
- preserve the compacted checkpoint while dropping the over-budget retained turn

## Validation

- cumulative `bun run check:changed`
- oversized retained-turn contract passed

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
