### PR TITLE
Capture final provider instructions for replay

### DIFF
--- a/.changeset/final-provider-instructions-300.md
+++ b/.changeset/final-provider-instructions-300.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Preserve final configured Responses instructions for native replay

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -81,7 +81,13 @@ export async function rewriteCodexProviderRequest(payload: unknown, ctx: Extensi
 		const piCompactionPayload = await injectPendingNativeWindowIntoPiCompactionRequest(configuredPayload, ctx, state);
 		rewrittenPayload = piCompactionPayload ?? (await rewriteCodexCompactedProviderRequest(configuredPayload, ctx, state)) ?? configuredPayload;
 	}
-	return applyCodexRuntimePayload(rewrittenPayload, isCodeModeRuntime(plan));
+	const finalPayload = applyCodexRuntimePayload(rewrittenPayload, isCodeModeRuntime(plan));
+	// Stock Responses providers and configured Code Mode overlays have no
+	// post-serialization callback. Keep native replay on the instructions that
+	// reached this final hook boundary; the custom Codex provider captures again
+	// after its transport-specific transforms.
+	if (state.pendingActiveProviderPromptCapture) captureActiveProviderSystemPrompt(finalPayload, state);
+	return finalPayload;
 }
 
 export function rewriteCodexPrewarmProviderRequest(

--- a/packages/pi-codex-conversion/tests/openai-codex-request.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-request.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { buildRequestBody } from "../src/providers/openai-codex-custom-provider.ts";
+import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import type { AdapterState } from "../src/adapter/activation/state.ts";
+import { rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import { createCodexTurnState } from "../src/providers/openai-codex/turn-state.ts";
 import {
 	buildSSEHeaders,
 	buildWebSocketHeaders,
@@ -81,6 +85,41 @@ test("buildRequestBody keeps Codex request shape stable for common options", () 
 		(normalModeBody.tools as Array<{ type: string; name: string }>).map(({ type, name }) => [type, name]),
 		[["function", "exec"], ["function", "wait"]],
 	);
+});
+
+test("final provider hook captures configured Responses instructions for native replay", async () => {
+	const state: AdapterState = {
+		enabled: true,
+		cwd: "/repo",
+		promptSkills: [],
+		executionMode: "normal",
+		codexTurnState: createCodexTurnState(),
+		pendingActiveProviderPromptCapture: true,
+		activeProviderSystemPrompt: "stale prompt",
+		config: {
+			...DEFAULT_CODEX_CONVERSION_CONFIG,
+			scope: { allProviders: "off", additionalProviders: ["passthrough"] },
+		},
+	};
+	const ctx = {
+		cwd: "/repo",
+		model: {
+			provider: "passthrough",
+			api: "openai-responses",
+			id: "gpt-5.6",
+			baseUrl: "https://proxy.example/v1",
+		},
+	} as never;
+	const finalPayload = await rewriteCodexProviderRequest({
+		model: "gpt-5.6",
+		instructions: "final chained instructions",
+		input: [],
+		text: { verbosity: "low" },
+		parallel_tool_calls: true,
+	}, ctx, state) as { instructions?: string };
+
+	assert.equal(finalPayload.instructions, "final chained instructions");
+	assert.equal(state.activeProviderSystemPrompt, "final chained instructions");
 });
 
 test("strict tool constraints serialize closed schemas and honor fallback policy", () => {


### PR DESCRIPTION
This PR captures configured Responses instructions at the final provider boundary for native replay.

Part of #325.

Closes #300.

## Summary

- retain the finalized configured-provider instructions used by the request
- replay those instructions through the existing native continuation path
- avoid broad provider-boundary enforcement beyond the evidenced stale-state gap

## Validation

- focused request-shape checks passed
- cumulative `bun run check:changed`

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
