### PR TITLE
Expose apply_patch display renderers

### DIFF
--- a/.changeset/apply-patch-renderers-303.md
+++ b/.changeset/apply-patch-renderers-303.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Expose `createApplyPatchTool` and an `apply-patch-display` integration API for custom patch views without changing the agent-facing `apply_patch` execution contract

--- a/packages/pi-codex-conversion/package.json
+++ b/packages/pi-codex-conversion/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/code-mode-preflight.d.ts",
       "import": "./dist/code-mode-preflight.js"
     },
+    "./apply-patch-display": {
+      "types": "./dist/apply-patch-display.d.ts",
+      "import": "./dist/apply-patch-display.js"
+    },
     "./realtime-voice": {
       "types": "./dist/realtime-voice.d.ts",
       "import": "./dist/realtime-voice.js"

--- a/packages/pi-codex-conversion/src/apply-patch-display.ts
+++ b/packages/pi-codex-conversion/src/apply-patch-display.ts
@@ -1,0 +1,74 @@
+import type {
+	EntryRenderer,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import {
+	APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+	APPLY_PATCH_DISPLAY_PROTOCOL,
+	APPLY_PATCH_DISPLAY_REQUEST_CHANNEL,
+	type ApplyPatchDisplayBroker,
+	isApplyPatchDisplayBroker,
+} from "./tools/apply-patch/display-protocol.js";
+import type { ApplyPatchToolDetails } from "./tools/apply-patch/render-state.js";
+
+export interface ApplyPatchDisplayData {
+	toolCallId: string;
+	input: string;
+	details?: ApplyPatchToolDetails | undefined;
+	content?: string | undefined;
+	error?: string | undefined;
+	isError: boolean;
+	source: "direct" | "nested";
+}
+
+export interface ApplyPatchDisplayOptions {
+	customType: string;
+	render: EntryRenderer<ApplyPatchDisplayData>;
+}
+
+export interface ApplyPatchDisplayRegistration {
+	readonly available: boolean;
+	dispose(): void;
+}
+
+export function registerApplyPatchDisplay(
+	pi: ExtensionAPI,
+	options: ApplyPatchDisplayOptions,
+): ApplyPatchDisplayRegistration {
+	const customType = options.customType.trim();
+	if (!customType)
+		throw new Error("apply_patch display customType cannot be empty");
+	pi.registerEntryRenderer(customType, options.render);
+
+	let broker: ApplyPatchDisplayBroker | undefined;
+	let unregisterDisplay: (() => void) | undefined;
+	let disposed = false;
+	const unregisterAvailable = pi.events.on(
+		APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+		(value) => {
+			if (disposed || !isApplyPatchDisplayBroker(value) || value === broker)
+				return;
+			unregisterDisplay?.();
+			broker = value;
+			unregisterDisplay = value.register(customType);
+		},
+	);
+	const registration: ApplyPatchDisplayRegistration = {
+		get available() {
+			return !disposed && (broker?.isActive() ?? false);
+		},
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			unregisterAvailable();
+			unregisterDisplay?.();
+			unregisterDisplay = undefined;
+			broker = undefined;
+		},
+	};
+	pi.on("session_shutdown", () => registration.dispose());
+	pi.events.emit(APPLY_PATCH_DISPLAY_REQUEST_CHANNEL, {
+		protocol: APPLY_PATCH_DISPLAY_PROTOCOL,
+	});
+	return registration;
+}

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerCodeModeProxyProvider } from "../providers/code-mode-proxy-provider.ts";
 import { registerOpenAICodexCustomProvider } from "../providers/openai-codex-custom-provider.ts";
+import { registerApplyPatchDisplayBroker } from "../tools/apply-patch/display-broker.ts";
 import { registerCodexCommand } from "../ui/settings/command.ts";
 import { registerCodexCodeMode } from "../adapter/code-mode.ts";
 import { prepareCodeModeHost, registerCanonicalAliasEndpointPreflight, registerCodexEvents } from "./events.ts";
@@ -13,6 +14,7 @@ import { captureActiveProviderSystemPrompt } from "../adapter/provider-request.t
 
 export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 	registerCodexVoiceRenderer(pi);
+	registerApplyPatchDisplayBroker(pi);
 	const runtime = createCodexExtensionRuntime(pi);
 	registerCanonicalAliasEndpointPreflight(pi, runtime);
 	const codeMode = await registerCodexCodeMode(pi, runtime);

