### PR TITLE
Recover interrupted notebooks without deleting durable state

### DIFF
--- a/.changeset/patch-notebook-interruption-305.md
+++ b/.changeset/patch-notebook-interruption-305.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Recover interrupted Notebook kernels without deleting durable project bindings

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/cell.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/cell.ts
@@ -21,6 +21,7 @@ export class NotebookCell {
 	private outputChars = 0;
 	private outputTruncated = false;
 	private cursor = 0;
+	private completedValue = false;
 	private yielded = deferred();
 	private readonly completed = deferred();
 
@@ -51,7 +52,12 @@ export class NotebookCell {
 	}
 
 	markCompleted(): void {
+		this.completedValue = true;
 		this.completed.resolve();
+	}
+
+	isCompleted(): boolean {
+		return this.completedValue;
 	}
 
 	waitForCompletion(): Promise<void> {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/client.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/client.ts
@@ -42,6 +42,7 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 			startClean: async (context, signal) => { await session.restart(context, signal, true); },
 			checkpointEmpty: () => session.checkpoints.flush({ force: true, requireIdle: true }),
 			configuredProfileActive: () => session.configuredProfileLoaded(),
+			runtimeHealth: (context) => session.runtimeHealthFor(context),
 		});
 		this.lifecycle = new NotebookLifecycleController({
 			prepare: (context, signal) => this.prepareSession(context, signal),
@@ -70,6 +71,7 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 			baselineNames: () => session.baselineNames(),
 			profileStorage: () => ({ agentDir: options.agentDir, maxBytes: session.checkpointMaxBytes }),
 			metadata: () => session.metadata(),
+			runtimeHealth: () => session.runtimeHealth(),
 		});
 	}
 
