### PR TITLE
Make durable Notebook globals self-describing

### DIFF
--- a/.changeset/patch-notebook-metadata-306.md
+++ b/.changeset/patch-notebook-metadata-306.md
@@ -2,4 +2,4 @@
 "@howaboua/pi-codex-conversion": patch
 ---
 
-Make durable Notebook Mode globals discoverable with bounded descriptions and usage hints
+Make durable Notebook Mode globals discoverable and guide safe reuse with bounded descriptions and usage hints

--- a/.changeset/patch-notebook-metadata-306.md
+++ b/.changeset/patch-notebook-metadata-306.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Make durable Notebook Mode globals discoverable with bounded descriptions and usage hints

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -63,7 +63,7 @@ const CODE_MODE_GUIDELINES = [
 
 const NOTEBOOK_MODE_GUIDELINES = [
 	"exec is a persistent Deno/TypeScript Jupyter notebook; project globals may come from earlier agents and sessions",
-	"Before repeating discovery or rebuilding helpers, use notebook status and reuse matching bindings",
+	"Treat retained globals as mini-tools: check notebook status description/usage before rebuilding; inspect other globals' description/usage before constructing reusable ones; give helpers concise own description/usage with a safe inspection recipe and simple one-shot call shape",
 	"Keep one-offs block-local; store compact reusable values and self-contained helpers on purpose-named globalThis properties",
 	"Turn repeatable project work into callable helpers; pin reusable project state worth protecting",
 	...CODE_MODE_GUIDELINES,

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -63,9 +63,8 @@ const CODE_MODE_GUIDELINES = [
 
 const NOTEBOOK_MODE_GUIDELINES = [
 	"exec is a persistent Deno/TypeScript Jupyter notebook; project globals may come from earlier agents and sessions",
-	"Treat retained globals as mini-tools: check notebook status description/usage before rebuilding; inspect other globals' description/usage before constructing reusable ones; give helpers concise own description/usage with a safe inspection recipe and simple one-shot call shape",
-	"Keep one-offs block-local; store compact reusable values and self-contained helpers on purpose-named globalThis properties",
-	"Turn repeatable project work into callable helpers; pin reusable project state worth protecting",
+	"Check notebook status and reuse matching retained globals before rebuilding; inspect description/usage before constructing reusable ones",
+	"Keep one-offs block-local; store cheap reusable state and repeatable helpers on purpose-named globalThis properties as unpinned scratch, pin only important prune-resistant state; give helpers concise description/usage with a safe inspection recipe",
 	...CODE_MODE_GUIDELINES,
 	"Use notebook status to inspect retained state or memory, release/prune disposable state, and diagnostics after broken state or helpers",
 	"Filter retained data inside exec and return only needed findings; never dump the namespace",

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-format.ts
@@ -1,6 +1,8 @@
+import type { ProjectBindingMetadata } from "./project-state-format.ts";
+
 export const CHECKPOINT_SCHEMA = 1;
 
-export interface CheckpointEntry {
+export interface CheckpointEntry extends ProjectBindingMetadata {
 	name: string;
 	kind: "value" | "function";
 	offset: number;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-manager.ts
@@ -1,10 +1,7 @@
 import { writeNotebookCheckpoint, type NotebookCheckpointIdentity } from "./checkpoint.ts";
 import type { DenoJupyterKernel } from "./jupyter-kernel.ts";
-import {
-	type ProjectStateBaseline,
-	writeProjectState,
-} from "./project-state.ts";
-import type { ProjectStatePinUpdate } from "./project-state-merge.ts";
+import { type ProjectStateBaseline, writeProjectState } from "./project-state.ts";
+import { projectStateEntryFingerprint, type ProjectStatePinUpdate } from "./project-state-merge.ts";
 
 const CHECKPOINT_DEBOUNCE_MS = 1_500;
 
@@ -127,9 +124,11 @@ export class NotebookCheckpointManager {
 				options.pins,
 			);
 			this.projectBaseline = project.baseline;
-			const sessionHashes = new Map(project.baseline.entries.map(({ name, hash }) => [name, hash]));
-			for (const { name, hash } of project.restored) {
-				if (sessionHashes.get(name) === hash) projectExclusions.add(name);
+			const sessionEntries = new Map(project.baseline.entries.map((entry) => [entry.name, entry]));
+			for (const entry of project.restored) {
+				if (projectStateEntryFingerprint(sessionEntries.get(entry.name)) === projectStateEntryFingerprint(entry)) {
+					projectExclusions.add(entry.name);
+				}
 			}
 			if (project.conflicts.length > 0) {
 				this.reportNotice(`Project notebook conflicts preserved without overwrite: ${project.conflicts.join(", ")}`, false);

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-runtime.ts
@@ -1,5 +1,10 @@
 import { CHECKPOINT_SCHEMA, type CheckpointManifest, type NotebookCheckpointIdentity } from "./checkpoint-format.ts";
-import { MAX_PROJECT_MANIFEST_BYTES } from "./project-state-format.ts";
+import {
+	MAX_PROJECT_DESCRIPTION_BYTES,
+	MAX_PROJECT_MANIFEST_BYTES,
+	MAX_PROJECT_USAGE_BYTES,
+	MAX_PROJECT_USAGE_LINES,
+} from "./project-state-format.ts";
 
 export function checkpointSource(options: {
 	candidates: string[];
@@ -34,8 +39,16 @@ export function checkpointSource(options: {
       if (__bytes.byteLength > __max) __skip(${JSON.stringify(name)}, "exceeds per-variable checkpoint cap");
       else if (__total + __bytes.byteLength > __max) __skip(${JSON.stringify(name)}, "exceeds total checkpoint cap");
       else {
+		const __metadata = __readBindingMetadata(__value);
 		await __writeAll(__bytes);
-		__entries.push({ name: ${JSON.stringify(name)}, kind: __kind, offset: __total, length: __bytes.byteLength });
+		__entries.push({
+		  name: ${JSON.stringify(name)},
+		  kind: __kind,
+		  offset: __total,
+		  length: __bytes.byteLength,
+		  ...(__metadata.description === undefined ? {} : { description: __metadata.description }),
+		  ...(__metadata.usage === undefined ? {} : { usage: __metadata.usage }),
+		});
         __total += __bytes.byteLength;
       }
     }
@@ -48,6 +61,31 @@ export function checkpointSource(options: {
   const __entries = [];
   const __skipped = ${JSON.stringify(options.skippedInvalid)};
   let __total = 0;
+  const __readBindingMetadata = (__value) => {
+    if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return {};
+    const __metadata = {};
+    for (const [__key, __max, __multiline, __lines] of [
+      ["description", ${MAX_PROJECT_DESCRIPTION_BYTES}, false, 1],
+      ["usage", ${MAX_PROJECT_USAGE_BYTES}, true, ${MAX_PROJECT_USAGE_LINES}],
+    ]) {
+      const __descriptor = Object.getOwnPropertyDescriptor(__value, __key);
+      if (!__descriptor || !("value" in __descriptor) || typeof __descriptor.value !== "string") continue;
+      const __text = __descriptor.value;
+      if (!__text || new TextEncoder().encode(__text).byteLength > __max || __text.includes("\\r")) continue;
+      const __textLines = __text.split("\\n");
+      if (__textLines.length > __lines) continue;
+      let __valid = true;
+      for (const __character of __text) {
+        const __codePoint = __character.codePointAt(0);
+        if ((__codePoint < 0x20 && __codePoint !== 0x0a) || __codePoint === 0x7f || !__multiline && __codePoint === 0x0a) {
+          __valid = false;
+          break;
+        }
+      }
+      if (__valid) __metadata[__key] = __text;
+    }
+    return __metadata;
+  };
   const __skip = (name, reason) => __skipped.push({ name, reason: String(reason).slice(0, 240) });
 	const __file = await Deno.open(${JSON.stringify(options.payloadPath)}, { create: true, write: true, truncate: true, mode: 0o600 });
 	const __writeAll = async (__bytes) => {
@@ -101,14 +139,30 @@ export function restoreSource(manifest: CheckpointManifest, payloadPath: string,
 	const __functions = [];
   for (const __entry of __entries) {
 	const __captured = deserialize(__payload.slice(__entry.offset, __entry.offset + __entry.length));
-	if (__entry.kind === "function") __functions.push([__entry.name, __captured]);
-	else __values.push([__entry.name, __captured]);
-  }
-	for (const [__name, __value] of __values) {
+	if (__entry.kind === "function") __functions.push([__entry.name, __captured, __entry]);
+	else __values.push([__entry.name, __captured, __entry]);
+	}
+	const __applyMetadata = (__value, __entry) => {
+	  if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return;
+	  for (const __key of ["description", "usage"]) {
+	    if (typeof __entry[__key] !== "string") continue;
+	    try {
+	      Object.defineProperty(__value, __key, {
+	        value: __entry[__key],
+	        writable: true,
+	        configurable: true,
+	        enumerable: true,
+	      });
+	    } catch {}
+	  }
+	};
+	for (const [__name, __value, __entry] of __values) {
+	  __applyMetadata(__value, __entry);
 	  Object.defineProperty(globalThis, __name, { value: __value, writable: true, configurable: true, enumerable: true });
 	}
-	for (const [__name, __source] of __functions) {
+	for (const [__name, __source, __entry] of __functions) {
 	  const __value = (0, eval)("(" + __source + ")");
+	  __applyMetadata(__value, __entry);
 	  Object.defineProperty(globalThis, __name, { value: __value, writable: true, configurable: true, enumerable: true });
 	}
   undefined;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint.ts
@@ -13,6 +13,7 @@ import {
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
 	MAX_PROJECT_NAME_BYTES,
+	parseProjectBindingMetadata,
 	type ProjectStateBaseline,
 } from "./project-state-format.ts";
 
@@ -254,12 +255,14 @@ function isValidCheckpointPayload(manifest: CheckpointManifest, path: string, ma
 function parseEntry(value: unknown): CheckpointEntry | undefined {
 	if (!isRecord(value)) return undefined;
 	const { name, offset, length, kind } = value;
+	const metadata = parseProjectBindingMetadata(value);
 	return typeof name === "string" && IDENTIFIER.test(name)
 		&& Buffer.byteLength(name) <= MAX_PROJECT_NAME_BYTES
 		&& (kind === undefined || kind === "value" || kind === "function")
 		&& Number.isSafeInteger(offset) && (offset as number) >= 0
 		&& Number.isSafeInteger(length) && (length as number) >= 0
-		? { name, kind: kind === "function" ? "function" : "value", offset: offset as number, length: length as number }
+		&& metadata !== undefined
+		? { name, kind: kind === "function" ? "function" : "value", offset: offset as number, length: length as number, ...metadata }
 		: undefined;
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/kernel-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/kernel-runtime.ts
@@ -252,3 +252,37 @@ export function notebookBootstrapSource(origin: string, token: string, exitToken
   };
 }`;
 }
+
+export function notebookExampleSource(marker: string, occupied = false): string {
+	return `{
+	  const __conflict = ${occupied} || "foo" in globalThis || "bar" in globalThis;
+  let __injected = [];
+  if (!__conflict) {
+    const __foo = [
+      { id: "alpha", value: "first example record" },
+      { id: "bravo", value: "second example record" },
+    ];
+    const __bar = (__item) => Object.fromEntries(Object.entries(__item).slice(0, 4));
+    Object.defineProperties(__foo, {
+      description: { value: "Example records for reusable helper patterns", writable: true, configurable: true },
+      usage: { value: "Inspect: foo.map((item, index) => ({ index, keys: Object.keys(item) }))", writable: true, configurable: true },
+    });
+    Object.defineProperties(__bar, {
+      description: { value: "Summarize one foo item without mutating foo", writable: true, configurable: true },
+      usage: { value: "Inspect: foo.map((item, index) => ({ index, keys: Object.keys(item) }))\\nRun: bar(foo[index])", writable: true, configurable: true },
+    });
+    try {
+      Object.defineProperties(globalThis, {
+        foo: { value: __foo, writable: true, configurable: true, enumerable: true },
+        bar: { value: __bar, writable: true, configurable: true, enumerable: true },
+      });
+      __injected = ["foo", "bar"];
+    } catch {
+      delete globalThis.foo;
+      delete globalThis.bar;
+    }
+  }
+  console.log(${JSON.stringify(marker)} + JSON.stringify(__injected));
+  undefined;
+}`;
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
@@ -101,13 +101,15 @@ export function formatStatus(details: NotebookStatusDetails): string {
 		for (const binding of details.pinned) lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
 		if (details.omittedPinned > 0) lines.push(`${details.omittedPinned} additional pinned binding(s) omitted; use status with a query glob`);
 	}
-	if (details.query === undefined && details.largestUnpinned.length > 0) {
-		lines.push("Largest unpinned retained bindings:");
-		for (const binding of details.largestUnpinned) {
-			lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
+	if (details.query === undefined && (details.largestUnpinned.length > 0 || details.omittedLargestUnpinned > 0)) {
+		if (details.largestUnpinned.length > 0) {
+			lines.push("Largest unpinned retained bindings:");
+			for (const binding of details.largestUnpinned) {
+				lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
+			}
 		}
 		if (details.omittedLargestUnpinned > 0) lines.push(`${details.omittedLargestUnpinned} additional unpinned binding(s) omitted; use status with a query glob`);
-		lines.push("Use status with a query glob for details; pin intentional state before pruning disposable matches");
+		lines.push("Use status with a query glob for details; unpinned state is reusable scratch, pin valuable state before pruning");
 	}
 	if (details.query !== undefined) {
 		lines.push(`Bindings matching ${JSON.stringify(details.query)}:`);

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
@@ -19,6 +19,8 @@ export interface NotebookStatusDetails extends Record<string, unknown> {
 		bytes?: number | undefined;
 		updatedAt?: string | undefined;
 		pinned?: boolean | undefined;
+		description?: string | undefined;
+		usage?: string | undefined;
 	}> | undefined;
 	omittedMatches?: number | undefined;
 	retainedBindings: number;
@@ -27,6 +29,7 @@ export interface NotebookStatusDetails extends Record<string, unknown> {
 	pinned: RetainedProjectBinding[];
 	omittedPinned: number;
 	largestUnpinned: RetainedProjectBinding[];
+	omittedLargestUnpinned: number;
 }
 
 export function withinNameBudget(names: string[]): string[] {
@@ -52,6 +55,10 @@ export function takeDetailValues<T>(values: T[], budget: { remaining: number }):
 		selected.push(value);
 	}
 	return selected;
+}
+
+export function remainingDetailsBudget(base: unknown): { remaining: number } {
+	return { remaining: Math.max(0, NOTEBOOK_DETAILS_BUDGET - Buffer.byteLength(JSON.stringify(base))) };
 }
 
 export function boundedReleaseDetails(
@@ -91,25 +98,32 @@ export function formatStatus(details: NotebookStatusDetails): string {
 	];
 	if (details.query === undefined && details.pinned.length > 0) {
 		lines.push("Pinned project bindings:");
-		for (const binding of details.pinned) lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}`);
+		for (const binding of details.pinned) lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
 		if (details.omittedPinned > 0) lines.push(`${details.omittedPinned} additional pinned binding(s) omitted; use status with a query glob`);
 	}
 	if (details.query === undefined && details.largestUnpinned.length > 0) {
 		lines.push("Largest unpinned retained bindings:");
 		for (const binding of details.largestUnpinned) {
-			lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}`);
+			lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
 		}
+		if (details.omittedLargestUnpinned > 0) lines.push(`${details.omittedLargestUnpinned} additional unpinned binding(s) omitted; use status with a query glob`);
 		lines.push("Use status with a query glob for details; pin intentional state before pruning disposable matches");
 	}
 	if (details.query !== undefined) {
 		lines.push(`Bindings matching ${JSON.stringify(details.query)}:`);
 		for (const binding of details.matches ?? []) {
-			lines.push(`- ${binding.name}: ${binding.kind}${binding.constructor ? ` ${binding.constructor}` : ` ${binding.type}`}${binding.disposable ? ` · ${binding.disposable} disposable` : ""}${binding.bytes === undefined ? "" : ` · ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt!)}`}${binding.pinned ? " · pinned" : ""}`);
+			lines.push(`- ${binding.name}: ${binding.kind}${binding.constructor ? ` ${binding.constructor}` : ` ${binding.type}`}${binding.disposable ? ` · ${binding.disposable} disposable` : ""}${binding.bytes === undefined ? "" : ` · ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt!)}`}${binding.pinned ? " · pinned" : ""}${formatBindingMetadata(binding)}`);
 		}
 		if ((details.matches?.length ?? 0) === 0) lines.push("- none");
 		if ((details.omittedMatches ?? 0) > 0) lines.push(`${details.omittedMatches} additional match(es) omitted; narrow query`);
 	}
 	return boundMessage(lines.filter(Boolean).join("\n"));
+}
+
+function formatBindingMetadata(binding: { description?: string | undefined; usage?: string | undefined }): string {
+	const description = binding.description === undefined ? "" : ` · ${binding.description}`;
+	const usage = binding.usage === undefined ? "" : ` · usage: ${binding.usage.replaceAll("\n", "\n  ")}`;
+	return `${description}${usage}`;
 }
 
 export function formatRelease(result: NotebookReleaseResult, restarted: boolean): string {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
@@ -15,6 +15,7 @@ import {
 	formatRelease,
 	formatStatus,
 	NOTEBOOK_DETAILS_BUDGET,
+	remainingDetailsBudget,
 	takeDetailValues,
 	withinNameBudget,
 	type NotebookStatusDetails,
@@ -121,7 +122,6 @@ export class NotebookLifecycleController {
 			);
 		}
 		const metadata = this.host.metadata();
-		const detailBudget = { remaining: NOTEBOOK_DETAILS_BUDGET };
 		const inspectedMatches = (runtime?.bindings ?? []).map((binding) => {
 			const retainedBinding = retainedByName.get(binding.name);
 			return {
@@ -130,13 +130,17 @@ export class NotebookLifecycleController {
 					bytes: retainedBinding.bytes,
 					updatedAt: retainedBinding.updatedAt,
 					pinned: retainedBinding.pinned,
+					...(retainedBinding.description === undefined ? {} : { description: retainedBinding.description }),
+					...(retainedBinding.usage === undefined ? {} : { usage: retainedBinding.usage }),
 				} : {}),
 			};
 		});
-		const reportedMatches = takeDetailValues(inspectedMatches, detailBudget);
 		const pinned = retained.filter((binding) => binding.pinned);
-		const reportedPinned = takeDetailValues(pinned, detailBudget);
-		const details: NotebookStatusDetails = {
+		const unpinned = retained
+			.filter(({ pinned }) => !pinned)
+			.sort((left, right) => right.bytes - left.bytes);
+		const largestUnpinned = unpinned.slice(0, 8);
+		const baseDetails: NotebookStatusDetails = {
 			state: activeCell ? "running" : "idle",
 			...(activeCell ? { activeCell } : {}),
 			userBindings: activeCell ? undefined : allNames.length,
@@ -147,14 +151,27 @@ export class NotebookLifecycleController {
 			retainedBindings: retained.length,
 			retainedBytes: retained.reduce((total, binding) => total + binding.bytes, 0),
 			pinnedBindings: pinned.length,
-			pinned: reportedPinned,
-			omittedPinned: pinned.length - reportedPinned.length,
-			largestUnpinned: retained
-				.filter(({ pinned }) => !pinned)
-				.sort((left, right) => right.bytes - left.bytes)
-				.slice(0, 8),
+			pinned: [],
+			omittedPinned: pinned.length,
+			largestUnpinned: [],
+			omittedLargestUnpinned: unpinned.length,
 			...(query === undefined ? {} : {
 				query,
+				matches: [],
+				omittedMatches: matches.length,
+			}),
+		};
+		const detailBudget = remainingDetailsBudget(baseDetails);
+		const reportedMatches = takeDetailValues(inspectedMatches, detailBudget);
+		const reportedPinned = takeDetailValues(pinned, detailBudget);
+		const reportedLargestUnpinned = takeDetailValues(largestUnpinned, detailBudget);
+		const details: NotebookStatusDetails = {
+			...baseDetails,
+			pinned: reportedPinned,
+			omittedPinned: pinned.length - reportedPinned.length,
+			largestUnpinned: reportedLargestUnpinned,
+			omittedLargestUnpinned: unpinned.length - reportedLargestUnpinned.length,
+			...(query === undefined ? {} : {
 				matches: reportedMatches,
 				omittedMatches: Math.max(0, matches.length - reportedMatches.length),
 			}),

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/profile-state-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/profile-state-format.ts
@@ -5,6 +5,7 @@ import {
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
 	MAX_PROJECT_NAME_BYTES,
+	parseProjectBindingMetadata,
 	type ProjectStateEntry,
 } from "./project-state-format.ts";
 
@@ -140,12 +141,14 @@ export function hashProfileBytes(bytes: Uint8Array): string {
 function parseEntry(value: unknown): ProjectStateEntry | undefined {
 	if (!isRecord(value)) return undefined;
 	const { name, kind, offset, length, hash } = value;
+	const metadata = parseProjectBindingMetadata(value);
 	return typeof name === "string" && IDENTIFIER.test(name) && Buffer.byteLength(name) <= MAX_PROJECT_NAME_BYTES
 		&& (kind === "value" || kind === "function")
 		&& Number.isSafeInteger(offset) && (offset as number) >= 0
 		&& Number.isSafeInteger(length) && (length as number) >= 0
 		&& typeof hash === "string" && HASH.test(hash)
-		? { name, kind, offset: offset as number, length: length as number, hash }
+		&& metadata !== undefined
+		? { name, kind, offset: offset as number, length: length as number, hash, ...metadata }
 		: undefined;
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-format.ts
@@ -6,6 +6,9 @@ export const PROJECT_STATE_SCHEMA = 2;
 export const MAX_PROJECT_ENTRIES = 10_000;
 export const MAX_PROJECT_NAME_BYTES = 4 * 1024;
 export const MAX_PROJECT_MANIFEST_BYTES = 8 * 1024 * 1024;
+export const MAX_PROJECT_DESCRIPTION_BYTES = 256;
+export const MAX_PROJECT_USAGE_BYTES = 512;
+export const MAX_PROJECT_USAGE_LINES = 4;
 const PAYLOAD_NAME = /^project-[0-9a-f-]+\.bin$/;
 const CONFLICT_PAYLOAD_NAME = /^[0-9]+-[0-9a-f-]+\.bin$/;
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
@@ -16,8 +19,15 @@ export interface ProjectStateEntry {
 	offset: number;
 	length: number;
 	hash: string;
+	description?: string | undefined;
+	usage?: string | undefined;
 	updatedAt?: string | undefined;
 	pinned?: true | undefined;
+}
+
+export interface ProjectBindingMetadata {
+	description?: string | undefined;
+	usage?: string | undefined;
 }
 
 export interface ProjectStateManifest {
@@ -43,7 +53,7 @@ export interface ProjectStateCandidate {
 
 export interface ProjectStateBaseline {
 	generation: string;
-	entries: Array<{ name: string; hash: string }>;
+	entries: Array<{ name: string; hash: string } & ProjectBindingMetadata>;
 }
 
 export interface ProjectStateSummary {
@@ -187,7 +197,15 @@ export function readProjectConflictRecord(path: string): ProjectConflictRecord |
 }
 
 export function baselineFromProjectManifest(manifest: ProjectStateManifest): ProjectStateBaseline {
-	return { generation: manifest.generation, entries: manifest.entries.map(({ name, hash }) => ({ name, hash })) };
+	return {
+		generation: manifest.generation,
+		entries: manifest.entries.map(({ name, hash, description, usage }) => ({
+			name,
+			hash,
+			...(description === undefined ? {} : { description }),
+			...(usage === undefined ? {} : { usage }),
+		})),
+	};
 }
 
 export function emptyProjectStateSummary(): ProjectStateSummary {
@@ -211,15 +229,40 @@ function parseEntry(value: unknown, payloadLength: number, requireHash: boolean)
 		|| updatedAt !== undefined && (typeof updatedAt !== "string" || !Number.isFinite(Date.parse(updatedAt)))
 		|| pinned !== undefined && pinned !== true
 	) return undefined;
+	const metadata = parseProjectBindingMetadata(value);
+	if (!metadata) return undefined;
 	const entry: Omit<ProjectStateEntry, "hash"> = {
 		name,
 		kind: kind as ProjectStateEntry["kind"],
 		offset: offset as number,
 		length: length as number,
+		...metadata,
 		...(typeof updatedAt === "string" ? { updatedAt } : {}),
 		...(pinned === true ? { pinned: true as const } : {}),
 	};
 	return requireHash ? { ...entry, hash: hash as string } : entry;
+}
+
+export function parseProjectBindingMetadata(value: Record<string, unknown>): ProjectBindingMetadata | undefined {
+	const description = parseMetadataText(value["description"], MAX_PROJECT_DESCRIPTION_BYTES, false);
+	const usage = parseMetadataText(value["usage"], MAX_PROJECT_USAGE_BYTES, true);
+	if (description === null || usage === null) return undefined;
+	return {
+		...(description === undefined ? {} : { description }),
+		...(usage === undefined ? {} : { usage }),
+	};
+}
+
+function parseMetadataText(value: unknown, maxBytes: number, multiline: boolean): string | undefined | null {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string" || value.length === 0 || Buffer.byteLength(value) > maxBytes) return null;
+	const lines = value.split("\n");
+	if ((!multiline && lines.length !== 1) || lines.length > MAX_PROJECT_USAGE_LINES || value.includes("\r")) return null;
+	for (const character of value) {
+		const codePoint = character.codePointAt(0)!;
+		if (codePoint < 0x20 && codePoint !== 0x0a || codePoint === 0x7f) return null;
+	}
+	return value;
 }
 
 function parseSkipped(value: unknown): { name: string; reason: string } | undefined {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-merge.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-merge.ts
@@ -32,7 +32,7 @@ export function mergeProjectState(options: {
 	currentPayload: Buffer;
 	pins?: ProjectStatePinUpdate | undefined;
 }): ProjectStateMerge {
-	const base = new Map(options.baseline.entries.map(({ name, hash }) => [name, hash]));
+	const base = new Map(options.baseline.entries.map((entry) => [entry.name, entry]));
 	const current = new Map((options.current?.entries ?? []).map((entry) => [entry.name, entry]));
 	const candidate = new Map(options.candidate.entries.map((entry) => [entry.name, {
 		...entry,
@@ -52,18 +52,19 @@ export function mergeProjectState(options: {
 	let conflictOffset = 0;
 	const capturedAt = new Date().toISOString();
 	for (const name of names) {
-		const baseHash = base.get(name);
+		const baseEntry = base.get(name);
 		const currentEntry = current.get(name);
 		const candidateEntry = candidate.get(name);
-		const candidateHash = skipped.has(name) ? baseHash : candidateEntry?.hash;
-		const currentHash = currentEntry?.hash;
-		const candidateChanged = !skipped.has(name) && candidateHash !== baseHash;
-		const currentChanged = currentHash !== baseHash;
+		const baseFingerprint = projectStateEntryFingerprint(baseEntry);
+		const candidateFingerprint = skipped.has(name) ? baseFingerprint : projectStateEntryFingerprint(candidateEntry);
+		const currentFingerprint = projectStateEntryFingerprint(currentEntry);
+		const candidateChanged = !skipped.has(name) && candidateFingerprint !== baseFingerprint;
+		const currentChanged = currentFingerprint !== baseFingerprint;
 		let selected: { entry: ProjectStateEntry; payload: Buffer } | undefined;
 		if (candidateChanged && !candidateEntry && currentEntry?.pinned) {
 			conflicts.push(name);
 			selected = { entry: currentEntry, payload: options.currentPayload };
-		} else if (candidateChanged && currentChanged && candidateHash !== currentHash) {
+		} else if (candidateChanged && currentChanged && candidateFingerprint !== currentFingerprint) {
 			conflicts.push(name);
 			if (candidateEntry) {
 				const bytes = options.candidatePayload.subarray(candidateEntry.offset, candidateEntry.offset + candidateEntry.length);
@@ -77,7 +78,7 @@ export function mergeProjectState(options: {
 			if (candidateEntry) selected = {
 				entry: {
 					...candidateEntry,
-					updatedAt: candidateHash === currentHash
+					updatedAt: candidateFingerprint === currentFingerprint
 						? currentEntry?.updatedAt ?? options.current?.createdAt ?? capturedAt
 						: capturedAt,
 					...(currentEntry?.pinned ? { pinned: true } : {}),
@@ -113,17 +114,19 @@ export function mergeProjectState(options: {
 			};
 		}
 	}
-	const currentShape = JSON.stringify((options.current?.entries ?? []).map(({ name, kind, hash, pinned }) => [name, kind, hash, pinned === true]));
-	const mergedShape = JSON.stringify(entries.map(({ name, kind, hash, pinned }) => [name, kind, hash, pinned === true]));
+	const currentShape = JSON.stringify((options.current?.entries ?? []).map(projectStateEntryShape));
+	const mergedShape = JSON.stringify(entries.map(projectStateEntryShape));
 	const skippedBaseline = options.baseline.entries.filter(({ name }) => skipped.has(name));
 	return {
 		changed: mergedShape !== currentShape,
 		baseline: {
 			generation: options.baseline.generation,
-			entries: [
-				...skippedBaseline,
-				...[...candidate.values()].map(({ name, hash }) => ({ name, hash })),
-			].sort((left, right) => left.name.localeCompare(right.name)),
+			entries: [...skippedBaseline, ...[...candidate.values()].map(({ name, hash, description, usage }) => ({
+				name,
+				hash,
+				...(description === undefined ? {} : { description }),
+				...(usage === undefined ? {} : { usage }),
+			}))].sort((left, right) => left.name.localeCompare(right.name)),
 		},
 		entries,
 		payload: Buffer.concat(parts),
@@ -133,4 +136,18 @@ export function mergeProjectState(options: {
 		conflictDeletions,
 		conflictPayload: Buffer.concat(conflictParts),
 	};
+}
+
+export function projectStateEntryFingerprint(entry: {
+	hash?: string | undefined;
+	description?: string | undefined;
+	usage?: string | undefined;
+} | undefined): string | undefined {
+	return entry === undefined
+		? undefined
+		: JSON.stringify([entry.hash ?? null, entry.description ?? null, entry.usage ?? null]);
+}
+
+function projectStateEntryShape(entry: ProjectStateEntry): [string, string, string, boolean, string | null, string | null] {
+	return [entry.name, entry.kind, entry.hash, entry.pinned === true, entry.description ?? null, entry.usage ?? null];
 }

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-metadata.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-metadata.ts
@@ -12,6 +12,8 @@ export interface RetainedProjectBinding {
 	bytes: number;
 	updatedAt: string;
 	pinned: boolean;
+	description?: string | undefined;
+	usage?: string | undefined;
 }
 
 export function readRetainedProjectBindings(
@@ -31,6 +33,8 @@ export function readRetainedProjectBindings(
 		bytes: entry.length,
 		updatedAt: entry.updatedAt ?? manifest.createdAt,
 		pinned: entry.pinned === true,
+		...(entry.description === undefined ? {} : { description: entry.description }),
+		...(entry.usage === undefined ? {} : { usage: entry.usage }),
 	}));
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
@@ -1,6 +1,9 @@
 import {
+	MAX_PROJECT_DESCRIPTION_BYTES,
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
+	MAX_PROJECT_USAGE_BYTES,
+	MAX_PROJECT_USAGE_LINES,
 	type ProjectStateManifest,
 } from "./project-state-format.ts";
 import type { KernelExecutionResult } from "./jupyter-kernel.ts";
@@ -59,8 +62,16 @@ export function projectStateCaptureSource(options: {
     const __bytes = serialize(__captured);
     if (__bytes.byteLength > __max) throw new Error("exceeds per-value checkpoint cap");
     if (__total + __bytes.byteLength > __max) throw new Error("exceeds total project checkpoint cap");
+	const __metadata = __readBindingMetadata(__value);
 	await __writeAll(__bytes);
-    __entries.push({ name: ${JSON.stringify(name)}, kind: __kind, offset: __total, length: __bytes.byteLength });
+	    __entries.push({
+	      name: ${JSON.stringify(name)},
+	      kind: __kind,
+	      offset: __total,
+	      length: __bytes.byteLength,
+	      ...(__metadata.description === undefined ? {} : { description: __metadata.description }),
+	      ...(__metadata.usage === undefined ? {} : { usage: __metadata.usage }),
+	    });
     __total += __bytes.byteLength;
   } catch (__error) {
     __skipped.push({ name: ${JSON.stringify(name)}, reason: String(__error instanceof Error ? __error.message : __error).slice(0, 240) });
@@ -68,9 +79,34 @@ export function projectStateCaptureSource(options: {
 	return `{
   const { serialize } = await import("node:v8");
   const __max = ${options.maxBytes};
-  const __entries = [];
-  const __skipped = [];
-  let __total = 0;
+	  const __entries = [];
+	  const __skipped = [];
+	  let __total = 0;
+	const __readBindingMetadata = (__value) => {
+	  if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return {};
+	  const __metadata = {};
+	  for (const [__key, __max, __multiline, __lines] of [
+	    ["description", ${MAX_PROJECT_DESCRIPTION_BYTES}, false, 1],
+	    ["usage", ${MAX_PROJECT_USAGE_BYTES}, true, ${MAX_PROJECT_USAGE_LINES}],
+	  ]) {
+	    const __descriptor = Object.getOwnPropertyDescriptor(__value, __key);
+	    if (!__descriptor || !("value" in __descriptor) || typeof __descriptor.value !== "string") continue;
+	    const __text = __descriptor.value;
+	    if (!__text || new TextEncoder().encode(__text).byteLength > __max || __text.includes("\\r")) continue;
+	    const __textLines = __text.split("\\n");
+	    if (__textLines.length > __lines) continue;
+	    let __valid = true;
+	    for (const __character of __text) {
+	      const __codePoint = __character.codePointAt(0);
+	      if ((__codePoint < 0x20 && __codePoint !== 0x0a) || __codePoint === 0x7f || !__multiline && __codePoint === 0x0a) {
+	        __valid = false;
+	        break;
+	      }
+	    }
+	    if (__valid) __metadata[__key] = __text;
+	  }
+	  return __metadata;
+	};
 	const __file = await Deno.open(${JSON.stringify(options.payloadPath)}, { create: true, write: true, truncate: true, mode: 0o600 });
 	const __writeAll = async (__bytes) => {
 	  let __offset = 0;
@@ -130,6 +166,20 @@ export function projectStateRestoreSource(
   const __matches = (__currentValue, __restore) => __restore.kind === "function"
     ? typeof __currentValue === "function" && Function.prototype.toString.call(__currentValue) === __restore.captured
     : __sameBytes(__currentValue, __restore.value);
+  const __applyMetadata = (__value, __entry) => {
+    if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return;
+    for (const __key of ["description", "usage"]) {
+      if (typeof __entry[__key] !== "string") continue;
+      try {
+        Object.defineProperty(__value, __key, {
+          value: __entry[__key],
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
+      } catch {}
+    }
+  };
   const __slot = "__piNotebookRebind_" + crypto.randomUUID().replaceAll("-", "");
   const __assign = (__name, __value) => {
     globalThis[__slot] = __value;
@@ -156,8 +206,10 @@ export function projectStateRestoreSource(
   for (const __restore of __restores) {
     if (__current.has(__restore.name)) {
       if (!__matches(__current.get(__restore.name), __restore)) __assign(__restore.name, __restore.value);
+      __applyMetadata(globalThis[__restore.name], __restore);
       continue;
     }
+    __applyMetadata(__restore.value, __restore);
     Object.defineProperty(globalThis, __restore.name, {
       value: __restore.value,
       writable: true,

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { NotebookRuntimeOptions } from "../code-mode/shared-runtime.ts";
 import type { NotebookBridgeServer } from "./bridge-server.ts";
@@ -9,7 +10,7 @@ import {
 import { ensureNotebookDenoBinary } from "./deno-binary.ts";
 import { initializeNotebookJournal, type NotebookJournal } from "./journal.ts";
 import { DenoJupyterKernel } from "./jupyter-kernel.ts";
-import { notebookBootstrapSource } from "./kernel-runtime.ts";
+import { notebookBootstrapSource, notebookExampleSource } from "./kernel-runtime.ts";
 import { formatNotebookNpmImportsNotice, readNotebookNpmImports } from "./npm-imports.ts";
 import {
 	formatProjectStateNotice,
@@ -98,9 +99,14 @@ export async function startNotebookSession(options: {
 				profileNotice = `Notebook profile ${runtime.profile} was not loaded: ${error instanceof Error ? error.message : String(error)}`;
 			}
 		}
+		const exampleNames = await installNotebookExamples(kernel, signal);
+		for (const name of exampleNames) baselineNames.add(name);
 		garbageCollectSupersededNotebookCheckpoints(checkpointIdentity);
 		const npmNotice = formatNotebookNpmImportsNotice(readNotebookNpmImports(checkpointIdentity));
-		const restoreNotice = [npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
+		const exampleNotice = exampleNames.length === 2
+			? "Notebook example foo/bar available; inspect foo.description, foo.usage, bar.description, and bar.usage before constructing a reusable global"
+			: undefined;
+		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
 		return {
 			kernel,
 			journal,
@@ -114,5 +120,25 @@ export async function startNotebookSession(options: {
 		await kernel.shutdown().catch(() => undefined);
 		await bridge.shutdown().catch(() => undefined);
 		throw error;
+	}
+}
+
+async function installNotebookExamples(kernel: DenoJupyterKernel, signal?: AbortSignal): Promise<string[]> {
+	const marker = `__PI_NOTEBOOK_EXAMPLES_${randomUUID()}__`;
+	signal?.throwIfAborted();
+	try {
+		const names = new Set(await kernel.complete("", 0, signal));
+		const result = await kernel.execute(notebookExampleSource(marker, names.has("foo") || names.has("bar")), { signal });
+		if (result.status !== "ok") return [];
+		const output = result.items.filter(({ type }) => type === "input_text").map(({ text }) => text ?? "").join("");
+		const start = output.indexOf(marker);
+		if (start === -1) return [];
+		const value = JSON.parse(output.slice(start + marker.length).split("\n", 1)[0]!) as unknown;
+		return Array.isArray(value) && value.every((name) => name === "foo" || name === "bar")
+			? [...new Set(value)]
+			: [];
+	} catch {
+		signal?.throwIfAborted();
+		return [];
 	}
 }

--- a/packages/pi-codex-conversion/tests/notebook-example.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-example.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCodexSystemPrompt } from "../src/prompt/build-system-prompt.ts";
+import { notebookExampleSource } from "../src/tools/notebook-mode/kernel-runtime.ts";
+
+test("Notebook system guidance treats retained globals as self-describing mini-tools", () => {
+	const prompt = buildCodexSystemPrompt("Guidelines:\n\nCurrent date: 2026-01-01", { mode: "notebook" });
+	assert.match(prompt, /Treat retained globals as mini-tools: check notebook status description\/usage before rebuilding/);
+	assert.match(prompt, /inspect other globals' description\/usage before constructing reusable ones; give helpers concise own description\/usage with a safe inspection recipe and simple one-shot call shape/);
+});
+
+test("Notebook seeds expose a self-describing foo/bar example and skip conflicts", async () => {
+	const previousFoo = Object.getOwnPropertyDescriptor(globalThis, "foo");
+	const previousBar = Object.getOwnPropertyDescriptor(globalThis, "bar");
+	const restore = (name: "foo" | "bar", descriptor: PropertyDescriptor | undefined) => {
+		if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+		else delete (globalThis as Record<string, unknown>)[name];
+	};
+	try {
+		delete (globalThis as Record<string, unknown>)["foo"];
+		delete (globalThis as Record<string, unknown>)["bar"];
+		let output = "";
+		const run = new Function("console", `return (async () => ${notebookExampleSource("EXAMPLE")})()`);
+		await run({ log(value: string) { output += value; } });
+		const foo = (globalThis as Record<string, unknown>)["foo"] as { description: string; usage: string }[] & { description: string; usage: string };
+		const bar = (globalThis as Record<string, unknown>)["bar"] as { description: string; usage: string } & ((item: unknown) => unknown);
+		assert.equal(foo.description, "Example records for reusable helper patterns");
+		assert.match(foo.usage, /^Inspect:/);
+		assert.equal(bar.description, "Summarize one foo item without mutating foo");
+		assert.match(bar.usage, /Run: bar\(foo\[index\]\)/);
+		assert.deepEqual(bar(foo[0]), { id: "alpha", value: "first example record" });
+		assert.equal(output, 'EXAMPLE["foo","bar"]');
+
+		delete (globalThis as Record<string, unknown>)["foo"];
+		delete (globalThis as Record<string, unknown>)["bar"];
+		output = "";
+		const runOccupied = new Function("console", `return (async () => ${notebookExampleSource("EXAMPLE", true)})()`);
+		await runOccupied({ log(value: string) { output += value; } });
+		assert.equal((globalThis as Record<string, unknown>)["foo"], undefined);
+		assert.equal((globalThis as Record<string, unknown>)["bar"], undefined);
+		assert.equal(output, "EXAMPLE[]");
+	} finally {
+		restore("foo", previousFoo);
+		restore("bar", previousBar);
+	}
+});

--- a/packages/pi-codex-conversion/tests/notebook-example.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-example.test.ts
@@ -1,13 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildCodexSystemPrompt } from "../src/prompt/build-system-prompt.ts";
 import { notebookExampleSource } from "../src/tools/notebook-mode/kernel-runtime.ts";
-
-test("Notebook system guidance treats retained globals as self-describing mini-tools", () => {
-	const prompt = buildCodexSystemPrompt("Guidelines:\n\nCurrent date: 2026-01-01", { mode: "notebook" });
-	assert.match(prompt, /Treat retained globals as mini-tools: check notebook status description\/usage before rebuilding/);
-	assert.match(prompt, /inspect other globals' description\/usage before constructing reusable ones; give helpers concise own description\/usage with a safe inspection recipe and simple one-shot call shape/);
-});
 
 test("Notebook seeds expose a self-describing foo/bar example and skip conflicts", async () => {
 	const previousFoo = Object.getOwnPropertyDescriptor(globalThis, "foo");

--- a/packages/pi-codex-conversion/tests/notebook-project-metadata.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-project-metadata.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { formatStatus, type NotebookStatusDetails } from "../src/tools/notebook-mode/lifecycle-result.ts";
+import { projectStateCaptureSource, projectStateRestoreSource } from "../src/tools/notebook-mode/project-state-runtime.ts";
+
+test("durable binding metadata ignores getters, survives restore, and is shown by status", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-notebook-project-metadata-"));
+	let getterCalls = 0;
+	let payload = Buffer.alloc(0);
+	let candidate: { deno: string; v8: string; entries: Array<Record<string, unknown>> } | undefined;
+	function helper() {
+		throw new Error("helper should not run during discovery");
+	}
+	Object.defineProperty(helper, "description", {
+		get() {
+			getterCalls += 1;
+			throw new Error("description getter invoked");
+		},
+	});
+	Object.defineProperty(helper, "usage", { value: 'await helper("check")' });
+	const captureDeno = {
+		version: { deno: "2.9.5", v8: "test" },
+		async open() {
+			return {
+				async write(bytes: Uint8Array) {
+					payload = Buffer.concat([payload, Buffer.from(bytes)]);
+					return bytes.byteLength;
+				},
+				close() {},
+			};
+		},
+		async writeTextFile(_path: string, text: string) {
+			candidate = JSON.parse(text) as typeof candidate;
+		},
+	};
+	try {
+		const capture = new Function("Deno", "probe", `return (async () => ${projectStateCaptureSource({
+			candidates: ["probe"],
+			payloadPath: join(root, "candidate.bin"),
+			manifestPath: join(root, "candidate.json"),
+			maxBytes: 8 * 1024 * 1024,
+		})})()`);
+		await capture(captureDeno, helper);
+		assert.equal(getterCalls, 0);
+		assert.deepEqual(candidate?.entries[0], {
+			name: "probe",
+			kind: "function",
+			offset: 0,
+			length: payload.length,
+			usage: 'await helper("check")',
+		});
+
+		const entry = { ...candidate!.entries[0], hash: createHash("sha256").update(payload).digest("hex") };
+		const previousProbe = Object.getOwnPropertyDescriptor(globalThis, "probe");
+		const previousNotebook = Object.getOwnPropertyDescriptor(globalThis, "__piNotebook");
+		try {
+			Object.defineProperty(globalThis, "__piNotebook", { value: { syncProjectBindings() {} }, configurable: true });
+			const restore = new Function("Deno", "crypto", `return (async () => ${projectStateRestoreSource({
+				deno: "2.9.5",
+				v8: "test",
+				entries: [entry as never],
+			}, join(root, "candidate.bin"))})()`);
+			await restore({ version: { deno: "2.9.5", v8: "test" }, async readFile() { return payload; } }, { randomUUID });
+			const restored = (globalThis as Record<string, unknown>)["probe"] as { usage?: string; description?: string };
+			assert.equal(restored.usage, 'await helper("check")');
+			assert.equal(restored.description, undefined);
+		} finally {
+			if (previousProbe) Object.defineProperty(globalThis, "probe", previousProbe);
+			else delete (globalThis as Record<string, unknown>)["probe"];
+			if (previousNotebook) Object.defineProperty(globalThis, "__piNotebook", previousNotebook);
+			else delete (globalThis as Record<string, unknown>)["__piNotebook"];
+		}
+
+		const details: NotebookStatusDetails = {
+			state: "idle",
+			userCells: 0,
+			checkpoint: {},
+			retainedBindings: 1,
+			retainedBytes: payload.length,
+			pinnedBindings: 1,
+			pinned: [{ name: "probe", kind: "function", bytes: payload.length, updatedAt: new Date().toISOString(), pinned: true, usage: 'await helper("check")' }],
+			omittedPinned: 0,
+			largestUnpinned: [],
+			omittedLargestUnpinned: 0,
+		};
+		assert.match(formatStatus(details), /probe: .*usage: await helper\("check"\)/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-codex-conversion/tests/notebook-project-state.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-project-state.test.ts
@@ -97,6 +97,21 @@ test("project notebook merge preserves a concurrent same-name edit", () => {
 	assert.equal(repeated.payload.toString(), "current");
 });
 
+test("project notebook merge treats metadata edits as concurrent changes", () => {
+	const payload = Buffer.from("same");
+	const merged = mergeProjectState({
+		baseline: { generation: "base-generation", entries: [{ name: "shared", hash: hash(payload), description: "base" }] },
+		current: projectManifest("current-generation", payload, false, { description: "current" }),
+		candidate: projectCandidate(payload, "function", { description: "candidate" }),
+		candidatePayload: payload,
+		currentPayload: payload,
+	});
+
+	assert.deepEqual(merged.conflicts, ["shared"]);
+	assert.equal(merged.payload.toString(), "same");
+	assert.equal(merged.entries[0]?.description, "current");
+});
+
 test("project notebook merge applies an uncontested plain global", () => {
 	const previous = Buffer.from("previous");
 	const payload = Buffer.from("value");
@@ -126,16 +141,16 @@ test("stale session recovery cannot overwrite a newer project generation", () =>
 	assert.deepEqual([...sessionCheckpointProjectExclusions({ projectGeneration: "new" }, project)], []);
 });
 
-function projectCandidate(payload: Buffer, kind: "value" | "function" = "function"): ProjectStateCandidate {
+function projectCandidate(payload: Buffer, kind: "value" | "function" = "function", metadata: { description?: string; usage?: string } = {}): ProjectStateCandidate {
 	return {
 		deno: "2.9.5",
 		v8: "test",
-		entries: [{ name: "shared", kind, offset: 0, length: payload.length }],
+		entries: [{ name: "shared", kind, offset: 0, length: payload.length, ...metadata }],
 		skipped: [],
 	};
 }
 
-function projectManifest(generation: string, payload: Buffer, pinned = false): ProjectStateManifest {
+function projectManifest(generation: string, payload: Buffer, pinned = false, metadata: { description?: string; usage?: string } = {}): ProjectStateManifest {
 	return {
 		schema: 1,
 		project: "/project",
@@ -151,6 +166,7 @@ function projectManifest(generation: string, payload: Buffer, pinned = false): P
 			offset: 0,
 			length: payload.length,
 			hash: hash(payload),
+			...metadata,
 			...(pinned ? { pinned: true } : {}),
 		}],
 		skipped: [],


### PR DESCRIPTION
This PR makes durable Notebook globals self-describing without evaluating them.

Part of #325.

Closes #306.

## Summary

- persist bounded optional description and usage metadata with retained bindings
- expose metadata through Notebook status while preserving existing manifests
- keep getters and full function source out of status discovery
- teach agents to reuse cheap unpinned globals as scratch and reserve pinning for prune-resistant state

## Validation

- focused tests and typecheck passed
- cumulative `bun run check:changed`

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`