--- a/packages/pi-codex-conversion/src/index.ts
+++ b/packages/pi-codex-conversion/src/index.ts
@@ -7,4 +7,18 @@ export default async function codexConversion(pi: ExtensionAPI): Promise<void> {
 	await registerCodexConversion(pi);
 }
 
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchRenderCall,
+	ApplyPatchRenderResult,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+	ApplyPatchToolOptions,
+	ExecutePatchResult,
+} from "./tools/apply-patch/tool.ts";
+export {
+	createApplyPatchTool,
+	isApplyPatchToolDetails,
+	registerApplyPatchResultEvent,
+} from "./tools/apply-patch/tool.ts";
 export { getCodexSkillPaths, mergeAdapterTools, restoreTools, stripAdapterTools };

--- a/packages/pi-codex-conversion/src/tools/apply-patch/display-broker.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/display-broker.ts
@@ -1,0 +1,311 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ApplyPatchDisplayData } from "../../apply-patch-display.js";
+import {
+	APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+	APPLY_PATCH_DISPLAY_PROTOCOL,
+	APPLY_PATCH_DISPLAY_REQUEST_CHANNEL,
+	type ApplyPatchDisplayBroker,
+	isApplyPatchDisplayRequest,
+} from "./display-protocol.js";
+import {
+	type ApplyPatchToolDetails,
+	isApplyPatchToolDetails,
+} from "./render-state.js";
+
+interface ApplyPatchDisplayEvent {
+	toolName: string;
+	toolCallId: string;
+	input: unknown;
+	content: unknown;
+	details: unknown;
+	isError: boolean;
+}
+
+interface NestedTrace {
+	id?: unknown;
+	name?: unknown;
+	input?: unknown;
+	status?: unknown;
+	result?: unknown;
+	error?: unknown;
+}
+
+interface CapturedApplyPatchCall {
+	input: string;
+	content?: string | undefined;
+	details?: ApplyPatchToolDetails | undefined;
+	error?: string | undefined;
+	isError?: boolean | undefined;
+}
+
+export interface CapturedApplyPatchOutcome {
+	content?: string | undefined;
+	details?: ApplyPatchToolDetails | undefined;
+	error?: string | undefined;
+	isError: boolean;
+}
+
+const MAX_DISPLAY_IDS = 256;
+
+interface ActiveApplyPatchDisplay {
+	shouldCompact(toolCallId?: string, executionStarted?: boolean): boolean;
+	recordInput(toolCallId: string, input: string): void;
+	recordOutcome(toolCallId: string, outcome: CapturedApplyPatchOutcome): void;
+}
+
+let activeDisplay: ActiveApplyPatchDisplay | undefined;
+
+export function shouldCompactApplyPatchDisplay(
+	toolCallId?: string,
+	executionStarted?: boolean,
+): boolean {
+	return activeDisplay?.shouldCompact(toolCallId, executionStarted) ?? false;
+}
+
+export function recordApplyPatchDisplayInput(
+	toolCallId: string,
+	input: string,
+): void {
+	activeDisplay?.recordInput(toolCallId, input);
+}
+
+export function recordApplyPatchDisplayOutcome(
+	toolCallId: string,
+	outcome: CapturedApplyPatchOutcome,
+): void {
+	activeDisplay?.recordOutcome(toolCallId, outcome);
+}
+
+export function registerApplyPatchDisplayBroker(pi: ExtensionAPI): void {
+	const registrations = new Map<string, number>();
+	const captured = new Map<string, CapturedApplyPatchCall>();
+	const pending = new Map<string, ApplyPatchDisplayData>();
+	const emitted = new Set<string>();
+	const activeCalls = new Set<string>();
+	const displayedCalls = new Set<string>();
+	let active = true;
+
+	const broker: ApplyPatchDisplayBroker = {
+		protocol: APPLY_PATCH_DISPLAY_PROTOCOL,
+		isActive: () => active,
+		register(customType) {
+			if (!active) return () => {};
+			registrations.set(customType, (registrations.get(customType) ?? 0) + 1);
+			return () => {
+				const count = registrations.get(customType) ?? 0;
+				if (count <= 1) registrations.delete(customType);
+				else registrations.set(customType, count - 1);
+			};
+		},
+	};
+	const controller: ActiveApplyPatchDisplay = {
+		shouldCompact(toolCallId, executionStarted) {
+			if (!active || !toolCallId) return false;
+			if (displayedCalls.has(toolCallId)) return true;
+			if (registrations.size === 0) return false;
+			if (executionStarted === false) return false;
+			return activeCalls.has(toolCallId);
+		},
+		recordInput(toolCallId, input) {
+			if (!active || registrations.size === 0) return;
+			activeCalls.add(toolCallId);
+			captured.set(toolCallId, { ...captured.get(toolCallId), input });
+			boundMap(captured);
+		},
+		recordOutcome(toolCallId, outcome) {
+			if (!active || registrations.size === 0) return;
+			activeCalls.add(toolCallId);
+			const call = captured.get(toolCallId);
+			if (!call) return;
+			captured.set(toolCallId, { ...call, ...outcome });
+		},
+	};
+	activeDisplay = controller;
+
+	const announce = () => {
+		if (active) pi.events.emit(APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL, broker);
+	};
+	pi.events.on(APPLY_PATCH_DISPLAY_REQUEST_CHANNEL, (value) => {
+		if (isApplyPatchDisplayRequest(value)) announce();
+	});
+	pi.on("tool_execution_start", (event) => {
+		if (event.toolName === "apply_patch" && active && registrations.size > 0)
+			activeCalls.add(event.toolCallId);
+	});
+	pi.on("tool_result", (event) => {
+		if (!active || registrations.size === 0) return undefined;
+		for (const data of collectApplyPatchDisplayData(event, captured)) {
+			if (!emitted.has(data.toolCallId)) pending.set(data.toolCallId, data);
+		}
+		return undefined;
+	});
+	pi.on("turn_end", () => {
+		for (const [toolCallId, data] of pending) {
+			let appended = false;
+			for (const customType of registrations.keys()) {
+				pi.appendEntry(customType, data);
+				appended = true;
+			}
+			if (appended) {
+				emitted.add(toolCallId);
+				boundSet(emitted);
+				displayedCalls.add(toolCallId);
+			}
+			captured.delete(toolCallId);
+		}
+		pending.clear();
+		activeCalls.clear();
+	});
+	pi.on("session_start", (_event, ctx) => {
+		for (const entry of ctx.sessionManager.getEntries()) {
+			if (
+				entry.type !== "custom" ||
+				!registrations.has(entry.customType) ||
+				!entry.data ||
+				typeof entry.data !== "object" ||
+				typeof (entry.data as { toolCallId?: unknown }).toolCallId !== "string"
+			)
+				continue;
+			displayedCalls.add((entry.data as { toolCallId: string }).toolCallId);
+		}
+	});
+	pi.on("session_before_switch", () => {
+		captured.clear();
+		pending.clear();
+		emitted.clear();
+		activeCalls.clear();
+		displayedCalls.clear();
+	});
+	pi.on("session_shutdown", () => {
+		active = false;
+		registrations.clear();
+		captured.clear();
+		pending.clear();
+		emitted.clear();
+		activeCalls.clear();
+		displayedCalls.clear();
+		if (activeDisplay === controller) activeDisplay = undefined;
+	});
+	announce();
+}
+
+function collectApplyPatchDisplayData(
+	event: ApplyPatchDisplayEvent,
+	captured: Map<string, CapturedApplyPatchCall>,
+): ApplyPatchDisplayData[] {
+	if (event.toolName === "apply_patch") {
+		const input = patchInput(event.input);
+		if (input === undefined) return [];
+		const text = textContent(event.content);
+		const isError = event.isError || isPartialFailure(event.details);
+		return [
+			{
+				toolCallId: event.toolCallId,
+				input,
+				...(isApplyPatchToolDetails(event.details)
+					? { details: event.details }
+					: {}),
+				...text,
+				...(isError && text.content ? { error: text.content } : {}),
+				isError,
+				source: "direct",
+			},
+		];
+	}
+
+	if (event.toolName !== "exec" && event.toolName !== "wait") return [];
+	return nestedTraces(event.details).flatMap((trace) => {
+		if (
+			trace.name !== "apply_patch" ||
+			trace.status === "running" ||
+			typeof trace.id !== "string"
+		)
+			return [];
+		const call = captured.get(trace.id);
+		const input = call?.input ?? patchInput(trace.input);
+		if (input === undefined) return [];
+		const result = trace.result;
+		const traceDetails =
+			result && typeof result === "object" && "details" in result
+				? (result as { details?: unknown }).details
+				: undefined;
+		const traceContent =
+			result && typeof result === "object" && "content" in result
+				? textContent((result as { content?: unknown }).content).content
+				: undefined;
+		const details = isApplyPatchToolDetails(traceDetails)
+			? traceDetails
+			: call?.details;
+		const content = traceContent ?? call?.content;
+		const error =
+			call?.error ??
+			(typeof trace.error === "string" ? trace.error : undefined);
+		return [
+			{
+				toolCallId: trace.id,
+				input,
+				...(details ? { details } : {}),
+				...(content ? { content } : {}),
+				...(error ? { error } : {}),
+				isError:
+					trace.status === "error" ||
+					call?.isError === true ||
+					isPartialFailure(details),
+				source: "nested",
+			},
+		];
+	});
+}
+
+function isPartialFailure(value: unknown): boolean {
+	return isApplyPatchToolDetails(value) && value.status === "partial_failure";
+}
+
+function nestedTraces(details: unknown): NestedTrace[] {
+	if (!details || typeof details !== "object" || !("traces" in details))
+		return [];
+	const traces = (details as { traces?: unknown }).traces;
+	return Array.isArray(traces)
+		? traces.filter((trace): trace is NestedTrace =>
+				Boolean(trace && typeof trace === "object"),
+			)
+		: [];
+}
+
+function patchInput(input: unknown): string | undefined {
+	if (typeof input === "string") return input;
+	if (!input || typeof input !== "object") return undefined;
+	for (const key of ["input", "patchText", "patch"]) {
+		const value = (input as Record<string, unknown>)[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+function textContent(content: unknown): { content?: string | undefined } {
+	if (!Array.isArray(content)) return {};
+	const text = content
+		.filter((item): item is { type: "text"; text: string } =>
+			Boolean(
+				item &&
+					typeof item === "object" &&
+					(item as { type?: unknown }).type === "text" &&
+					typeof (item as { text?: unknown }).text === "string",
+			),
+		)
+		.map((item) => item.text)
+		.join("\n");
+	return text ? { content: text } : {};
+}
+
+function boundMap(map: Map<string, unknown>): void {
+	if (map.size <= MAX_DISPLAY_IDS) return;
+	const oldest = map.keys().next().value;
+	if (typeof oldest === "string") map.delete(oldest);
+}
+
+function boundSet(set: Set<string>): void {
+	if (set.size <= MAX_DISPLAY_IDS) return;
+	const oldest = set.values().next().value;
+	if (typeof oldest === "string") set.delete(oldest);
+}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/display-protocol.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/display-protocol.ts
@@ -1,0 +1,34 @@
+export const APPLY_PATCH_DISPLAY_PROTOCOL =
+	"@howaboua/pi-codex-conversion/apply-patch-display/v1";
+export const APPLY_PATCH_DISPLAY_REQUEST_CHANNEL = `${APPLY_PATCH_DISPLAY_PROTOCOL}/request`;
+export const APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL = `${APPLY_PATCH_DISPLAY_PROTOCOL}/available`;
+
+export interface ApplyPatchDisplayBroker {
+	protocol: typeof APPLY_PATCH_DISPLAY_PROTOCOL;
+	isActive(): boolean;
+	register(customType: string): () => void;
+}
+
+export function isApplyPatchDisplayRequest(value: unknown): boolean {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"protocol" in value &&
+			value.protocol === APPLY_PATCH_DISPLAY_PROTOCOL,
+	);
+}
+
+export function isApplyPatchDisplayBroker(
+	value: unknown,
+): value is ApplyPatchDisplayBroker {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"protocol" in value &&
+			value.protocol === APPLY_PATCH_DISPLAY_PROTOCOL &&
+			"isActive" in value &&
+			typeof value.isActive === "function" &&
+			"register" in value &&
+			typeof value.register === "function",
+	);
+}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/render-state.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/render-state.ts
@@ -27,7 +27,30 @@ export type ApplyPatchToolDetails = ApplyPatchSuccessDetails | ApplyPatchPartial
 const applyPatchRenderStates = new Map<string, ApplyPatchRenderState>();
 
 export function isApplyPatchToolDetails(details: unknown): details is ApplyPatchToolDetails {
-	return typeof details === "object" && details !== null && "status" in details && "result" in details;
+	if (!details || typeof details !== "object") return false;
+	const record = details as Record<string, unknown>;
+	if (record["status"] !== "success" && record["status"] !== "partial_failure") return false;
+	const result = record["result"];
+	if (!result || typeof result !== "object") return false;
+	const patchResult = result as Record<string, unknown>;
+	if (
+		!isStringArray(patchResult["changedFiles"]) ||
+		!isStringArray(patchResult["createdFiles"]) ||
+		!isStringArray(patchResult["deletedFiles"]) ||
+		!isStringArray(patchResult["movedFiles"]) ||
+		typeof patchResult["fuzz"] !== "number" ||
+		!Number.isFinite(patchResult["fuzz"])
+	)
+		return false;
+	return (
+		record["status"] === "success" ||
+		record["failedTargets"] === undefined ||
+		isStringArray(record["failedTargets"])
+	);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 export function clearApplyPatchRenderState(): void {

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -1,19 +1,24 @@
 import { Type } from "typebox";
-import { type ExtensionAPI, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, type ToolDefinition, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { parsePatchActions } from "../../patch/parser.ts";
 import { resolvePatchPath } from "../../patch/paths.ts";
 import { ExecutePatchError, type ExecutePatchResult } from "../../patch/types.ts";
 import { getExperimentalToolSampling } from "../tool-sampling.ts";
+import {
+	recordApplyPatchDisplayInput,
+	recordApplyPatchDisplayOutcome,
+	shouldCompactApplyPatchDisplay,
+} from "./display-broker.ts";
 import { formatPatchTarget } from "./rendering.ts";
 import { executePatchWithRust } from "./executor.ts";
 import {
-	clearApplyPatchRenderState,
 	isApplyPatchToolDetails,
 	markApplyPatchFailure,
 	markApplyPatchPartialFailure,
 	renderApplyPatchCallFromState,
 	setApplyPatchRenderState,
+	type ApplyPatchToolDetails,
 	type ApplyPatchPartialFailureDetails,
 	type ApplyPatchSuccessDetails,
 } from "./render-state.ts";
@@ -27,14 +32,22 @@ const APPLY_PATCH_PARAMETERS = Type.Object({
 interface ApplyPatchRenderContextLike {
 	toolCallId?: string | undefined;
 	cwd?: string | undefined;
+	executionStarted?: boolean | undefined;
 	expanded?: boolean | undefined;
 	argsComplete?: boolean | undefined;
 }
 
-interface ApplyPatchToolOptions {
+type ApplyPatchToolDefinition = ToolDefinition<typeof APPLY_PATCH_PARAMETERS, ApplyPatchToolDetails>;
+
+export type ApplyPatchRenderCall = NonNullable<ApplyPatchToolDefinition["renderCall"]>;
+export type ApplyPatchRenderResult = NonNullable<ApplyPatchToolDefinition["renderResult"]>;
+
+export interface ApplyPatchToolOptions {
 	customRustBinariesDir?: string | undefined;
 	promptSnippet?: boolean | undefined;
 	showDiffWhenCollapsed?: boolean | undefined;
+	renderCall?: ApplyPatchRenderCall | undefined;
+	renderResult?: ApplyPatchRenderResult | undefined;
 }
 
 function parseApplyPatchParams(params: unknown): { patchText: string } {
@@ -133,7 +146,12 @@ function describeFailedActions(error: ExecutePatchError, cwd: string): string[] 
 }
 
 export type { ExecutePatchResult } from "../../patch/types.ts";
-export { clearApplyPatchRenderState };
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+} from "./render-state.ts";
+export { clearApplyPatchRenderState, isApplyPatchToolDetails } from "./render-state.ts";
 
 const renderApplyPatchCallWithOptionalContext = (
 	args: { input?: unknown | undefined },
@@ -142,8 +160,30 @@ const renderApplyPatchCallWithOptionalContext = (
 	options: ApplyPatchToolOptions = {},
 ) => new Text(renderApplyPatchCallFromState(args, theme, { ...context, showCollapsedDiff: options.showDiffWhenCollapsed }), 0, 0);
 
-export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
+function renderCompactApplyPatchCall(theme: { fg(role: string, text: string): string; bold(text: string): string }): Text {
+	return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
+}
+
+export function createApplyPatchTool(options: ApplyPatchToolOptions = {}): ApplyPatchToolDefinition {
 	const constrainedSampling = getExperimentalToolSampling("apply_patch");
+	const compactRendering = (context?: ApplyPatchRenderContextLike) => shouldCompactApplyPatchDisplay(context?.toolCallId, context?.executionStarted);
+	const defaultRenderCall: ApplyPatchRenderCall = (args, theme, context) =>
+		compactRendering(context) ? renderCompactApplyPatchCall(theme) : renderApplyPatchCallWithOptionalContext(args, theme, context, options);
+	const defaultRenderResult: ApplyPatchRenderResult = (result, { isPartial }, theme, context) => {
+		if (compactRendering(context)) {
+			if (isPartial) return renderCompactApplyPatchCall(theme);
+			if (isApplyPatchToolDetails(result.details)) {
+				if (result.details.status === "partial_failure") return new Text(theme.fg("error", "• Patch partially failed"), 0, 0);
+				return new Text(theme.fg("dim", `• Applied patch (${summarizePatchCounts(result.details.result)})`), 0, 0);
+			}
+			if (context.isError) return new Text(theme.fg("error", "• Patch failed"), 0, 0);
+			return new Container();
+		}
+		if (isPartial) return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
+		if (!isApplyPatchToolDetails(result.details)) return new Container();
+		if (result.details.status === "partial_failure") return new Container();
+		return new Container();
+	};
 	return {
 		name: "apply_patch",
 		label: "apply_patch",
@@ -157,6 +197,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 			if (signal?.aborted) throw new Error("apply_patch aborted");
 
 			const typedParams = parseApplyPatchParams(params);
+			recordApplyPatchDisplayInput(toolCallId, typedParams.patchText);
 			setApplyPatchRenderState(toolCallId, typedParams.patchText, ctx.cwd);
 			let result: ExecutePatchResult;
 			try {
@@ -176,20 +217,35 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 						const appliedFiles = getAppliedPaths(error.result, failedFiles);
 						const recoveryMessage = buildPartialFailureMessage(rawMessage, failedFiles, appliedFiles);
 						markApplyPatchPartialFailure(toolCallId, failedTargets);
+						const details = {
+							status: "partial_failure",
+							result: error.result,
+							failedTargets,
+						} satisfies ApplyPatchPartialFailureDetails;
+						recordApplyPatchDisplayOutcome(toolCallId, {
+							content: recoveryMessage,
+							details,
+							error: recoveryMessage,
+							isError: true,
+						});
 						return {
 							content: [{ type: "text", text: recoveryMessage }],
-							details: {
-								status: "partial_failure",
-								result: error.result,
-								failedTargets,
-							} satisfies ApplyPatchPartialFailureDetails,
+							details,
 						};
 					}
 					const message = addContextRecovery(rawMessage, error.message, failedTargets);
 					markApplyPatchFailure(toolCallId, "failed", failedTargets);
+					recordApplyPatchDisplayOutcome(toolCallId, {
+						error: message,
+						isError: true,
+					});
 					throw new Error(message);
 				}
 				markApplyPatchFailure(toolCallId, "failed");
+				recordApplyPatchDisplayOutcome(toolCallId, {
+					error: error instanceof Error ? error.message : String(error),
+					isError: true,
+				});
 				throw error;
 			}
 			const summary = [
@@ -201,16 +257,17 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 				`Fuzz: ${result.fuzz}`,
 			].join("\n");
 
-			return { content: [{ type: "text", text: summary }], details: { status: "success", result } satisfies ApplyPatchSuccessDetails };
+			const details = { status: "success", result } satisfies ApplyPatchSuccessDetails;
+			recordApplyPatchDisplayOutcome(toolCallId, {
+				content: summary,
+				details,
+				isError: false,
+			});
+			return { content: [{ type: "text", text: summary }], details };
 		},
-		renderCall: ((args: { input?: unknown | undefined }, theme: { fg(role: string, text: string): string; bold(text: string): string }, context?: ApplyPatchRenderContextLike) => renderApplyPatchCallWithOptionalContext(args, theme, context, options)) as any,
-		renderResult(result, { isPartial }, theme) {
-			if (isPartial) return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
-			if (!isApplyPatchToolDetails(result.details)) return new Container();
-			if (result.details.status === "partial_failure") return new Container();
-			return new Container();
-		},
-	} satisfies Parameters<ExtensionAPI["registerTool"]>[0];
+		renderCall: options.renderCall ?? defaultRenderCall,
+		renderResult: options.renderResult ?? defaultRenderResult,
+	} satisfies ApplyPatchToolDefinition;
 }
 
 export function registerApplyPatchTool(pi: ExtensionAPI, options: ApplyPatchToolOptions = {}): void {

--- a/packages/pi-codex-conversion/src/tools/code-mode/delegate-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/delegate-runtime.ts
@@ -22,6 +22,7 @@ interface DelegateController {
 type SendMessage = (message: unknown) => void;
 
 export class CodeModeDelegateRuntime {
+	private readonly traceRuntimeGeneration = crypto.randomUUID();
 	private readonly cellContexts = new Map<string, ToolExecutionContext>();
 	private readonly cellTools = new Map<string, Map<string, CodeModeToolDefinition>>();
 	private readonly controllers = new Map<string, DelegateController>();
@@ -194,7 +195,12 @@ export class CodeModeDelegateRuntime {
 		const context = this.cellContexts.get(cellId);
 		if (!tool) throw new Error(`Unknown custom tool: ${toolName}`);
 		if (!context) throw new Error("Code-mode cell context is unavailable");
-		const trace = this.traces.start(cellId, traceId, tool.name, input);
+		const trace = this.traces.start(
+			cellId,
+			`${this.traceRuntimeGeneration}:${cellId}:${traceId}`,
+			tool.name,
+			input,
+		);
 		const invocationContext: ToolExecutionContext = {
 			...context,
 			toolCallId: trace.id,

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	createEventBus,
+	type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { registerApplyPatchDisplay } from "../src/apply-patch-display.ts";
+import {
+	recordApplyPatchDisplayInput,
+	recordApplyPatchDisplayOutcome,
+	registerApplyPatchDisplayBroker,
+	shouldCompactApplyPatchDisplay,
+} from "../src/tools/apply-patch/display-broker.ts";
+
+function displayExtensionApi(bus = createEventBus()) {
+	const handlers = new Map<string, Array<(event: never) => unknown>>();
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	let renderedType: string | undefined;
+	const pi = {
+		events: { emit: bus.emit, on: bus.on },
+		registerEntryRenderer(customType: string) {
+			renderedType = customType;
+		},
+		on(event: string, handler: (event: never) => unknown) {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push({ customType, data });
+		},
+	} as unknown as ExtensionAPI;
+	return {
+		pi,
+		entries,
+		get renderedType() {
+			return renderedType;
+		},
+		emit(event: string, value: unknown = {}) {
+			return (handlers.get(event) ?? []).map((handler) =>
+				handler(value as never),
+			);
+		},
+	};
+}
+
+test("apply_patch display protocol routes scoped entries after tool results", () => {
+	const bus = createEventBus();
+	const consumer = displayExtensionApi(bus);
+	const registration = registerApplyPatchDisplay(consumer.pi, {
+		customType: "test-apply-patch-display",
+		render: (() => undefined) as never,
+	});
+	assert.equal(registration.available, false);
+	assert.equal(consumer.renderedType, "test-apply-patch-display");
+	const conversion = displayExtensionApi(bus);
+	registerApplyPatchDisplayBroker(conversion.pi);
+	assert.equal(registration.available, true);
+
+	const details = {
+		status: "success" as const,
+		result: {
+			changedFiles: ["file.ts"],
+			createdFiles: [],
+			deletedFiles: [],
+			movedFiles: [],
+			fuzz: 0,
+		},
+	};
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "apply_patch",
+			toolCallId: "direct-1",
+			input: { input: "*** Begin Patch\n*** End Patch" },
+			content: [{ type: "text", text: "Applied direct" }],
+			details,
+			isError: false,
+		}),
+		[undefined],
+	);
+	const fullInput = `*** Begin Patch\n${"+full patch line\n".repeat(1_100)}*** End Patch`;
+	const partialDetails = {
+		...details,
+		status: "partial_failure" as const,
+		failedTargets: ["file.ts"],
+	};
+	recordApplyPatchDisplayInput("runtime-1:cell-1:tool-1", fullInput);
+	recordApplyPatchDisplayOutcome("runtime-1:cell-1:tool-1", {
+		content: "Earlier actions were applied",
+		details: partialDetails,
+		error: "Earlier actions were applied",
+		isError: true,
+	});
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "exec",
+			toolCallId: "exec-1",
+			input: {},
+			content: [],
+			details: {
+				codeMode: true,
+				traces: [
+					{
+						id: "runtime-1:cell-1:tool-1",
+						name: "apply_patch",
+						input: `${fullInput.slice(0, 16_000)}[value truncated]`,
+						status: "error",
+						error: "Earlier actions were applied",
+					},
+				],
+			},
+			isError: false,
+		}),
+		[undefined],
+	);
+	const secondNestedId = "runtime-1:cell-2:tool-1";
+	const secondNestedInput = "*** Begin Patch\nsecond\n*** End Patch";
+	recordApplyPatchDisplayInput(secondNestedId, secondNestedInput);
+	recordApplyPatchDisplayOutcome(secondNestedId, {
+		content: "Applied again",
+		details,
+		isError: false,
+	});
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "exec",
+			toolCallId: "exec-2",
+			input: {},
+			content: [],
+			details: {
+				codeMode: true,
+				traces: [
+					{
+						id: secondNestedId,
+						name: "apply_patch",
+						input: secondNestedInput,
+						status: "done",
+						result: {
+							content: [{ type: "text", text: "Applied again" }],
+							details,
+						},
+					},
+				],
+			},
+			isError: false,
+		}),
+		[undefined],
+	);
+
+	assert.deepEqual(conversion.entries, []);
+	conversion.emit("turn_end");
+	assert.deepEqual(conversion.entries, [
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: "direct-1",
+				input: "*** Begin Patch\n*** End Patch",
+				details,
+				content: "Applied direct",
+				isError: false,
+				source: "direct",
+			},
+		},
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: "runtime-1:cell-1:tool-1",
+				input: fullInput,
+				details: partialDetails,
+				content: "Earlier actions were applied",
+				error: "Earlier actions were applied",
+				isError: true,
+				source: "nested",
+			},
+		},
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: secondNestedId,
+				input: secondNestedInput,
+				details,
+				content: "Applied again",
+				isError: false,
+				source: "nested",
+			},
+		},
+	]);
+
+	conversion.emit("tool_result", {
+		toolName: "apply_patch",
+		toolCallId: "pending-1",
+		input: { input: "pending" },
+		content: [{ type: "text", text: "Pending" }],
+		details,
+		isError: false,
+	});
+	registration.dispose();
+	conversion.emit("turn_end");
+
+	const lateConsumer = displayExtensionApi(bus);
+	const lateRegistration = registerApplyPatchDisplay(lateConsumer.pi, {
+		customType: "late-apply-patch-display",
+		render: (() => undefined) as never,
+	});
+	assert.equal(lateRegistration.available, true);
+	assert.equal(shouldCompactApplyPatchDisplay("pending-1", true), false);
+	assert.equal(shouldCompactApplyPatchDisplay("direct-1", true), true);
+	lateRegistration.dispose();
+	conversion.emit("session_shutdown");
+	assert.equal(registration.available, false);
+});

