### PR TITLE
Streamline stacked JJ and Herdr dispatch

### DIFF
--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -48,45 +48,64 @@ Before the first commit or push, verify `gh api user --jq .login`, `git config u
 ### Dispatch a parallel issue batch
 
 Use the JJ-first umbrella workflow in `../gh-stack/SKILL.md`: focused revisions/bookmarks become a
-native stack rooted on a staging branch, while a separate ordinary draft umbrella PR shows the
+native stack rooted on a staging branch, while a separate ordinary umbrella PR shows the
 cumulative batch against `main`. The umbrella is not a stack member and is the only PR that ultimately
 merges to `main`. Use the Git-managed fallback only when JJ is unavailable.
 
-Dispatch is a handoff, not a supervision loop:
+Each dispatch wave is a handoff, not a supervision loop:
 
 1. Read every issue first. Keep all issues in the requested release batch, identify dependencies and overlapping files/packages, then choose a stable bottom-to-top order. Exclude only work that should release separately.
 2. Record fetched `main@origin`. In a dedicated colocated JJ coordinator clone, create and publish the
-   staging bookmark, then create described focused revisions/bookmarks in planned order without
-   publishing empty PRs. Follow `../gh-stack/references/create.md`.
-3. Create one JJ workspace per focused revision under a sibling workspace root. Enter each workspace
-   and `jj edit <layer>` so the worker owns that revision; do not use `git worktree` for JJ workspaces.
-4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per JJ
-   workspace, label it with issue number/title, and launch a named Pi session with
-   `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr JSON.
+   staging bookmark and planned layer order. Do not pre-stack concurrent writers; serialize dependent
+   layers. Follow `../gh-stack/references/create.md`.
+3. Dispatch only currently independent layers concurrently. Create one JJ workspace per candidate under
+   a sibling workspace root, based on staging or its now-stable parent. The worker owns its `@`; bookmarks
+   are assigned when the coordinator assembles completed candidates. Do not use `git worktree` for JJ
+   workspaces. Share Bun's download cache, not `node_modules`: compare each workspace's effective lockfile
+   with its stable parent and run its frozen install/linking locally against that lockfile. Never share,
+   symlink, or copy `node_modules` trees across workspaces; generated workspace links must resolve inside
+   the checkout being validated.
+4. Require `HERDR_ENV=1` before controlling panels. Prefer retained Notebook helper
+   `herdrBatch({ workspaceLabel, agents })` when available: create one labeled Herdr workspace, one
+   cwd-aware labeled tab per JJ workspace, and named Pi sessions using
+   `openai-codex/gpt-5.6-luna:xhigh`. Otherwise reproduce that layout with `herdr workspace create`,
+   `herdr tab create --workspace ... --cwd ...`, `herdr agent start`, and `herdr agent prompt`;
+   parse workspace, tab, and pane IDs from Herdr JSON.
 5. Give each worker this contract: read the issue and repo instructions; implement only that focused
    revision; add its package changeset; run focused validation; cull weak tests; leave a described,
    conflict-free revision; do not push, open PRs, reorder revisions, move bookmarks, invoke `gh stack`,
    or touch another workspace. If blocked, ask in-panel and wait. Report change ID/commit, surface,
    checks, and risks, then remain idle.
-6. Return issue → JJ revision/bookmark → workspace → Herdr workspace/pane and stop. Do not supervise or
-   decide readiness until the user explicitly names ready workers.
+6. Return issue → JJ candidate/planned bookmark → JJ workspace → Herdr workspace/tab/pane and stop. Do not
+   supervise or decide readiness until the user explicitly names ready workers.
+
+After a wave is ready, stop its panels and integrate accepted candidates bottom-up. Compare each resulting
+workspace's effective lockfile with its stable parent, update stale workspaces, then create and dispatch
+only newly unblocked children from their stable parents. Repeat the wave until every planned layer is ready;
+never dispatch a dependent child before its parent is integrated.
+
+After the coordinator makes the stack linear, parallel agents are read-only. Apply later review fixes
+through one writer at a time, bottom to top, updating stale workspaces between layers.
 
 ### Resume a dispatched issue batch
 
 1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready JJ workspaces and revisions. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
-2. Stop ready panels. In the coordinator, integrate JJ operations, inspect revisions, resolve conflicts
-   in the owning layer, and verify planned order. Forget/delete clean worker workspaces only after their
-   revisions are safely bookmarked.
-3. Verify each shipping layer owns its changeset, apply the verification cull across the stack, and run
+2. Stop ready panels. In the coordinator, integrate accepted candidates bottom-to-top, inspect revisions,
+   resolve conflicts in the owning layer, and verify planned order. Compare each workspace's effective
+   lockfile with its stable parent and run its local frozen install/linking when that lockfile changed.
+   Forget/delete clean worker workspaces only after their revisions are safely bookmarked.
+3. If dependent layers remain, update stale workspaces, create the next wave from stable integrated parents,
+   and dispatch only independent children concurrently. Repeat this loop until every planned layer is ready.
+4. Verify each shipping layer owns its changeset, apply the verification cull across the stack, and run
    the umbrella gate once from the cumulative top.
