### PR TITLE
Invalidate stale background widget contexts

### DIFF
--- a/.changeset/stale-background-widget-ctx.md
+++ b/.changeset/stale-background-widget-ctx.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Prevent delayed background shell widget renders from using stale session contexts

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -191,12 +191,11 @@ export function registerCodexEvents(
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const failures: unknown[] = [];
+		await runShutdownStep(failures, () => ui.invalidateBackgroundWidget());
 		await runShutdownStep(failures, () => runtime.lanVoice.stop(ctx));
 		await runShutdownStep(failures, () => runtime.voice.stop({ announce: true }));
 		await runShutdownStep(failures, () => runtime.shutdownTransport(ctx.sessionManager.getSessionId()));
 		await runShutdownStep(failures, () => runtime.shutdownDiagnostics());
-		await runShutdownStep(failures, () => ui.clearBackgroundWidget());
-		runtime.backgroundWidget.ctx = undefined;
 		await runShutdownStep(failures, () => sessions.shutdown());
 		await runShutdownStep(failures, () => proxyProvider.shutdown());
 		await runShutdownStep(failures, () => codeMode.shutdown());

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -10,6 +10,7 @@ import { fetchCodexWeeklyUsageLeft } from "../codex-usage/client.ts";
 
 export interface CodexUiController {
 	clearBackgroundWidget(): void;
+	invalidateBackgroundWidget(): void;
 	renderBackgroundWidget(): void;
 	invalidateUsageStatus(): void;
 	applyConfig(config: CodexConversionConfig, ctx: ExtensionContext, previousConfig: CodexConversionConfig): void;
@@ -18,13 +19,25 @@ export interface CodexUiController {
 
 export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexUiController {
 	let renderTimer: ReturnType<typeof setTimeout> | undefined;
+	let backgroundWidgetGeneration = 0;
 	let usageGeneration = 0;
-	const clearBackgroundWidget = () => {
+	const cancelScheduledBackgroundRender = () => {
+		backgroundWidgetGeneration += 1;
 		if (renderTimer) clearTimeout(renderTimer);
 		renderTimer = undefined;
+	};
+	const clearBackgroundWidget = () => {
+		cancelScheduledBackgroundRender();
 		runtime.backgroundWidget.ctx?.ui.setWidget(BACKGROUND_BASH_WIDGET_ID, undefined);
 	};
-	const renderBackgroundWidget = () => {
+	const invalidateBackgroundWidget = () => {
+		cancelScheduledBackgroundRender();
+		const ctx = runtime.backgroundWidget.ctx;
+		runtime.backgroundWidget.ctx = undefined;
+		ctx?.ui.setWidget(BACKGROUND_BASH_WIDGET_ID, undefined);
+	};
+	const renderBackgroundWidget = (generation = backgroundWidgetGeneration) => {
+		if (generation !== backgroundWidgetGeneration) return;
 		const ctx = runtime.backgroundWidget.ctx;
 		if (!ctx) return;
 		if (runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.backgroundShellWidget) {
@@ -64,14 +77,14 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 		if (!runtime.backgroundWidget.ctx || runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.backgroundShellWidget) return;
 		if (reason === "output") {
 			if (renderTimer) return;
+			const generation = backgroundWidgetGeneration;
 			renderTimer = setTimeout(() => {
 				renderTimer = undefined;
-				renderBackgroundWidget();
+				renderBackgroundWidget(generation);
 			}, 250);
 			return;
 		}
-		if (renderTimer) clearTimeout(renderTimer);
-		renderTimer = undefined;
+		cancelScheduledBackgroundRender();
 		renderBackgroundWidget();
 	});
 	const invalidateUsageStatus = () => {
@@ -100,6 +113,7 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 
 	return {
 		clearBackgroundWidget,
+		invalidateBackgroundWidget,
 		renderBackgroundWidget,
 		invalidateUsageStatus,
 		refreshUsageStatus,


### PR DESCRIPTION
This PR prevents delayed Background Bash Widget renders from using an invalidated session context.

Part of #325.

Closes #309.

## Summary

- invalidate widget state before asynchronous session teardown
- prevent pending callbacks from rendering through the old context
- keep unrelated rendering failures visible

## Validation

- typecheck passed
- lifecycle and error-propagation probe passed
- cumulative `bun run check:changed`

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