--- a/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
+++ b/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
@@ -1,8 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import {
-	registerApplyPatchResultEvent,
-} from "../src/tools/apply-patch/tool.ts";
+import { registerApplyPatchResultEvent } from "../src/index.ts";
 import { toCodeModeToolResult } from "../src/tools/code-mode/tool-result.ts";
 
 test("apply_patch partial mutations remain error results", () => {
@@ -12,12 +10,19 @@ test("apply_patch partial mutations remain error results", () => {
 			if (event === "tool_result") handler = registered as typeof handler;
 		},
 	} as never);
+	const result = {
+		changedFiles: [],
+		createdFiles: [],
+		deletedFiles: [],
+		movedFiles: [],
+		fuzz: 0,
+	};
 
 	assert.deepEqual(handler?.({
 		toolName: "apply_patch",
-		details: { status: "partial_failure", result: {} },
+		details: { status: "partial_failure", result },
 	}), { isError: true });
-	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result: {} } }), undefined);
+	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result } }), undefined);
 });
 
 test("Notebook memory pressure is model-visible", () => {

--- a/packages/pi-codex-conversion/types/index.d.ts
+++ b/packages/pi-codex-conversion/types/index.d.ts
@@ -16,3 +16,18 @@ export function stripAdapterTools(
 	toolNames: string[],
 	adapterOwnedTools?: string[],
 ): string[];
+
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchRenderCall,
+	ApplyPatchRenderResult,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+	ApplyPatchToolOptions,
+	ExecutePatchResult,
+} from "../dist/tools/apply-patch/tool.js";
+export {
+	createApplyPatchTool,
+	isApplyPatchToolDetails,
+	registerApplyPatchResultEvent,
+} from "../dist/tools/apply-patch/tool.js";


### PR DESCRIPTION
This PR exposes replaceable apply_patch presentation while preserving the authoritative executor and model contract.

Part of #325.

Closes #303.

## Summary

- add a public apply-patch display integration seam with reload and load-order recovery
- preserve structured and nested execution results, errors, mutation ordering, and partial failures
- keep the apply_patch name, schema, and system guidance unchanged

## Validation

- package checks passed
- public installed-package typing smoke passed
- cumulative `bun run check:changed`
- Knip passed

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