@@ -103,7 +105,12 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 		excludeNames?: ReadonlySet<string>,
 		pins?: { names: readonly string[]; pinned: boolean },
 	): Promise<void> {
-		await this.session.checkpoints.flush({ requireIdle: true, force: true, excludeNames, pins });
+		try {
+			await this.session.checkpoints.flush({ requireIdle: true, force: true, excludeNames, pins });
+		} catch (error) {
+			await this.session.recoverFromBootstrapFailure(error);
+			throw error;
+		}
 		try {
 			this.session.materializeJournal();
 		} catch (error) {
@@ -117,7 +124,13 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 		context: ToolExecutionContext,
 		signal?: AbortSignal,
 	): Promise<NotebookControlResult> {
-		const result = await this.lifecycle.control(request, context, signal);
+		let result: NotebookControlResult;
+		try {
+			result = await this.lifecycle.control(request, context, signal);
+		} catch (error) {
+			await this.session.recoverFromBootstrapFailure(error);
+			throw error;
+		}
 		const notice = this.session.takeNotice();
 		return notice
 			? { message: `${notice}\n${result.message}`, details: { ...result.details, startupNotice: notice } }

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/execution-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/execution-runtime.ts
@@ -17,8 +17,10 @@ import type {
 import { NotebookBridgeServer } from "./bridge-server.ts";
 import { NotebookCell } from "./cell.ts";
 import { beginNotebookJournalCell, finishNotebookJournalCell } from "./journal.ts";
+import { NOTEBOOK_INTERRUPTED_NOTICE } from "./runtime-health.ts";
 import type { NotebookSessionRuntime } from "./session-runtime.ts";
 
+const CANCEL_GRACE_MS = 250;
 const TERMINATE_GRACE_MS = 1_500;
 
 export class NotebookExecutionRuntime {
@@ -94,8 +96,10 @@ export class NotebookExecutionRuntime {
 			.map((tool) => ({ name: tool.name, description: formatCodeModeToolHelp(tool) }));
 		const toolNames = Object.fromEntries(tools.map((tool) => [tool.name, resolveCodeModeToolIdentity(tool)]));
 		const wrapped = [
+			`if (typeof globalThis.__piNotebook?.begin !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.begin");`,
 			`await globalThis.__piNotebook.begin(${JSON.stringify(id)}, ${JSON.stringify(metadata)}, ${JSON.stringify(toolNames)});`,
 			code,
+			`if (typeof globalThis.__piNotebook?.flush !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.flush");`,
 			`await globalThis.__piNotebook.flush(${JSON.stringify(id)});`,
 			"undefined;",
 		].join("\n");
@@ -159,16 +163,19 @@ export class NotebookExecutionRuntime {
 		try {
 			const result = await session.kernel()!.execute(source, {
 				signal: cell.controller.signal,
+				interruptOnAbort: false,
 				onOutput: (item) => cell.emit([item]),
 			});
 			const normalized = result.errorName === "PiNotebookExit" && result.errorValue === this.bridge.exitToken
 				? { ...result, status: "ok" as const, errorText: undefined, errorName: undefined, errorValue: undefined }
 				: result;
 			cell.result = normalized;
-			await this.endCellRuntime(cell);
-			if (cell.result.status === "ok") {
-				await session.recordNpmImports(cell.source);
-				session.checkpoints.schedule();
+			if (!(await session.recoverFromBootstrapFailure(normalized))) {
+				await this.endCellRuntime(cell);
+				if (cell.result.status === "ok") {
+					await session.recordNpmImports(cell.source);
+					session.checkpoints.schedule();
+				}
 			}
 		} catch (error) {
 			this.delegate.cancelCell(cell.id);
@@ -200,7 +207,8 @@ export class NotebookExecutionRuntime {
 		const kernel = this.session().kernel();
 		if (!kernel) return;
 		const id = JSON.stringify(cell.id);
-		const result = await kernel.execute(`await globalThis.__piNotebook.finish(${id}); undefined;`);
+		const result = await kernel.execute(`if (typeof globalThis.__piNotebook?.finish !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.finish"); await globalThis.__piNotebook.finish(${id}); undefined;`);
+		await this.session().recoverFromBootstrapFailure(result);
 		if (result.status !== "ok" && cell.result?.status === "ok") {
 			cell.result = { status: "error", items: [], errorText: result.errorText ?? "Notebook helper flush failed" };
 		}
@@ -240,13 +248,18 @@ export class NotebookExecutionRuntime {
 	}
 
 	private async stopCellInner(cell: NotebookCell): Promise<void> {
+		const isolateKernel = !cell.isCompleted();
 		cell.terminated = true;
 		cell.controller.abort();
 		this.delegate.cancelCell(cell.id);
-		await this.session().kernel()?.interrupt().catch(() => undefined);
+		await Promise.race([cell.waitForCompletion(), delay(CANCEL_GRACE_MS)]);
+		if (!cell.isCompleted()) {
+			const kernel = this.session().kernel();
+			try { await kernel?.interrupt(); } catch {}
+		}
+		if (isolateKernel) await this.session().invalidateKernel(NOTEBOOK_INTERRUPTED_NOTICE);
 		await Promise.race([cell.waitForCompletion(), delay(TERMINATE_GRACE_MS)]);
-		if (!cell.result) {
-			await this.session().discardKernel();
+		if (!cell.isCompleted()) {
 			cell.result = { status: "aborted", items: [] };
 			cell.markCompleted();
 		}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/jupyter-kernel.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/jupyter-kernel.ts
@@ -38,6 +38,7 @@ export class DenoJupyterKernel {
 	private readonly deno: string;
 	private readonly env: NodeJS.ProcessEnv;
 	private readonly maxHeapMiB: number;
+	private readonly onFailure: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
 	private readonly session = randomUUID();
 	private process: ChildProcess | undefined;
 	private tempDir: string | undefined;
@@ -51,14 +52,24 @@ export class DenoJupyterKernel {
 	private active: ActiveKernelExecution | undefined;
 	private readonly shellReplies = new Map<string, ShellReplyWaiter>();
 	private stderr = "";
+	private terminalFailure: Error | undefined;
 
-	constructor(options: { deno: string; maxHeapMiB: number; env?: NodeJS.ProcessEnv | undefined }) {
+	constructor(options: {
+		deno: string;
+		maxHeapMiB: number;
+		env?: NodeJS.ProcessEnv | undefined;
+		onFailure?: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
+	}) {
 		this.deno = options.deno;
 		this.env = options.env ?? process.env;
 		this.maxHeapMiB = options.maxHeapMiB;
+		this.onFailure = options.onFailure;
 	}
 
 	async start(signal?: AbortSignal): Promise<void> {
+		if (this.terminalFailure) {
+			throw new Error(`Deno Jupyter kernel is unavailable: ${this.terminalFailure.message}`, { cause: this.terminalFailure });
+		}
 		if (!this.startup) this.startup = this.startInner(signal).catch((error) => {
 			this.startup = undefined;
 			this.dispose();
@@ -69,7 +80,11 @@ export class DenoJupyterKernel {
 
 	async execute(
 		code: string,
-		options: { signal?: AbortSignal | undefined; onOutput?: ((item: RuntimeContentItem) => void) | undefined } = {},
+		options: {
+			signal?: AbortSignal | undefined;
+			onOutput?: ((item: RuntimeContentItem) => void) | undefined;
+			interruptOnAbort?: boolean | undefined;
+		} = {},
 	): Promise<KernelExecutionResult> {
 		await this.start(options.signal);
 		options.signal?.throwIfAborted();
@@ -101,7 +116,7 @@ export class DenoJupyterKernel {
 		let abortTimer: ReturnType<typeof setTimeout> | undefined;
 		let finished = false;
 		const abort = () => {
-			void this.interrupt().catch(() => undefined);
+			if (options.interruptOnAbort !== false) void this.interrupt().catch(() => undefined);
 			abortTimer = setTimeout(() => {
 				if (!finished) {
 					this.failKernel(options.signal?.reason instanceof Error
@@ -144,7 +159,11 @@ export class DenoJupyterKernel {
 				throw new Error(`Deno Jupyter returned ${reply.header.msg_type} for execute_request`);
 			}
 			const replied = applyExecuteReplyError(result, reply);
-			return options.signal?.aborted ? { ...replied, status: "aborted" } : replied;
+			if (options.signal?.aborted) {
+				if (options.interruptOnAbort !== false) this.failKernel(new Error("Deno Jupyter execution was aborted"));
+				return { ...replied, status: "aborted" };
+			}
+			return replied;
 		} catch (error) {
 			if (this.active === execution) this.active = undefined;
 			throw error;
@@ -380,6 +399,10 @@ export class DenoJupyterKernel {
 	}
 
 	private failKernel(error: Error): void {
+		if (!this.terminalFailure) {
+			this.terminalFailure = error;
+			this.onFailure?.(this, error);
+		}
 		const active = this.active;
 		this.active = undefined;
 		active?.reject(error);

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
@@ -28,6 +28,7 @@ import {
 	type NotebookReleaseResult,
 } from "./lifecycle-runtime.ts";
 import { NotebookProfileController } from "./profile-lifecycle.ts";
+import type { NotebookRuntimeHealth } from "./runtime-health.ts";
 
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 const STATUS_TIMEOUT_MS = 8_000;
@@ -47,6 +48,7 @@ interface NotebookLifecycleHost {
 	rollback(context: ExtensionContext): Promise<void>;
 	baselineNames(): ReadonlySet<string>;
 	profileStorage(): { agentDir: string; maxBytes: number };
+	runtimeHealth(): NotebookRuntimeHealth;
 	metadata(): {
 		startedAt?: number | undefined;
 		userCells: number;
@@ -72,6 +74,7 @@ export class NotebookLifecycleController {
 		if (request.action === "list") return this.profiles.list(request.query);
 		if (request.action === "diagnostics") return this.host.diagnostics(context, signal);
 		if (request.action === "reset") return this.host.reset(context, signal);
+		if (request.action === "restart" && this.host.runtimeHealth().state !== "ready") return this.restart(context, signal);
 		await this.host.prepare(context, signal);
 		switch (request.action) {
 			case "status": return this.status(request.query, signal);
@@ -264,7 +267,15 @@ export class NotebookLifecycleController {
 
 	private async restart(context: ToolExecutionContext, signal?: AbortSignal): Promise<NotebookControlResult> {
 		const activeCell = await this.host.stopActive();
-		if (!activeCell) await this.host.checkpoint();
+		let checkpointNotice: string | undefined;
+		if (!activeCell && this.host.runtimeHealth().state === "ready") {
+			try {
+				await this.host.checkpoint();
+			} catch (error) {
+				if (this.host.runtimeHealth().state !== "invalidated") throw error;
+				checkpointNotice = `Checkpoint skipped after runtime invalidation: ${error instanceof Error ? error.message : String(error)}`;
+			}
+		}
 		const disposal = await this.disposeAll(signal).catch((error) => ({
 			released: [],
 			disposed: [],
@@ -283,6 +294,7 @@ export class NotebookLifecycleController {
 			message: [
 				`Notebook kernel restarted from the last completed checkpoint${activeCell ? `; terminated ${activeCell}` : ""}`,
 				disposal && disposal.failures.length > 0 ? `${disposal.failures.length} resource cleanup failure${disposal.failures.length === 1 ? "" : "s"}; restart continued` : undefined,
+				checkpointNotice,
 				restoreNotice,
 			].filter(Boolean).join(". "),
 			details,

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/notebook-diagnostics.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/notebook-diagnostics.ts
@@ -2,9 +2,13 @@ import { pathToFileURL } from "node:url";
 import type { NotebookControlResult } from "../code-mode/types.ts";
 import { readNotebookJournalCodeCells } from "./journal.ts";
 import { OneShotLspProcess } from "./lsp-process.ts";
+import type { NotebookRuntimeHealthState } from "./runtime-health.ts";
 
 const DIAGNOSTIC_TIMEOUT_MS = 30_000;
 const MESSAGE_BUDGET = 16 * 1024;
+const DETAILS_BUDGET = 16 * 1024;
+const MAX_DIAGNOSTIC_TEXT_BYTES = 2 * 1024;
+const MAX_DIAGNOSTIC_SAMPLES = 3;
 const HOST_BINDINGS = new Set([
 	"ALL_TOOLS",
 	"exit",
@@ -18,7 +22,7 @@ const HOST_BINDINGS = new Set([
 	"yield_control",
 ]);
 
-interface NotebookDiagnostic {
+export interface NotebookDiagnostic {
 	cellId: string;
 	cellIndex: number;
 	line: number;
@@ -28,7 +32,18 @@ interface NotebookDiagnostic {
 	severity: "error" | "warning" | "information" | "hint" | "unknown";
 	code?: string | number | undefined;
 	source?: string | undefined;
+	name?: string | undefined;
 	message: string;
+}
+
+export interface NotebookDiagnosticGroup {
+	count: number;
+	severity: NotebookDiagnostic["severity"];
+	code?: string | number | undefined;
+	source?: string | undefined;
+	name?: string | undefined;
+	message: string;
+	samples: Array<Pick<NotebookDiagnostic, "cellId" | "cellIndex" | "line" | "column" | "endLine" | "endColumn">>;
 }
 
 export async function diagnoseNotebook(options: {
@@ -36,20 +51,27 @@ export async function diagnoseNotebook(options: {
 	cwd: string;
 	path: string;
 	runtimeBindings?: ReadonlySet<string> | undefined;
+	runtimeHealth?: NotebookRuntimeHealthState | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<NotebookControlResult> {
+	const runtimeHealth = options.runtimeHealth ?? "not_started";
+	const healthMessage = formatRuntimeHealth(runtimeHealth);
+	const path = boundText(options.path);
 	let cells;
 	try {
 		cells = readNotebookJournalCodeCells(options.path);
 	} catch (error) {
-		const reason = error instanceof Error ? error.message : String(error);
-		return {
-			message: `Notebook diagnostics could not read ${options.path}: ${reason}`,
-			details: { path: options.path, error: reason },
-		};
+		const reason = boundText(error instanceof Error ? error.message : String(error));
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNotebook diagnostics could not read ${path}: ${reason}`,
+			{ path, runtime: { state: runtimeHealth }, error: reason },
+		);
 	}
 	if (cells.length === 0) {
-		return { message: `No code cells to diagnose in ${options.path}`, details: { path: options.path, cells: 0, diagnostics: [] } };
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNo historical static code cells to diagnose in ${path}`,
+			{ path, cells: 0, runtime: { state: runtimeHealth }, diagnosticGroups: [] },
+		);
 	}
 
 	const timeout = AbortSignal.timeout(DIAGNOSTIC_TIMEOUT_MS);
@@ -101,7 +123,16 @@ export async function diagnoseNotebook(options: {
 			notebookDocument: { uri: notebookUri },
 			cellTextDocuments: documents.map(({ uri }) => ({ uri })),
 		});
-		return formatDiagnostics(options.path, cells.length, diagnostics);
+		return formatNotebookDiagnostics(options.path, cells.length, diagnostics, runtimeHealth);
+	} catch (error) {
+		if (options.signal?.aborted) throw error;
+		const reason = boundText(timeout.aborted
+			? `Deno diagnostics timed out after ${DIAGNOSTIC_TIMEOUT_MS}ms`
+			: error instanceof Error ? error.message : String(error));
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNotebook diagnostics could not complete: ${reason}`,
+			{ path, cells: cells.length, runtime: { state: runtimeHealth }, error: reason },
+		);
 	} finally {
 		await lsp.shutdown();
 	}
@@ -117,6 +148,7 @@ function parseDiagnosticReport(
 		if (!isRecord(item) || typeof item["message"] !== "string" || !isRange(item["range"])) return [];
 		const range = item["range"];
 		if (isRuntimeDiagnostic(item, range, cell.source, runtimeBindings)) return [];
+		const message = boundText(item["message"]);
 		return [{
 			cellId: cell.id,
 			cellIndex: cell.index,
@@ -127,7 +159,8 @@ function parseDiagnosticReport(
 			severity: severityName(item["severity"]),
 			...(typeof item["code"] === "string" || typeof item["code"] === "number" ? { code: item["code"] } : {}),
 			...(typeof item["source"] === "string" ? { source: item["source"] } : {}),
-			message: item["message"],
+			...(diagnosticName(message) ? { name: diagnosticName(message) } : {}),
+			message,
 		}];
 	});
 }
@@ -147,25 +180,127 @@ function isRuntimeDiagnostic(
 	return line !== undefined && /globalThis\s*\.\s*$/.test(line.slice(0, range.start.character));
 }
 
-function formatDiagnostics(path: string, cells: number, diagnostics: NotebookDiagnostic[]): NotebookControlResult {
-	if (diagnostics.length === 0) {
-		return { message: `No Deno diagnostics in ${path} (${cells} code cells)`, details: { path, cells, diagnostics: [] } };
-	}
-	const lines = [`Deno diagnostics for ${path}:`];
-	const included: NotebookDiagnostic[] = [];
-	for (const diagnostic of diagnostics) {
-		const code = diagnostic.code === undefined ? "" : ` ${diagnostic.source ?? "deno"}-${diagnostic.code}`;
-		const line = `- ${diagnostic.cellId} cell ${diagnostic.cellIndex + 1}:${diagnostic.line}:${diagnostic.column} ${diagnostic.severity}${code}: ${diagnostic.message.replaceAll("\n", " ")}`;
-		if (lines.join("\n").length + line.length + 1 > MESSAGE_BUDGET) break;
+export function formatNotebookDiagnostics(path: string, cells: number, diagnostics: NotebookDiagnostic[], runtimeHealth: NotebookRuntimeHealthState = "not_started"): NotebookControlResult {
+	const groups = groupDiagnostics(diagnostics);
+	const reportedPath = boundText(path);
+	const lines = [formatRuntimeHealth(runtimeHealth), `Historical static diagnostics for ${reportedPath} (${cells} code cells):`];
+	const included: NotebookDiagnosticGroup[] = [];
+	for (const group of groups) {
+		const line = formatDiagnosticGroup(group);
+		const candidate = [...included, group];
+		const candidateDetails = diagnosticDetails(reportedPath, cells, runtimeHealth, diagnostics.length, candidate, groups.length - candidate.length);
+		if (Buffer.byteLength(JSON.stringify(candidateDetails), "utf8") > DETAILS_BUDGET) break;
+		if (Buffer.byteLength(`${lines.join("\n")}\n${line}`, "utf8") + 64 > MESSAGE_BUDGET) break;
 		lines.push(line);
-		included.push(diagnostic);
+		included.push(group);
 	}
-	const omitted = diagnostics.length - included.length;
-	if (omitted > 0) lines.push(`${omitted} additional diagnostic${omitted === 1 ? "" : "s"} omitted; repair these and run diagnostics again`);
+	const omittedGroups = groups.length - included.length;
+	if (groups.length === 0) lines.push("No historical static Deno diagnostics");
+	if (omittedGroups > 0) lines.push(`${omittedGroups} additional historical diagnostic group${omittedGroups === 1 ? "" : "s"} omitted by the output bound`);
+	return boundedDiagnosticResult(
+		lines.join("\n"),
+		diagnosticDetails(reportedPath, cells, runtimeHealth, diagnostics.length, included, omittedGroups),
+	);
+}
+
+function diagnosticDetails(
+	path: string,
+	cells: number,
+	runtimeHealth: NotebookRuntimeHealthState,
+	diagnosticCount: number,
+	diagnosticGroups: NotebookDiagnosticGroup[],
+	omittedGroups: number,
+): Record<string, unknown> {
+	return { path, cells, runtime: { state: runtimeHealth }, diagnosticCount, diagnosticGroups, omittedGroups };
+}
+
+function groupDiagnostics(diagnostics: NotebookDiagnostic[]): NotebookDiagnosticGroup[] {
+	const groups = new Map<string, NotebookDiagnosticGroup>();
+	for (const diagnostic of diagnostics) {
+		const key = JSON.stringify([
+			diagnostic.code ?? null,
+			diagnostic.message,
+			diagnostic.name ?? null,
+			diagnostic.severity,
+			diagnostic.source ?? null,
+		]);
+		let group = groups.get(key);
+		if (!group) {
+			group = {
+				count: 0,
+				severity: diagnostic.severity,
+				...(diagnostic.code === undefined ? {} : { code: diagnostic.code }),
+				...(diagnostic.source === undefined ? {} : { source: diagnostic.source }),
+				...(diagnostic.name === undefined ? {} : { name: diagnostic.name }),
+				message: diagnostic.message,
+				samples: [],
+			};
+			groups.set(key, group);
+		}
+		group.count += 1;
+		if (group.samples.length < MAX_DIAGNOSTIC_SAMPLES) group.samples.push({
+			cellId: diagnostic.cellId,
+			cellIndex: diagnostic.cellIndex,
+			line: diagnostic.line,
+			column: diagnostic.column,
+			endLine: diagnostic.endLine,
+			endColumn: diagnostic.endColumn,
+		});
+	}
+	return [...groups.values()];
+}
+
+function formatDiagnosticGroup(group: NotebookDiagnosticGroup): string {
+	const code = group.code === undefined ? "" : ` ${group.source ?? "deno"}-${group.code}`;
+	const name = group.name ? ` [${group.name}]` : "";
+	const samples = group.samples.map((sample) => `${sample.cellId} cell ${sample.cellIndex + 1}:${sample.line}:${sample.column}`).join(", ");
+	return `- ${group.count} occurrence${group.count === 1 ? "" : "s"} ${group.severity}${code}${name}: ${group.message.replaceAll("\n", " ")}; samples: ${samples}`;
+}
+
+function formatRuntimeHealth(state: NotebookRuntimeHealthState): string {
+	switch (state) {
+		case "ready": return "Notebook runtime health: ready; bootstrap is available";
+		case "invalidated": return "Notebook runtime health: invalidated; exec or restart will recreate it from the last completed checkpoint. Durable project bindings are preserved; external side effects were not rolled back";
+		case "not_started": return "Notebook runtime health: not started; exec or restart will create it from the last completed checkpoint";
+	}
+}
+
+function diagnosticName(message: string): string | undefined {
+	return /(?:Cannot redeclare block-scoped variable|Duplicate identifier) ['"]([^'"]+)['"]/.exec(message)?.[1];
+}
+
+function boundText(value: string): string {
+	return boundUtf8(value, MAX_DIAGNOSTIC_TEXT_BYTES, " [diagnostic text truncated]");
+}
+
+function boundedDiagnosticResult(message: string, details: Record<string, unknown>): NotebookControlResult {
+	const boundedMessage = boundUtf8(message, MESSAGE_BUDGET, "\n[diagnostics output truncated]");
+	if (Buffer.byteLength(JSON.stringify(details), "utf8") <= DETAILS_BUDGET) {
+		return { message: boundedMessage, details };
+	}
 	return {
-		message: lines.join("\n"),
-		details: { path, cells, diagnostics: included, omitted },
+		message: boundedMessage,
+		details: {
+			...(isRecord(details["runtime"]) ? { runtime: details["runtime"] } : {}),
+			detailsOmitted: true,
+		},
 	};
+}
+
+function boundUtf8(value: string, maxBytes: number, suffix: string): string {
+	if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+	const available = Math.max(0, maxBytes - Buffer.byteLength(suffix, "utf8"));
+	let low = 0;
+	let high = value.length;
+	while (low < high) {
+		const middle = Math.ceil((low + high) / 2);
+		if (Buffer.byteLength(value.slice(0, middle), "utf8") <= available) low = middle;
+		else high = middle - 1;
+	}
+	let prefix = value.slice(0, low);
+	const last = prefix.charCodeAt(prefix.length - 1);
+	if (last >= 0xd800 && last <= 0xdbff) prefix = prefix.slice(0, -1);
+	return `${prefix}${suffix}`;
 }
 
 function notebookCellUri(path: string, index: number, id: string): string {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/npm-imports.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/npm-imports.ts
@@ -55,12 +55,6 @@ export async function recordNotebookNpmImports(
 	return readNotebookNpmImports(identity);
 }
 
-export async function resetNotebookNpmImports(identity: { project: string; agentDir: string }): Promise<void> {
-	const paths = npmImportPaths(identity);
-	mkdirSync(paths.directory, { recursive: true });
-	await withProjectStateLock(paths.lock, async () => { rmSync(paths.manifest, { force: true }); });
-}
-
 export function formatNotebookNpmImportsNotice(imports: string[]): string {
 	const prefix = `Available npm imports previously established in this project: ${imports.length === 0 ? "none" : boundedImportList(imports)}`;
 	return `${prefix}. All npm packages are unsafe by default; ask the user before first use of any unlisted package and use an exact-version npm: specifier`;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
@@ -8,7 +8,7 @@ import type { KernelExecutionResult } from "./jupyter-kernel.ts";
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 export function projectBindingNamesSource(marker: string): string {
-	return `console.log(${JSON.stringify(marker)} + JSON.stringify(globalThis.__piNotebook.projectBindings())); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.projectBindings !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.projectBindings"); console.log(${JSON.stringify(marker)} + JSON.stringify(globalThis.__piNotebook.projectBindings())); undefined;`;
 }
 
 export function parseProjectBindingNames(result: KernelExecutionResult, marker: string): string[] {
@@ -28,11 +28,11 @@ export function parseProjectBindingNames(result: KernelExecutionResult, marker: 
 }
 
 export function promoteProjectBindingsSource(names: string[]): string {
-	return `globalThis.__piNotebook.promote(${JSON.stringify(names)}); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.promote !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.promote"); globalThis.__piNotebook.promote(${JSON.stringify(names)}); undefined;`;
 }
 
 export function syncProjectBindingsSource(names: string[]): string {
-	return `globalThis.__piNotebook.syncProjectBindings(${JSON.stringify(names)}); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.syncProjectBindings !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.syncProjectBindings"); globalThis.__piNotebook.syncProjectBindings(${JSON.stringify(names)}); undefined;`;
 }
 
 export function projectStateCaptureSource(options: {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state.ts
@@ -52,44 +52,6 @@ export async function restoreProjectState(
 	return withProjectStateLock(paths.lock, () => restoreProjectStateLocked(kernel, identity, paths), identity.signal);
 }
 
-export async function resetProjectState(identity: {
-	project: string;
-	session: string;
-	agentDir: string;
-}): Promise<{ previousBindings: number; generation: string }> {
-	const paths = projectStatePaths(identity.project, identity.agentDir);
-	mkdirSync(paths.directory, { recursive: true });
-	return withProjectStateLock(paths.lock, async () => {
-		const current = readProjectStateManifest(paths.manifest);
-		if (!current) {
-			rmSync(paths.manifest, { force: true });
-			removeProjectArtifacts(paths.directory);
-			return { previousBindings: 0, generation: "root" };
-		}
-		const generation = randomUUID();
-		const payload = `project-${generation}.bin`;
-		const manifest: ProjectStateManifest = {
-			schema: PROJECT_STATE_SCHEMA,
-			project: resolve(identity.project),
-			generation,
-			parentGeneration: current.generation,
-			deno: current.deno,
-			v8: current.v8,
-			payload,
-			createdAt: new Date().toISOString(),
-			sourceSession: identity.session,
-			entries: [],
-			skipped: [],
-		};
-		writeFileSync(join(paths.directory, payload), Buffer.alloc(0), { mode: 0o600 });
-		const temporary = `${paths.manifest}.${randomUUID()}.tmp`;
-		writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
-		renameSync(temporary, paths.manifest);
-		removeProjectArtifacts(paths.directory, new Set([payload]));
-		return { previousBindings: current.entries.length, generation };
-	});
-}
-
 export function projectStateBindingNames(identity: { project: string; agentDir: string }, maxBytes: number): string[] {
 	const paths = projectStatePaths(identity.project, identity.agentDir);
 	const manifest = readProjectStateManifest(paths.manifest);
@@ -306,18 +268,6 @@ function writeMergedProjectState(
 		try { rmSync(join(paths.directory, current.payload), { force: true }); } catch {}
 	}
 	return manifest;
-}
-
-function removeProjectArtifacts(directory: string, keep = new Set<string>()): void {
-	for (const name of readDirectoryNames(directory)) {
-		if (keep.has(name) || name === "project.json" || name === "write.lock") continue;
-		if (
-			name === "conflicts"
-			|| /^project-[0-9a-f-]+\.bin$/.test(name)
-			|| /^candidate-[0-9a-f-]+\.(?:bin|json)$/.test(name)
-			|| name.endsWith(".tmp")
-		) rmSync(join(directory, name), { recursive: true, force: true });
-	}
 }
 
 function writeProjectConflict(

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/recovery.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/recovery.ts
@@ -7,11 +7,12 @@ import {
 } from "./checkpoint.ts";
 import { ensureNotebookDenoBinary } from "./deno-binary.ts";
 import { initializeNotebookJournal } from "./journal.ts";
-import { resetNotebookNpmImports } from "./npm-imports.ts";
 import { diagnoseNotebook } from "./notebook-diagnostics.ts";
 import { resolveNotebookProject } from "./project-identity.ts";
 import { notebookProfileBindingNames } from "./profile-state.ts";
-import { projectStateBindingNames, resetProjectState } from "./project-state.ts";
+import { projectStateBindingNames } from "./project-state.ts";
+import { readRetainedProjectBindings } from "./project-state-metadata.ts";
+import type { NotebookRuntimeHealth } from "./runtime-health.ts";
 import { notebookSessionIdentity } from "./session-identity.ts";
 
 interface NotebookRecoveryHost {
@@ -19,6 +20,7 @@ interface NotebookRecoveryHost {
 	startClean(context: ExtensionContext, signal?: AbortSignal): Promise<void>;
 	checkpointEmpty(): Promise<void>;
 	configuredProfileActive(): boolean;
+	runtimeHealth(context: ExtensionContext): NotebookRuntimeHealth;
 }
 
 export class NotebookRecoveryController {
@@ -48,25 +50,26 @@ export class NotebookRecoveryController {
 				? notebookProfileBindingNames(this.profile, this.agentDir, this.maxBytes)
 				: []),
 		]);
-		return diagnoseNotebook({ deno, cwd: identity.project, path: journal.path, runtimeBindings, signal });
+		return diagnoseNotebook({ deno, cwd: identity.project, path: journal.path, runtimeBindings, runtimeHealth: this.host.runtimeHealth(requireExtensionContext(context, "diagnostics")).state, signal });
 	}
 
 	async reset(context: ToolExecutionContext, signal?: AbortSignal): Promise<NotebookControlResult> {
 		signal?.throwIfAborted();
 		const extension = requireExtensionContext(context, "reset");
 		const identity = notebookIdentity(extension, this.agentDir);
+		const retained = readRetainedProjectBindings(identity, this.maxBytes);
+		const pinned = retained.filter(({ pinned: isPinned }) => isPinned).length;
 		const activeCell = await this.host.stopWithoutCheckpoint();
-		const projectReset = await resetProjectState(identity);
-		await resetNotebookNpmImports(identity);
 		removeNotebookCheckpoint(identity);
 		await this.host.startClean(extension, signal);
 		await this.host.checkpointEmpty();
 		return {
-			message: `Notebook reset to empty state; discarded ${projectReset.previousBindings} project binding${projectReset.previousBindings === 1 ? "" : "s"}${activeCell ? ` and terminated ${activeCell}` : ""}. Saved notebook and named profiles were preserved; use exec to establish repaired state`,
+			message: `Notebook reset to durable project state; preserved ${retained.length} project binding${retained.length === 1 ? "" : "s"}${pinned > 0 ? ` including ${pinned} pinned` : ""}${activeCell ? ` and terminated ${activeCell}` : ""}. The session checkpoint was discarded; saved notebook and named profiles were preserved`,
 			details: {
 				project: identity.project,
-				projectGeneration: projectReset.generation,
-				discardedProjectBindings: projectReset.previousBindings,
+				preservedProjectBindings: retained.length,
+				preservedPinnedBindings: pinned,
+				discardedSessionCheckpoint: true,
 				...(activeCell ? { terminatedCell: activeCell } : {}),
 			},
 		};

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/runtime-health.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/runtime-health.ts
@@ -1,0 +1,35 @@
+export type NotebookRuntimeHealthState = "not_started" | "ready" | "invalidated";
+
+export interface NotebookRuntimeHealth {
+	state: NotebookRuntimeHealthState;
+}
+
+export const NOTEBOOK_INTERRUPTED_NOTICE =
+	"Notebook runtime was invalidated by an interrupted cell. The next operation will recreate it from the last completed checkpoint; durable project bindings were preserved. External side effects were not rolled back";
+
+export const NOTEBOOK_BOOTSTRAP_NOTICE =
+	"Notebook runtime bootstrap was unavailable. The kernel was discarded; the next operation will recreate it from the last completed checkpoint. Durable project bindings were preserved";
+
+export const NOTEBOOK_KERNEL_FAILURE_NOTICE =
+	"Notebook runtime became unavailable during a host operation. The next operation will recreate it from the last completed checkpoint; durable project bindings were preserved. External side effects were not rolled back";
+
+export function isNotebookBootstrapFailure(value: unknown): boolean {
+	const text = errorText(value);
+	return text.includes("Notebook runtime bootstrap unavailable: __piNotebook.");
+}
+
+function errorText(value: unknown, depth = 0): string {
+	if (depth > 2) return "";
+	if (typeof value === "string") return value;
+	if (value instanceof Error) return [value.message, errorText(value.cause, depth + 1)].filter(Boolean).join(" ");
+	if (value && typeof value === "object") {
+		const result = value as Record<string, unknown>;
+		return [
+			typeof result["errorText"] === "string" ? result["errorText"] : undefined,
+			typeof result["errorName"] === "string" ? result["errorName"] : undefined,
+			typeof result["errorValue"] === "string" ? result["errorValue"] : undefined,
+			errorText(result["cause"], depth + 1),
+		].filter(Boolean).join(" ");
+	}
+	return "";
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-runtime.ts
@@ -10,6 +10,14 @@ import type { DenoJupyterKernel } from "./jupyter-kernel.ts";
 import { extractNotebookNpmImports, recordNotebookNpmImports } from "./npm-imports.ts";
 import { resolveNotebookProject } from "./project-identity.ts";
 import { readRetainedProjectBindings, type RetainedProjectBinding } from "./project-state-metadata.ts";
+import {
+	NOTEBOOK_INTERRUPTED_NOTICE,
+	NOTEBOOK_BOOTSTRAP_NOTICE,
+	isNotebookBootstrapFailure,
+	NOTEBOOK_KERNEL_FAILURE_NOTICE,
+	type NotebookRuntimeHealth,
+	type NotebookRuntimeHealthState,
+} from "./runtime-health.ts";
 import { startNotebookSession } from "./session-startup.ts";
 import { notebookSessionIdentity } from "./session-identity.ts";
 
@@ -22,6 +30,7 @@ export class NotebookSessionRuntime {
 	private readonly bridge: NotebookBridgeServer;
 	private readonly runningCellId: () => string | undefined;
 	private kernelValue: DenoJupyterKernel | undefined;
+	private runtimeHealthValue: NotebookRuntimeHealthState = "not_started";
 	private identityValue: string | undefined;
 	private checkpointIdentityValue: NotebookCheckpointIdentity | undefined;
 	private startup: Promise<void> | undefined;
@@ -74,6 +83,7 @@ export class NotebookSessionRuntime {
 		try { this.materializeJournal(); } catch {}
 		const previous = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		await this.checkpoints.discard();
 		this.memoryValue = undefined;
@@ -86,15 +96,23 @@ export class NotebookSessionRuntime {
 		return this.takeNotice();
 	}
 
-	async discardKernel(): Promise<void> {
+	async invalidateKernel(notice = NOTEBOOK_INTERRUPTED_NOTICE): Promise<void> {
 		const kernel = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "invalidated";
 		this.startup = undefined;
 		this.memoryValue = undefined;
 		this.startedAtValue = undefined;
 		this.profileLoaded = false;
 		this.checkpointIdentityValue = undefined;
+		this.addNotice(notice);
 		await kernel?.shutdown().catch(() => undefined);
+	}
+
+	async recoverFromBootstrapFailure(value: unknown): Promise<boolean> {
+		if (!isNotebookBootstrapFailure(value)) return false;
+		if (this.kernelValue) await this.invalidateKernel(NOTEBOOK_BOOTSTRAP_NOTICE);
+		return true;
 	}
 
 	async stopWithoutCheckpoint(): Promise<void> {
@@ -102,6 +120,7 @@ export class NotebookSessionRuntime {
 		await this.startup?.catch(() => undefined);
 		const previous = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		await this.checkpoints.discard();
 		this.memoryValue = undefined;
@@ -122,6 +141,7 @@ export class NotebookSessionRuntime {
 		try { this.materializeJournal(); } catch {}
 		const kernel = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		this.startupAbort = undefined;
 		this.identityValue = undefined;
@@ -139,6 +159,10 @@ export class NotebookSessionRuntime {
 	}
 
 	kernel(): DenoJupyterKernel | undefined { return this.kernelValue; }
+	runtimeHealth(): NotebookRuntimeHealth { return { state: this.runtimeHealthValue }; }
+	runtimeHealthFor(context: ExtensionContext): NotebookRuntimeHealth {
+		return this.identityMatches(context) ? this.runtimeHealth() : { state: "not_started" };
+	}
 	journal(): NotebookJournal | undefined { return this.journalValue; }
 	materializeJournal(): void {
 		if (this.journalValue) materializeNotebookJournal(this.journalValue);
@@ -195,6 +219,7 @@ export class NotebookSessionRuntime {
 				: this.options,
 			bridge: this.bridge,
 			checkpointMaxBytes: this.checkpointMaxBytes,
+			onKernelFailure: (kernel) => this.handleKernelFailure(kernel),
 			...(signal ? { signal } : {}),
 		});
 		this.kernelValue = started.kernel;
@@ -203,10 +228,23 @@ export class NotebookSessionRuntime {
 		this.checkpointIdentityValue = started.checkpointIdentity;
 		this.baseline = started.baselineNames;
 		this.profileLoaded = started.configuredProfileLoaded;
+		this.runtimeHealthValue = "ready";
 		this.checkpoints.configure(started.checkpointIdentity, started.baselineNames, started.projectBaseline);
 		if (started.restoreNotice) {
 			this.addNotice(started.restoreNotice);
 		}
+	}
+
+	private handleKernelFailure(kernel: DenoJupyterKernel): void {
+		if (this.kernelValue !== kernel) return;
+		this.kernelValue = undefined;
+		this.runtimeHealthValue = "invalidated";
+		this.startup = undefined;
+		this.memoryValue = undefined;
+		this.startedAtValue = undefined;
+		this.profileLoaded = false;
+		this.checkpointIdentityValue = undefined;
+		this.addNotice(NOTEBOOK_KERNEL_FAILURE_NOTICE);
 	}
 
 	private beginStartup(context: ExtensionContext, signal?: AbortSignal, skipProfile = false): Promise<void> {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -35,6 +35,7 @@ export async function startNotebookSession(options: {
 	runtime: NotebookRuntimeOptions;
 	bridge: NotebookBridgeServer;
 	checkpointMaxBytes: number;
+	onKernelFailure?: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<StartedNotebookSession> {
 	const { context, runtime, bridge, signal } = options;
@@ -54,7 +55,7 @@ export async function startNotebookSession(options: {
 		throw error;
 	}
 
-	const kernel = new DenoJupyterKernel({ deno, maxHeapMiB: runtime.maxHeapMiB });
+	const kernel = new DenoJupyterKernel({ deno, maxHeapMiB: runtime.maxHeapMiB, onFailure: options.onKernelFailure });
 	try {
 		await kernel.start(signal);
 		const bootstrap = await kernel.execute(notebookBootstrapSource(origin, bridge.token, bridge.exitToken, context.cwd), { signal });

--- a/packages/pi-codex-conversion/tests/notebook-recovery.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-recovery.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { NotebookExecutionRuntime } from "../src/tools/notebook-mode/execution-runtime.ts";
+import { NotebookLifecycleController } from "../src/tools/notebook-mode/lifecycle.ts";
+import { formatNotebookDiagnostics, type NotebookDiagnostic } from "../src/tools/notebook-mode/notebook-diagnostics.ts";
+import { NotebookRecoveryController } from "../src/tools/notebook-mode/recovery.ts";
+import { PROJECT_STATE_SCHEMA, projectStatePaths, readProjectStateManifest, type ProjectStateManifest } from "../src/tools/notebook-mode/project-state-format.ts";
+import { isNotebookBootstrapFailure } from "../src/tools/notebook-mode/runtime-health.ts";
+
+test("notebook diagnostics group historical duplicates and put runtime health first", () => {
+	const diagnostics: NotebookDiagnostic[] = [diagnostic("cell-1", 0), diagnostic("cell-2", 1), diagnostic("cell-3", 2, "other"), diagnostic("cell-4", 3, "r", "error", "ts")];
+	const result = formatNotebookDiagnostics("/project/notebook.ipynb", 4, diagnostics, "invalidated");
+	assert.match(result.message, /^Notebook runtime health: invalidated;/);
+	assert.match(result.message, /Historical static diagnostics/);
+	assert.match(result.message, /2 occurrences warning deno-2451 \[r\]/);
+	assert.match(result.message, /samples: cell-1 cell 1:1:1, cell-2 cell 2:2:1/);
+	assert.doesNotMatch(result.message, /repair these/);
+	assert.deepEqual((result.details as { diagnosticGroups: Array<{ count: number; name?: string; severity: string; source?: string }> }).diagnosticGroups.map(({ count, name, severity, source }) => ({ count, name, severity, source })), [
+		{ count: 2, name: "r", severity: "warning", source: "deno" },
+		{ count: 1, name: "other", severity: "warning", source: "deno" },
+		{ count: 1, name: "r", severity: "error", source: "ts" },
+	]);
+	const bounded = formatNotebookDiagnostics(
+		`/${"é".repeat(12_000)}`,
+		2_000,
+		Array.from({ length: 2_000 }, (_, index) => diagnostic(`cell-${index}`, index, `name-${index}`)),
+		"ready",
+	);
+	assert.ok(Buffer.byteLength(bounded.message, "utf8") <= 16 * 1024);
+	assert.ok(Buffer.byteLength(JSON.stringify(bounded.details), "utf8") <= 16 * 1024);
+});
+
+test("notebook reset preserves the durable project manifest and pins", async () => {
+	const root = join(tmpdir(), `pi-notebook-reset-${process.pid}-${Date.now()}`);
+	const project = join(root, "project");
+	const agentDir = join(root, "agent");
+	const payload = Buffer.from("durable");
+	const paths = projectStatePaths(project, agentDir);
+	const manifest: ProjectStateManifest = {
+		schema: PROJECT_STATE_SCHEMA,
+		project,
+		generation: "generation-1",
+		deno: "2.9.5",
+		v8: "test",
+		payload: "project-00000000-0000-0000-0000-000000000001.bin",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		sourceSession: "session",
+		entries: [{ name: "prReview", kind: "value", offset: 0, length: payload.length, hash: hash(payload), pinned: true }],
+		skipped: [],
+	};
+	mkdirSync(paths.directory, { recursive: true });
+	writeFileSync(join(paths.directory, manifest.payload), payload);
+	writeFileSync(paths.manifest, `${JSON.stringify(manifest)}\n`);
+	writeFileSync(join(paths.directory, "npm-imports.json"), `${JSON.stringify({ schema: 1, project, imports: ["npm:example@1.2.3"] })}\n`);
+	const extensionContext = { cwd: project, sessionManager: { getSessionId: () => "session-id", getBranch: () => [] } };
+	const events: string[] = [];
+	const controller = new NotebookRecoveryController({ agentDir, maxBytes: 8 * 1024 * 1024 }, {
+		stopWithoutCheckpoint: async () => { events.push("stop"); return undefined; },
+		startClean: async () => { events.push("start"); },
+		checkpointEmpty: async () => { events.push("checkpoint"); },
+		configuredProfileActive: () => false,
+		runtimeHealth: () => ({ state: "ready" }),
+	});
+	try {
+		const result = await controller.reset({ cwd: project, extensionContext } as never);
+		const restored = readProjectStateManifest(paths.manifest);
+		assert.equal(restored?.entries[0]?.name, "prReview");
+		assert.equal(restored?.entries[0]?.pinned, true);
+		assert.deepEqual(JSON.parse(readFileSync(join(paths.directory, "npm-imports.json"), "utf8")).imports, ["npm:example@1.2.3"]);
+		assert.deepEqual(events, ["stop", "start", "checkpoint"]);
+		assert.match(result.message, /preserved 1 project binding including 1 pinned/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("terminating a notebook cell invalidates its kernel before another cell can use it", async () => {
+	assert.equal(isNotebookBootstrapFailure({ errorText: "TypeError: Cannot read properties of undefined (reading 'begin')" }), false);
+	assert.equal(isNotebookBootstrapFailure({ errorText: "Notebook runtime bootstrap unavailable: __piNotebook.begin" }), true);
+	type FakeResult = { status: "ok" | "aborted"; items: [] };
+	let kernel: { execute(): Promise<FakeResult>; interrupt(): Promise<void> } | undefined;
+	let interrupts = 0;
+	let executeCalls = 0;
+	let finish!: (result: FakeResult) => void;
+	const pending = new Promise<FakeResult>((resolve) => { finish = resolve; });
+	kernel = {
+		execute: () => {
+			executeCalls += 1;
+			return executeCalls === 1
+				? new Promise((resolve) => setTimeout(() => resolve({ status: "ok", items: [] }), 50))
+				: pending;
+		},
+		interrupt: async () => { interrupts += 1; finish({ status: "aborted", items: [] }); },
+	};
+	const session = {
+		kernel: () => kernel,
+		checkpoints: { flush: async () => {}, schedule: () => {} },
+		journal: () => undefined,
+		recordMemory: () => {},
+		memory: () => undefined,
+		takeNotice: () => undefined,
+		invalidateKernel: async () => { kernel = undefined; },
+		recoverFromBootstrapFailure: async () => false,
+	};
+	const runtime = new NotebookExecutionRuntime(
+		() => session as never,
+		async () => {},
+	);
+	const context = { cwd: "/tmp" };
+	const yielded = await runtime.execute('// @exec: {"yield_time_ms": 1}\nawait new Promise(() => {})', context);
+	assert.equal(yielded.kind, "yielded");
+	await new Promise((resolve) => setTimeout(resolve, 60));
+	assert.equal(executeCalls, 2);
+	assert.equal(runtime.activeCellId(), yielded.cellId);
+	const terminated = await runtime.terminate(yielded.cellId, context);
+	assert.equal(terminated.kind, "terminated");
+	assert.equal(interrupts, 1);
+	assert.equal(kernel, undefined);
+	assert.equal(runtime.activeCellId(), undefined);
+
+	let quickKernel: { execute(): Promise<FakeResult>; interrupt(): Promise<void> } | undefined;
+	let quickExecuteCalls = 0;
+	let quickInterrupts = 0;
+	quickKernel = {
+		execute: () => {
+			quickExecuteCalls += 1;
+			const delay = quickExecuteCalls === 1 ? 50 : 20;
+			return new Promise((resolve) => setTimeout(() => resolve({ status: "ok", items: [] }), delay));
+		},
+		interrupt: async () => { quickInterrupts += 1; },
+	};
+	const quickSession = {
+		...session,
+		kernel: () => quickKernel,
+		invalidateKernel: async () => { quickKernel = undefined; },
+	};
+	const quickRuntime = new NotebookExecutionRuntime(() => quickSession as never, async () => {});
+	const quickYielded = await quickRuntime.execute('// @exec: {"yield_time_ms": 1}\nawait new Promise(() => {})', context);
+	assert.equal(quickYielded.kind, "yielded");
+	await new Promise((resolve) => setTimeout(resolve, 60));
+	await quickRuntime.terminate(quickYielded.cellId, context);
+	assert.equal(quickExecuteCalls, 2);
+	assert.equal(quickInterrupts, 0);
+	assert.equal(quickKernel, undefined);
+});
+
+test("notebook restart bypasses capture after the runtime is invalidated", async () => {
+	let checkpoints = 0;
+	let prepares = 0;
+	let restarts = 0;
+	const controller = new NotebookLifecycleController({
+		prepare: async () => { prepares += 1; },
+		diagnostics: async () => ({ message: "", details: {} }),
+		reset: async () => ({ message: "", details: {} }),
+		kernel: () => undefined,
+		activeCellId: () => undefined,
+		stopActive: async () => undefined,
+		checkpoint: async () => { checkpoints += 1; },
+		retainedBindings: () => [],
+		promoteBindings: async () => async () => {},
+		markChanged: () => {},
+		restart: async () => { restarts += 1; return undefined; },
+		rollback: async () => {},
+		baselineNames: () => new Set(),
+		profileStorage: () => ({ agentDir: "/tmp", maxBytes: 8 * 1024 * 1024 }),
+		runtimeHealth: () => ({ state: "invalidated" }),
+		metadata: () => ({ userCells: 0, checkpoint: {} }),
+	} as never);
+
+	const result = await controller.control({ action: "restart" }, { cwd: "/tmp", extensionContext: {} } as never);
+	assert.equal(checkpoints, 0);
+	assert.equal(prepares, 0);
+	assert.equal(restarts, 1);
+	assert.match(result.message, /restarted from the last completed checkpoint/);
+});
+
+function diagnostic(cellId: string, cellIndex: number, name = "r", severity: NotebookDiagnostic["severity"] = "warning", source = "deno"): NotebookDiagnostic {
+	return {
+		cellId, cellIndex, line: cellIndex + 1, column: 1, endLine: cellIndex + 1, endColumn: 8,
+		severity, code: 2451, source, name,
+		message: `Cannot redeclare block-scoped variable '${name}'.`,
+	};
+}
+
+function hash(value: Buffer): string {
+	return createHash("sha256").update(value).digest("hex");
+}


### PR DESCRIPTION
This PR makes interrupted Notebook kernels recover from the last completed checkpoint without deleting durable project state.

Part of #325.

Closes #305.

## Summary

- invalidate a kernel after forced interruption instead of reusing it
- preserve durable globals and pins across restart and reset
- keep current runtime faults distinct from bounded historical diagnostics

## Validation

- typecheck passed
- 22 focused Notebook tests passed
- cumulative `bun run check:changed`
- Knip passed

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