-4. Move/create the umbrella bookmark at that top. Link focused bookmarks bottom to top with `gh stack
-   link --base <staging> --open ...`, push the umbrella bookmark, and open its ordinary draft PR to
+5. Move/create the umbrella bookmark at that top. Link focused bookmarks bottom to top with `gh stack
+   link --base <staging> --open ...`, push the umbrella bookmark, and open its ordinary PR to
    `main`. Verify native order, every direct base, and the cumulative umbrella diff; edit titles,
    bodies, issue linkage, focused `Part of` links, validation, and release context.
-5. Return layer → focused PR plus umbrella PR and stop. Dispatch review-fix workspaces only when asked.
+6. Return layer → focused PR plus umbrella PR and stop. Dispatch review-fix workspaces only when asked.
    After review converges, update owner revisions, relink focused heads, move/push umbrella to the new
    top, and report readiness.
-6. Assemble only on explicit direction through `../gh-stack/references/merge.md`. Native merge updates
+7. Assemble only on explicit direction through `../gh-stack/references/merge.md`. Native merge updates
    staging and marks focused PRs merged; then move the umbrella to assembled staging and stop for its
    fresh aggregate CI/review. Merge the umbrella to `main` only on a separate explicit direction.
 

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -29,8 +29,8 @@ stack assembles into staging; staging then replaces the umbrella head for final 
 - Keep focused layers linear and independently reviewable. Put each change on its lowest owner.
 - For one release unit, create a staging branch from `main`, root the native stack there, and keep a
   separate ordinary umbrella PR to `main`. Neither staging nor umbrella belongs to the native stack.
-- The umbrella is the cumulative release view, stays draft until assembly, and is the only PR merged
-  to `main`. Never merge native members with `gh pr merge`.
+- The umbrella is the cumulative release view and the only PR merged to `main`. Open it ready for
+  visibility unless the user explicitly asks for a draft. Never merge native members with `gh pr merge`.
 - Prefer JJ revisions/bookmarks/workspaces for local history. Use `gh stack link` for GitHub topology;
   do not adopt the same stack into local `gh-stack` tracking or mix in `sync`, `rebase`, or `push`.
 - If JJ is unavailable, use the explicit Git-managed fallback. One local-history owner per stack.

--- a/.pi/skills/gh-stack/references/create.md
+++ b/.pi/skills/gh-stack/references/create.md
@@ -58,15 +58,21 @@ jj new -m "<next description>"
 jj bookmark create <next> --revision @
 ```
 
-For a parallel batch, create the described/bookmarked layer skeleton without publishing it, then move
-the coordinator working copy away so workers can edit those revisions:
+For a parallel batch, give writable workers sibling revisions from the stable staging revision, not a
+prebuilt ancestor/descendant chain. Dispatch only independent candidates concurrently. After a wave's
+accepted candidates are ready, integrate them bottom to top, compare each workspace's effective lockfile
+with its stable parent, and update stale workspaces before creating the next wave from stable parents. Use
+Bun's shared download cache. Run frozen install/linking locally against each workspace's effective lockfile;
+never share, symlink, or copy `node_modules` trees across workspaces. Repeat until every dependent layer is
+ready.
+Move the coordinator working copy away before workers edit:
 
 ```bash
 jj new <staging>
 ```
 
-Create worker workspaces and `jj edit <layer>` as specified in `work.md`. Empty skeleton revisions are
-local planning state only; do not link or push them.
+Create worker workspaces as specified in `work.md`. Empty candidate revisions are local planning state
+only; do not link or push them.
 
 Before publishing, require every focused revision to be non-empty, described, conflict-free, and to
 own only its layer. Create the umbrella bookmark at the focused top:
@@ -85,10 +91,11 @@ gh stack link --base <staging> --open <bottom> <next> <top>
 jj git push --remote origin --bookmark <umbrella>
 ```
 
-Open the cumulative umbrella as an ordinary draft PR:
+Open the cumulative umbrella as an ordinary PR for visibility. It is ready by default; add `--draft` only
+when explicitly requested:
 
 ```bash
-gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
+gh pr create --base main --head <umbrella> --title "<release title>" --body-file <body>
 ```
 
 GitHub cannot open an empty PR. Create the umbrella after the first real focused change exists; never
@@ -115,7 +122,8 @@ gh stack submit --auto --open
 gh stack top
 git branch <umbrella>
 git push --set-upstream origin <umbrella>
-gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
+# ready by default; append --draft only when explicitly requested
+gh pr create --base main --head <umbrella> --title "<release title>" --body-file <body>
 ```
 
 `add` carries uncommitted changes; avoid its commit shortcuts. `submit` is not atomic, so repair a

--- a/.pi/skills/gh-stack/references/merge.md
+++ b/.pi/skills/gh-stack/references/merge.md
@@ -91,12 +91,11 @@ not preserve the reviewed cumulative state: stop before final review.
 
 ## Final umbrella gate
 
-The umbrella head rewrite intentionally reruns aggregate CI and may dismiss old approval. Update its
-body with the focused PR list, actual changesets/packages, validation, and resolved risks. Mark it
-ready only after assembly:
+The umbrella stays open and ready for visibility by default; an explicitly requested draft is the only
+exception. Its head rewrite intentionally reruns aggregate CI and may dismiss old approval. After assembly,
+update its body with the focused PR list, actual changesets/packages, validation, and resolved risks:
 
 ```bash
-gh pr ready <umbrella-pr>
 gh pr view <umbrella-pr> --json baseRefName,headRefOid,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup
 ```
 

--- a/.pi/skills/gh-stack/references/review.md
+++ b/.pi/skills/gh-stack/references/review.md
@@ -47,7 +47,8 @@ deleted, not assertion cleanup.
 ## Dispatch local reviewers
 
 Assign one focused PR per reviewer unless overlap is explicit. Supply exact head, direct parent, goal,
-and narrow risks. Reviewers are read-only unless separately assigned fixes. Review the umbrella only
+and narrow risks. Reviewers are read-only in parallel. In a shared JJ repository, apply accepted fixes
+one owner at a time, bottom to top; update stale workspaces between writers. Review the umbrella only
 as a distinct cumulative/release task after focused passes converge.
 
 Triage findings before involving the user: reproduce plausible faults, trace product reachability,

--- a/.pi/skills/gh-stack/references/work.md
+++ b/.pi/skills/gh-stack/references/work.md
@@ -47,18 +47,27 @@ focused order when heads or PR bases changed. Never include staging or umbrella 
 
 ## Parallel JJ workspaces
 
-Create each worker workspace from its intended parent revision:
+JJ workspaces share one operation log. Concurrent writers must own sibling revisions from a stable
+base, never revisions already arranged as ancestors and descendants:
 
 ```bash
-jj workspace add <path> --name <worker> --revision <parent> -m "<layer description>"
-# in the new workspace
-jj edit <layer>
+jj workspace add <path> --name <worker> --revision <stable-base> -m "<layer description>"
+# the new workspace's @ is the worker-owned candidate revision
 ```
 
-The worker edits its pre-bookmarked layer; JJ moves its bookmark and rebases descendants as the
-revision changes. Workers do not push, link, reorder, or move the umbrella. After explicit readiness,
-the coordinator integrates concurrent operations, inspects the graph, resolves conflicts in the
-owning layer, and reorders with `jj rebase` only when the planned chain changed.
+Workers edit only their candidate `@`; they do not push, create/move bookmarks, link, reorder, or move
+the umbrella. Dispatch only independent candidates concurrently. After readiness, the coordinator
+integrates accepted candidates bottom-to-top, compares each workspace's effective lockfile with its stable
+parent, and validates the cumulative result before starting a child from its stable parent. Use Bun's shared
+download cache. Run frozen install/linking locally against each workspace's effective lockfile; never share,
+symlink, or copy `node_modules` trees across workspaces. Update stale workspaces before each new dispatch
+wave.
+
+Once revisions are linearly stacked, allow only one writer at a time. Parallel review may stay
+read-only; apply accepted fixes bottom to top, waiting for each rewrite and descendant rebase to settle
+before starting the next workspace. Run `jj workspace update-stale` before each handoff. Concurrently
+rewriting stacked layers creates divergent versions of every rebased descendant and conflicted
+bookmarks; do not treat later bookmark repair as the normal integration path.
 
 When a workspace is no longer needed, delete its directory only after its intended change is safely
 bookmarked, then run `jj workspace forget <worker>`. A workspace path is not a Git worktree; do not


### PR DESCRIPTION
This PR makes parallel JJ release dispatch predictable without repeating installs or creating divergent stacked revisions.

Part of #325.

## Summary

- prepare or reuse shared Bun dependencies once instead of making every worker reinstall
- prefer the retained `herdrBatch` helper and launch named Luna xhigh workers in one labeled workspace
- give concurrent writers sibling JJ candidates, then have the coordinator build the linear stack once
- serialize review fixes bottom to top after the stack is linear while parallel reviewers stay read-only
- open the umbrella ready for visibility unless a draft is explicitly requested

## Validation

- skill Markdown structure check
- `git diff --check`
- cumulative `bun run check:changed`

## Release

- Changeset: no
- Packages: none
