### PR TITLE
3.0.16

### DIFF
--- a/.changeset/apply-patch-renderers-303.md
+++ b/.changeset/apply-patch-renderers-303.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Expose `createApplyPatchTool` and an `apply-patch-display` integration API for custom patch views without changing the agent-facing `apply_patch` execution contract

--- a/.changeset/final-provider-instructions-300.md
+++ b/.changeset/final-provider-instructions-300.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Preserve final configured Responses instructions for native replay

--- a/.changeset/keep-codex-project-cache-warm.md
+++ b/.changeset/keep-codex-project-cache-warm.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Add a project-only experimental Codex cache keepalive that refreshes idle WebSocket context and reports cache-read results.

--- a/.changeset/notebook-exec-bridge.md
+++ b/.changeset/notebook-exec-bridge.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Make safe Notebook lifecycle controls callable from inside Notebook exec cells.

--- a/.changeset/patch-msx9n87r-b2fe3f.md
+++ b/.changeset/patch-msx9n87r-b2fe3f.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Report native compaction cache misses with replay and transport diagnostics

--- a/.changeset/patch-notebook-interruption-305.md
+++ b/.changeset/patch-notebook-interruption-305.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Recover interrupted Notebook kernels without deleting durable project bindings

--- a/.changeset/patch-notebook-metadata-306.md
+++ b/.changeset/patch-notebook-metadata-306.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Make durable Notebook Mode globals discoverable and guide safe reuse with bounded descriptions and usage hints

--- a/.changeset/patch-v2-retention-budget-308.md
+++ b/.changeset/patch-v2-retention-budget-308.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep oversized Responses V2 user turns out of the retained compaction window

--- a/.changeset/stale-background-widget-ctx.md
+++ b/.changeset/stale-background-widget-ctx.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Prevent delayed background shell widget renders from using stale session contexts

--- a/.pi/skills/gh-issue-pr-flow/SKILL.md
+++ b/.pi/skills/gh-issue-pr-flow/SKILL.md
@@ -48,45 +48,64 @@ Before the first commit or push, verify `gh api user --jq .login`, `git config u
 ### Dispatch a parallel issue batch
 
 Use the JJ-first umbrella workflow in `../gh-stack/SKILL.md`: focused revisions/bookmarks become a
-native stack rooted on a staging branch, while a separate ordinary draft umbrella PR shows the
+native stack rooted on a staging branch, while a separate ordinary umbrella PR shows the
 cumulative batch against `main`. The umbrella is not a stack member and is the only PR that ultimately
 merges to `main`. Use the Git-managed fallback only when JJ is unavailable.
 
-Dispatch is a handoff, not a supervision loop:
+Each dispatch wave is a handoff, not a supervision loop:
 
 1. Read every issue first. Keep all issues in the requested release batch, identify dependencies and overlapping files/packages, then choose a stable bottom-to-top order. Exclude only work that should release separately.
 2. Record fetched `main@origin`. In a dedicated colocated JJ coordinator clone, create and publish the
-   staging bookmark, then create described focused revisions/bookmarks in planned order without
-   publishing empty PRs. Follow `../gh-stack/references/create.md`.
-3. Create one JJ workspace per focused revision under a sibling workspace root. Enter each workspace
-   and `jj edit <layer>` so the worker owns that revision; do not use `git worktree` for JJ workspaces.
-4. Require `HERDR_ENV=1` before controlling panels. Create one unfocused Herdr workspace per JJ
-   workspace, label it with issue number/title, and launch a named Pi session with
-   `--model openai-codex/gpt-5.6-luna:high`. Parse workspace and pane IDs from Herdr JSON.
+   staging bookmark and planned layer order. Do not pre-stack concurrent writers; serialize dependent
+   layers. Follow `../gh-stack/references/create.md`.
+3. Dispatch only currently independent layers concurrently. Create one JJ workspace per candidate under
+   a sibling workspace root, based on staging or its now-stable parent. The worker owns its `@`; bookmarks
+   are assigned when the coordinator assembles completed candidates. Do not use `git worktree` for JJ
+   workspaces. Share Bun's download cache, not `node_modules`: compare each workspace's effective lockfile
+   with its stable parent and run its frozen install/linking locally against that lockfile. Never share,
+   symlink, or copy `node_modules` trees across workspaces; generated workspace links must resolve inside
+   the checkout being validated.
+4. Require `HERDR_ENV=1` before controlling panels. Prefer retained Notebook helper
+   `herdrBatch({ workspaceLabel, agents })` when available: create one labeled Herdr workspace, one
+   cwd-aware labeled tab per JJ workspace, and named Pi sessions using
+   `openai-codex/gpt-5.6-luna:xhigh`. Otherwise reproduce that layout with `herdr workspace create`,
+   `herdr tab create --workspace ... --cwd ...`, `herdr agent start`, and `herdr agent prompt`;
+   parse workspace, tab, and pane IDs from Herdr JSON.
 5. Give each worker this contract: read the issue and repo instructions; implement only that focused
    revision; add its package changeset; run focused validation; cull weak tests; leave a described,
    conflict-free revision; do not push, open PRs, reorder revisions, move bookmarks, invoke `gh stack`,
    or touch another workspace. If blocked, ask in-panel and wait. Report change ID/commit, surface,
    checks, and risks, then remain idle.
-6. Return issue → JJ revision/bookmark → workspace → Herdr workspace/pane and stop. Do not supervise or
-   decide readiness until the user explicitly names ready workers.
+6. Return issue → JJ candidate/planned bookmark → JJ workspace → Herdr workspace/tab/pane and stop. Do not
+   supervise or decide readiness until the user explicitly names ready workers.
+
+After a wave is ready, stop its panels and integrate accepted candidates bottom-up. Compare each resulting
+workspace's effective lockfile with its stable parent, update stale workspaces, then create and dispatch
+only newly unblocked children from their stable parents. Repeat the wave until every planned layer is ready;
+never dispatch a dependent child before its parent is integrated.
+
+After the coordinator makes the stack linear, parallel agents are read-only. Apply later review fixes
+through one writer at a time, bottom to top, updating stale workspaces between layers.
 
 ### Resume a dispatched issue batch
 
 1. Treat the user's readiness signal—not panel status—as the phase gate. Inspect only the named ready JJ workspaces and revisions. Report dirty, missing, or conflicting results instead of silently completing worker tasks.
-2. Stop ready panels. In the coordinator, integrate JJ operations, inspect revisions, resolve conflicts
-   in the owning layer, and verify planned order. Forget/delete clean worker workspaces only after their
-   revisions are safely bookmarked.
-3. Verify each shipping layer owns its changeset, apply the verification cull across the stack, and run
+2. Stop ready panels. In the coordinator, integrate accepted candidates bottom-to-top, inspect revisions,
+   resolve conflicts in the owning layer, and verify planned order. Compare each workspace's effective
+   lockfile with its stable parent and run its local frozen install/linking when that lockfile changed.
+   Forget/delete clean worker workspaces only after their revisions are safely bookmarked.
+3. If dependent layers remain, update stale workspaces, create the next wave from stable integrated parents,
+   and dispatch only independent children concurrently. Repeat this loop until every planned layer is ready.
+4. Verify each shipping layer owns its changeset, apply the verification cull across the stack, and run
    the umbrella gate once from the cumulative top.
-4. Move/create the umbrella bookmark at that top. Link focused bookmarks bottom to top with `gh stack
-   link --base <staging> --open ...`, push the umbrella bookmark, and open its ordinary draft PR to
+5. Move/create the umbrella bookmark at that top. Link focused bookmarks bottom to top with `gh stack
+   link --base <staging> --open ...`, push the umbrella bookmark, and open its ordinary PR to
    `main`. Verify native order, every direct base, and the cumulative umbrella diff; edit titles,
    bodies, issue linkage, focused `Part of` links, validation, and release context.
-5. Return layer → focused PR plus umbrella PR and stop. Dispatch review-fix workspaces only when asked.
+6. Return layer → focused PR plus umbrella PR and stop. Dispatch review-fix workspaces only when asked.
    After review converges, update owner revisions, relink focused heads, move/push umbrella to the new
    top, and report readiness.
-6. Assemble only on explicit direction through `../gh-stack/references/merge.md`. Native merge updates
+7. Assemble only on explicit direction through `../gh-stack/references/merge.md`. Native merge updates
    staging and marks focused PRs merged; then move the umbrella to assembled staging and stop for its
    fresh aggregate CI/review. Merge the umbrella to `main` only on a separate explicit direction.
 

--- a/.pi/skills/gh-stack/SKILL.md
+++ b/.pi/skills/gh-stack/SKILL.md
@@ -29,8 +29,8 @@ stack assembles into staging; staging then replaces the umbrella head for final 
 - Keep focused layers linear and independently reviewable. Put each change on its lowest owner.
 - For one release unit, create a staging branch from `main`, root the native stack there, and keep a
   separate ordinary umbrella PR to `main`. Neither staging nor umbrella belongs to the native stack.
-- The umbrella is the cumulative release view, stays draft until assembly, and is the only PR merged
-  to `main`. Never merge native members with `gh pr merge`.
+- The umbrella is the cumulative release view and the only PR merged to `main`. Open it ready for
+  visibility unless the user explicitly asks for a draft. Never merge native members with `gh pr merge`.
 - Prefer JJ revisions/bookmarks/workspaces for local history. Use `gh stack link` for GitHub topology;
   do not adopt the same stack into local `gh-stack` tracking or mix in `sync`, `rebase`, or `push`.
 - If JJ is unavailable, use the explicit Git-managed fallback. One local-history owner per stack.

--- a/.pi/skills/gh-stack/references/create.md
+++ b/.pi/skills/gh-stack/references/create.md
@@ -58,15 +58,21 @@ jj new -m "<next description>"
 jj bookmark create <next> --revision @
 ```
 
-For a parallel batch, create the described/bookmarked layer skeleton without publishing it, then move
-the coordinator working copy away so workers can edit those revisions:
+For a parallel batch, give writable workers sibling revisions from the stable staging revision, not a
+prebuilt ancestor/descendant chain. Dispatch only independent candidates concurrently. After a wave's
+accepted candidates are ready, integrate them bottom to top, compare each workspace's effective lockfile
+with its stable parent, and update stale workspaces before creating the next wave from stable parents. Use
+Bun's shared download cache. Run frozen install/linking locally against each workspace's effective lockfile;
+never share, symlink, or copy `node_modules` trees across workspaces. Repeat until every dependent layer is
+ready.
+Move the coordinator working copy away before workers edit:
 
 ```bash
 jj new <staging>
 ```
 
-Create worker workspaces and `jj edit <layer>` as specified in `work.md`. Empty skeleton revisions are
-local planning state only; do not link or push them.
+Create worker workspaces as specified in `work.md`. Empty candidate revisions are local planning state
+only; do not link or push them.
 
 Before publishing, require every focused revision to be non-empty, described, conflict-free, and to
 own only its layer. Create the umbrella bookmark at the focused top:
@@ -85,10 +91,11 @@ gh stack link --base <staging> --open <bottom> <next> <top>
 jj git push --remote origin --bookmark <umbrella>
 ```
 
-Open the cumulative umbrella as an ordinary draft PR:
+Open the cumulative umbrella as an ordinary PR for visibility. It is ready by default; add `--draft` only
+when explicitly requested:
 
 ```bash
-gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
+gh pr create --base main --head <umbrella> --title "<release title>" --body-file <body>
 ```
 
 GitHub cannot open an empty PR. Create the umbrella after the first real focused change exists; never
@@ -115,7 +122,8 @@ gh stack submit --auto --open
 gh stack top
 git branch <umbrella>
 git push --set-upstream origin <umbrella>
-gh pr create --draft --base main --head <umbrella> --title "<release title>" --body-file <body>
+# ready by default; append --draft only when explicitly requested
+gh pr create --base main --head <umbrella> --title "<release title>" --body-file <body>
 ```
 
 `add` carries uncommitted changes; avoid its commit shortcuts. `submit` is not atomic, so repair a

--- a/.pi/skills/gh-stack/references/merge.md
+++ b/.pi/skills/gh-stack/references/merge.md
@@ -91,12 +91,11 @@ not preserve the reviewed cumulative state: stop before final review.
 
 ## Final umbrella gate
 
-The umbrella head rewrite intentionally reruns aggregate CI and may dismiss old approval. Update its
-body with the focused PR list, actual changesets/packages, validation, and resolved risks. Mark it
-ready only after assembly:
+The umbrella stays open and ready for visibility by default; an explicitly requested draft is the only
+exception. Its head rewrite intentionally reruns aggregate CI and may dismiss old approval. After assembly,
+update its body with the focused PR list, actual changesets/packages, validation, and resolved risks:
 
 ```bash
-gh pr ready <umbrella-pr>
 gh pr view <umbrella-pr> --json baseRefName,headRefOid,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup
 ```
 

--- a/.pi/skills/gh-stack/references/review.md
+++ b/.pi/skills/gh-stack/references/review.md
@@ -47,7 +47,8 @@ deleted, not assertion cleanup.
 ## Dispatch local reviewers
 
 Assign one focused PR per reviewer unless overlap is explicit. Supply exact head, direct parent, goal,
-and narrow risks. Reviewers are read-only unless separately assigned fixes. Review the umbrella only
+and narrow risks. Reviewers are read-only in parallel. In a shared JJ repository, apply accepted fixes
+one owner at a time, bottom to top; update stale workspaces between writers. Review the umbrella only
 as a distinct cumulative/release task after focused passes converge.
 
 Triage findings before involving the user: reproduce plausible faults, trace product reachability,

--- a/.pi/skills/gh-stack/references/work.md
+++ b/.pi/skills/gh-stack/references/work.md
@@ -47,18 +47,27 @@ focused order when heads or PR bases changed. Never include staging or umbrella 
 
 ## Parallel JJ workspaces
 
-Create each worker workspace from its intended parent revision:
+JJ workspaces share one operation log. Concurrent writers must own sibling revisions from a stable
+base, never revisions already arranged as ancestors and descendants:
 
 ```bash
-jj workspace add <path> --name <worker> --revision <parent> -m "<layer description>"
-# in the new workspace
-jj edit <layer>
+jj workspace add <path> --name <worker> --revision <stable-base> -m "<layer description>"
+# the new workspace's @ is the worker-owned candidate revision
 ```
 
-The worker edits its pre-bookmarked layer; JJ moves its bookmark and rebases descendants as the
-revision changes. Workers do not push, link, reorder, or move the umbrella. After explicit readiness,
-the coordinator integrates concurrent operations, inspects the graph, resolves conflicts in the
-owning layer, and reorders with `jj rebase` only when the planned chain changed.
+Workers edit only their candidate `@`; they do not push, create/move bookmarks, link, reorder, or move
+the umbrella. Dispatch only independent candidates concurrently. After readiness, the coordinator
+integrates accepted candidates bottom-to-top, compares each workspace's effective lockfile with its stable
+parent, and validates the cumulative result before starting a child from its stable parent. Use Bun's shared
+download cache. Run frozen install/linking locally against each workspace's effective lockfile; never share,
+symlink, or copy `node_modules` trees across workspaces. Update stale workspaces before each new dispatch
+wave.
+
+Once revisions are linearly stacked, allow only one writer at a time. Parallel review may stay
+read-only; apply accepted fixes bottom to top, waiting for each rewrite and descendant rebase to settle
+before starting the next workspace. Run `jj workspace update-stale` before each handoff. Concurrently
+rewriting stacked layers creates divergent versions of every rebased descendant and conflicted
+bookmarks; do not treat later bookmark repair as the normal integration path.
 
 When a workspace is no longer needed, delete its directory only after its intended change is safely
 bookmarked, then run `jj workspace forget <worker>`. A workspace path is not a Git worktree; do not

--- a/packages/pi-codex-conversion/package.json
+++ b/packages/pi-codex-conversion/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/code-mode-preflight.d.ts",
       "import": "./dist/code-mode-preflight.js"
     },
+    "./apply-patch-display": {
+      "types": "./dist/apply-patch-display.d.ts",
+      "import": "./dist/apply-patch-display.js"
+    },
     "./realtime-voice": {
       "types": "./dist/realtime-voice.d.ts",
       "import": "./dist/realtime-voice.js"

--- a/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
@@ -76,6 +76,7 @@ export function migrateCodexConversionConfigIfNeeded(value: unknown): { migrated
 		openai: {
 			fast: typeof value["fast"] === "boolean" ? value["fast"] : DEFAULT_CODEX_CONVERSION_CONFIG.openai["fast"],
 			verbosity: normalizeCodexVerbosity(value["verbosity"]) ?? DEFAULT_CODEX_CONVERSION_CONFIG.openai["verbosity"],
+			cacheKeepalive: DEFAULT_CODEX_CONVERSION_CONFIG.openai.cacheKeepalive,
 			proxyResponsesLite: DEFAULT_CODEX_CONVERSION_CONFIG.openai.proxyResponsesLite,
 			forceCachedWebSockets: typeof value["forceCachedWebSockets"] === "boolean" ? value["forceCachedWebSockets"] : DEFAULT_CODEX_CONVERSION_CONFIG.openai["forceCachedWebSockets"],
 			cacheDiagnostics: DEFAULT_CODEX_CONVERSION_CONFIG.openai.cacheDiagnostics,

--- a/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
@@ -57,6 +57,23 @@ function writeConfigDocumentAtomic(configPath: string, document: Record<string, 
 	}
 }
 
+function withoutProjectOnlyConfig(config: CodexConversionConfig): CodexConversionConfig {
+	return {
+		...config,
+		openai: { ...config.openai, cacheKeepalive: false },
+	};
+}
+
+function withoutProjectOnlyDocument(document: Record<string, unknown>): Record<string, unknown> {
+	const openai = isRecord(document["openai"]) ? { ...document["openai"] } : undefined;
+	if (!openai) return document;
+	delete openai["cacheKeepalive"];
+	const next = { ...document };
+	if (Object.keys(openai).length > 0) next["openai"] = openai;
+	else delete next["openai"];
+	return next;
+}
+
 export function getCodexConversionConfigPath(agentDir: string = getAgentDir()): string {
 	return join(agentDir, CODEX_CONVERSION_CONFIG_BASENAME);
 }
@@ -80,7 +97,7 @@ export function readCodexConversionConfig(configPath: string = getCodexConversio
 	const parsed = readConfigDocument(configPath, "global");
 	if (parsed === undefined) return structuredClone(DEFAULT_CODEX_CONVERSION_CONFIG);
 	const migration = migrateCodexConversionConfigIfNeeded(parsed);
-	const config = normalizeCodexConversionConfig(migration.config);
+	const config = withoutProjectOnlyConfig(normalizeCodexConversionConfig(migration.config));
 	const voice = isRecord(parsed) && isRecord(parsed["voice"])
 		? parsed["voice"]
 		: undefined;
@@ -100,7 +117,12 @@ export function readProjectCodexConversionDocument(cwd: string, projectTrusted: 
 
 export function hasFolderCodexConversionConfig(cwd: string, projectTrusted: boolean): boolean {
 	const project = readProjectCodexConversionDocument(cwd, projectTrusted);
-	return !!project && [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS].some((key) => key in project);
+	if (!project) return false;
+	return [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS].some((key) => {
+		if (key !== "openai") return key in project;
+		const openai = isRecord(project["openai"]) ? project["openai"] : undefined;
+		return !!openai && Object.keys(openai).some((option) => option !== "cacheKeepalive");
+	});
 }
 
 function applyProcessOverrides(config: CodexConversionConfig, env: NodeJS.ProcessEnv): CodexConversionConfig {
@@ -127,6 +149,32 @@ export function readLayeredCodexConversionConfig(
 		: global;
 }
 
+export function setProjectCodexCacheKeepalive(
+	cwd: string,
+	projectTrusted: boolean,
+	enabled: boolean,
+): { ok: true } | { ok: false; error: string } {
+	if (!projectTrusted) return { ok: false, error: "Trust this folder before changing project cache keepalive" };
+	const path = getProjectCodexConversionConfigPath(cwd);
+	try {
+		const existing = readConfigDocument(path, "trusted project");
+		if (existsSync(path) && !isRecord(existing)) return { ok: false, error: "Project config is not a JSON object" };
+		const document = isRecord(existing) ? existing : {};
+		const openai = isRecord(document["openai"]) ? { ...document["openai"] } : {};
+		if (enabled) openai["cacheKeepalive"] = true;
+		else delete openai["cacheKeepalive"];
+		if (Object.keys(openai).length > 0) document["openai"] = openai;
+		else delete document["openai"];
+		if (Object.keys(document).length === 0) rmSync(path, { force: true });
+		else writeConfigDocumentAtomic(path, document);
+		return { ok: true };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-codex-conversion] Failed to write project cache keepalive ${path}: ${message}`);
+		return { ok: false, error: message };
+	}
+}
+
 export function materializeFolderCodexConversionConfig(
 	cwd: string,
 	projectTrusted: boolean,
@@ -134,7 +182,7 @@ export function materializeFolderCodexConversionConfig(
 ): { ok: true; config: CodexConversionConfig } | { ok: false; error: string } {
 	if (!projectTrusted) return { ok: false, error: "Trust this folder before enabling folder settings" };
 	const config = readLayeredCodexConversionConfig({ cwd, projectTrusted, globalConfigPath });
-	const result = writeCodexConversionConfig(config, getProjectCodexConversionConfigPath(cwd));
+	const result = writeCodexConversionConfig(config, getProjectCodexConversionConfigPath(cwd), true);
 	return result.ok ? { ok: true, config } : result;
 }
 
@@ -146,7 +194,16 @@ export function clearFolderCodexConversionConfig(
 	const path = getProjectCodexConversionConfigPath(cwd);
 	const project = readProjectCodexConversionDocument(cwd, true);
 	if (!project) return { ok: true };
-	for (const key of [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS]) delete project[key];
+	for (const key of [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS]) {
+		if (key === "openai" && isRecord(project[key])) {
+			const keepalive = project[key]["cacheKeepalive"];
+			const nextOpenAI = typeof keepalive === "boolean" ? { cacheKeepalive: keepalive } : {};
+			if (Object.keys(nextOpenAI).length === 0) delete project[key];
+			else project[key] = nextOpenAI;
+			continue;
+		}
+		delete project[key];
+	}
 	try {
 		if (Object.keys(project).length === 0) rmSync(path, { force: true });
 		else writeConfigDocumentAtomic(path, project);
@@ -161,9 +218,10 @@ export function clearFolderCodexConversionConfig(
 export function writeCodexConversionConfig(
 	config: CodexConversionConfig,
 	configPath: string = getCodexConversionConfigPath(),
+	preserveProjectCacheKeepalive = false,
 ): { ok: true } | { ok: false; error: string } {
 	try {
-		const normalized = normalizeCodexConversionConfig(config) as unknown as Record<string, unknown>;
+		const normalized = withoutProjectOnlyDocument(normalizeCodexConversionConfig(config) as unknown as Record<string, unknown>);
 		let document = normalized;
 		if (existsSync(configPath)) {
 			try {
@@ -173,6 +231,7 @@ export function writeCodexConversionConfig(
 				// A valid explicit settings write replaces an unreadable document.
 			}
 		}
+		if (!preserveProjectCacheKeepalive) document = withoutProjectOnlyDocument(document);
 		clearAbsentOwnedOptionals(document, normalized);
 		for (const key of LEGACY_OWNED_CONFIG_KEYS) delete document[key];
 		writeConfigDocumentAtomic(configPath, document);

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -103,6 +103,7 @@ export interface CodexConversionConfig {
 	openai: {
 		fast: boolean;
 		verbosity: CodexVerbosity;
+		cacheKeepalive: boolean;
 		proxyResponsesLite: boolean;
 		forceCachedWebSockets: boolean;
 		cacheDiagnostics: CacheDiagnosticsMode;
@@ -155,6 +156,7 @@ export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	openai: {
 		fast: false,
 		verbosity: "low",
+		cacheKeepalive: false,
 		proxyResponsesLite: false,
 		forceCachedWebSockets: true,
 		cacheDiagnostics: "off",
@@ -464,6 +466,10 @@ export function normalizeCodexConversionConfig(
 			verbosity:
 				normalizeCodexVerbosity(openai["verbosity"]) ??
 				DEFAULT_CODEX_CONVERSION_CONFIG.openai["verbosity"],
+			cacheKeepalive: bool(
+				openai["cacheKeepalive"],
+				DEFAULT_CODEX_CONVERSION_CONFIG.openai["cacheKeepalive"],
+			),
 			proxyResponsesLite: bool(
 				openai["proxyResponsesLite"],
 				DEFAULT_CODEX_CONVERSION_CONFIG.openai.proxyResponsesLite,

--- a/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/compaction.ts
@@ -18,8 +18,9 @@ import { executeRemoteCompactionV2 } from "./remote-v2-client.ts";
 import { buildRemoteCompactionV2Window } from "./remote-v2-history.ts";
 import { CODE_MODE_EXEC_GRAMMAR_INPUTS } from "../../tools/code-mode/exec-contract.ts";
 import { getActiveToolsInActiveOrder } from "../active-tools.ts";
-import { canonicalCompactionPromptInput } from "../../providers/openai-codex/session-continuity.ts";
+import { resolveCanonicalCompactionPromptInput } from "../../providers/openai-codex/session-continuity.ts";
 import { extractAccountId, resolveCodexWebSocketUrl } from "../../providers/openai-codex/headers.ts";
+import type { CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
@@ -229,17 +230,26 @@ async function handleCodexSessionBeforeCompactInner(event: SessionBeforeCompactE
 		ctx.ui.notify("OpenAI native compaction could not clone the previous compacted window; Pi compaction was not run.", "error");
 		return { cancel: true };
 	}
-	const canonicalInput = runtime.codexTransport && runtime.apiKey
-		? canonicalCompactionPromptInput(ctx.sessionManager.getSessionId(), runtime.model, {
+	const canonicalReplay = runtime.codexTransport && runtime.apiKey
+		? resolveCanonicalCompactionPromptInput(ctx.sessionManager.getSessionId(), runtime.model, {
 			url: resolveCodexWebSocketUrl(runtime.baseUrl),
 			accountId: extractAccountId(runtime.apiKey),
 		}, builtInput.input)
-		: undefined;
-	const validatedCanonicalInput = canonicalInput?.every(isRecord)
-		? canonicalInput as ResponsesInputItem[]
+		: { decision: "not_applicable" as const };
+	const validatedCanonicalInput = canonicalReplay.input?.every(isRecord)
+		? canonicalReplay.input as ResponsesInputItem[]
 		: undefined;
 	const input = validatedCanonicalInput ?? builtInput.input;
 	const { compactedKeptWindow } = builtInput;
+	const compactionDiagnostic: CodexCompactionDiagnostic = {
+		model: runtime.model,
+		inputSource: validatedCanonicalInput ? "canonical" : "reconstructed",
+		canonicalReplay: canonicalReplay.decision,
+		checkpointReused: latestNativeCompaction.ok,
+		...(latestNativeCompaction.ok && latestNativeCompaction.entry.details?.model
+			? { checkpointModel: latestNativeCompaction.entry.details.model }
+			: {}),
+	};
 
 	if (input.length === 0) {
 		ctx.ui.notify("OpenAI native compaction had no serializable conversation items; Pi compaction was not run.", "error");
@@ -261,7 +271,8 @@ async function handleCodexSessionBeforeCompactInner(event: SessionBeforeCompactE
 		modelRegistry: ctx.modelRegistry,
 		context,
 		promptInput: input,
-		promptInputSource: validatedCanonicalInput ? "canonical" : "reconstructed",
+		promptInputSource: compactionDiagnostic.inputSource,
+		compactionDiagnostic,
 		requestOptions,
 		tokensBefore: event.preparation.tokensBefore,
 		sessionId: ctx.sessionManager.getSessionId(),

--- a/packages/pi-codex-conversion/src/adapter/compaction/diagnostics.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/diagnostics.ts
@@ -1,0 +1,122 @@
+export type CodexCompactionInputSource = "canonical" | "reconstructed";
+
+export type CodexCompactionContinuation =
+	| "disabled"
+	| "no_session_cache_entry"
+	| "no_continuation"
+	| "body_mismatch"
+	| "input_shorter_than_baseline"
+	| "input_prefix_mismatch"
+	| "missing_previous_response_id"
+	| "delta";
+
+export type CodexCompactionReplayDecision =
+	| "validated"
+	| "not_applicable"
+	| "no_state"
+	| "model_mismatch"
+	| "identity_mismatch"
+	| "input_shorter_than_baseline"
+	| "request_prefix_mismatch"
+	| "response_prefix_mismatch";
+
+export type CodexCompactionDiagnostic = {
+	model?: string | undefined;
+	inputSource: CodexCompactionInputSource;
+	canonicalReplay: CodexCompactionReplayDecision;
+	checkpointReused: boolean;
+	checkpointModel?: string | undefined;
+	transport?: "websocket" | "sse" | undefined;
+	continuation?: CodexCompactionContinuation | undefined;
+	previousResponseId?: boolean | undefined;
+	fullInputItems?: number | undefined;
+	sentInputItems?: number | undefined;
+	rewrittenToolOutputs?: number | undefined;
+};
+
+const COMPACTION_INPUT_SOURCES = ["canonical", "reconstructed"] as const;
+const COMPACTION_CONTINUATIONS = [
+	"disabled",
+	"no_session_cache_entry",
+	"no_continuation",
+	"body_mismatch",
+	"input_shorter_than_baseline",
+	"input_prefix_mismatch",
+	"missing_previous_response_id",
+	"delta",
+] as const;
+const COMPACTION_REPLAY_DECISIONS = [
+	"validated",
+	"not_applicable",
+	"no_state",
+	"model_mismatch",
+	"identity_mismatch",
+	"input_shorter_than_baseline",
+	"request_prefix_mismatch",
+	"response_prefix_mismatch",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOneOf<T extends string>(values: readonly T[], value: unknown): value is T {
+	return typeof value === "string" && values.includes(value as T);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function isOptionalNonNegativeNumber(value: unknown): value is number | undefined {
+	return value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0);
+}
+
+export function isCodexCompactionDiagnostic(value: unknown): value is CodexCompactionDiagnostic {
+	if (!isRecord(value)) return false;
+	return isOneOf(COMPACTION_INPUT_SOURCES, value["inputSource"])
+		&& isOneOf(COMPACTION_REPLAY_DECISIONS, value["canonicalReplay"])
+		&& typeof value["checkpointReused"] === "boolean"
+		&& isOptionalString(value["model"])
+		&& isOptionalString(value["checkpointModel"])
+		&& (value["transport"] === undefined || value["transport"] === "websocket" || value["transport"] === "sse")
+		&& (value["continuation"] === undefined || isOneOf(COMPACTION_CONTINUATIONS, value["continuation"]))
+		&& (value["previousResponseId"] === undefined || typeof value["previousResponseId"] === "boolean")
+		&& isOptionalNonNegativeNumber(value["fullInputItems"])
+		&& isOptionalNonNegativeNumber(value["sentInputItems"])
+		&& isOptionalNonNegativeNumber(value["rewrittenToolOutputs"]);
+}
+
+export const COMPACTION_CACHE_DIAGNOSTIC_THRESHOLD = 0.8;
+
+function readable(value: string): string {
+	return value.replaceAll("_", " ");
+}
+
+export function formatCompactionCacheDiagnostic(
+	usage: { inputTokens: number; cachedInputTokens: number },
+	diagnostic: CodexCompactionDiagnostic | undefined,
+): string | undefined {
+	if (!isCodexCompactionDiagnostic(diagnostic) || usage.inputTokens <= 0) return undefined;
+	if (usage.cachedInputTokens / usage.inputTokens >= COMPACTION_CACHE_DIAGNOSTIC_THRESHOLD) return undefined;
+
+	const reasons: string[] = [];
+	if (diagnostic.inputSource === "reconstructed") {
+		reasons.push(`reconstructed history: ${readable(diagnostic.canonicalReplay)}`);
+	} else {
+		reasons.push("canonical replay");
+	}
+	if (diagnostic.transport === "sse") {
+		reasons.push("SSE full request");
+	} else if (diagnostic.transport === "websocket") {
+		if (diagnostic.continuation === "delta") reasons.push("WS delta");
+		else reasons.push(`WS full: ${readable(diagnostic.continuation ?? "no_continuation")}`);
+	}
+	if (diagnostic.checkpointReused) {
+		reasons.push(`checkpoint reused${diagnostic.checkpointModel ? ` (recorded model ${diagnostic.checkpointModel})` : ""}`);
+	}
+	if (diagnostic.rewrittenToolOutputs) {
+		reasons.push(`${diagnostic.rewrittenToolOutputs} tool output${diagnostic.rewrittenToolOutputs === 1 ? "" : "s"} shortened`);
+	}
+	return `(${reasons.join("; ")})`;
+}

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
@@ -10,6 +10,7 @@ import { sleep } from "../../providers/openai-codex/sse.ts";
 import { isWebSocketSseFallbackActive } from "../../providers/openai-codex/websocket.ts";
 import { canonicalCompactionPromptInput, canonicalCompactionRequestBody } from "../../providers/openai-codex/session-continuity.ts";
 import { extractAccountId, resolveCodexWebSocketUrl } from "../../providers/openai-codex/headers.ts";
+import type { CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 const MAX_STREAM_RETRIES = 2;
 type V2Stream = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AsyncIterable<unknown>;
@@ -23,6 +24,7 @@ export type RemoteCompactionV2Usage = {
 	cachedInputTokens: number;
 	cacheWriteInputTokens: number;
 	outputTokens: number;
+	diagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 export type ExecuteRemoteCompactionV2Options = {
@@ -37,6 +39,7 @@ export type ExecuteRemoteCompactionV2Options = {
 	transport?: Transport | undefined;
 	retryDelayMs?: number | undefined;
 	promptInputSource?: "canonical" | "reconstructed" | undefined;
+	compactionDiagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 function resolveStream(options: ExecuteRemoteCompactionV2Options): V2Stream | undefined {
@@ -65,14 +68,18 @@ function shouldRetry(result: Extract<RemoteCompactionV2Result, { ok: false }>): 
 	return !/\b(?:401|403)\b|unauthori[sz]ed|forbidden|usage limit|quota|not included|invalid request|context window|unsupported parameter/i.test(result.errorMessage);
 }
 
-function compactionUsage(message: AssistantMessage): RemoteCompactionV2Usage | undefined {
+function compactionUsage(message: AssistantMessage, diagnostic: CodexCompactionDiagnostic): RemoteCompactionV2Usage | undefined {
 	const inputTokens = message.usage.input + message.usage.cacheRead + message.usage.cacheWrite;
 	const cachedInputTokens = message.usage.cacheRead;
 	const cacheWriteInputTokens = message.usage.cacheWrite;
 	const outputTokens = message.usage.output;
 	if (![inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens].every((value) => Number.isFinite(value) && value >= 0)) return undefined;
 	if (inputTokens + outputTokens === 0) return undefined;
-	return { inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens };
+	return { inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens, diagnostic: structuredClone(diagnostic) };
+}
+
+function diagnosticTransport(transport: Transport | undefined): "websocket" | "sse" {
+	return transport === "websocket" || transport === "websocket-cached" ? "websocket" : "sse";
 }
 
 function canonicalSessionIdentity(options: ExecuteRemoteCompactionV2Options): { url: string; accountId: string } | undefined {
@@ -113,6 +120,14 @@ function withCurrentCompactionControls(
 async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimple: V2Stream): Promise<RemoteCompactionV2Result> {
 	const outputItems: unknown[] = [];
 	let responseStatus: number | undefined;
+	const compactionDiagnostic = options.compactionDiagnostic ?? {
+		inputSource: options.promptInputSource ?? "reconstructed",
+		canonicalReplay: "not_applicable" as const,
+		checkpointReused: false,
+	};
+	if (!options.runtime.codexTransport) {
+		compactionDiagnostic.transport = diagnosticTransport(options.transport);
+	}
 	const canonicalIdentity = canonicalSessionIdentity(options);
 	const canonicalInput = options.promptInputSource === "canonical"
 		? options.promptInput
@@ -129,6 +144,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 		...(options.signal ? { signal: options.signal } : {}),
 		...(options.transport ? { transport: options.transport } : {}),
 		...(options.runtime.codexTransport ? { canonicalCompaction: true } : {}),
+		compactionDiagnostics: compactionDiagnostic,
 		maxRetries: options.runtime.codexTransport ? MAX_STREAM_RETRIES : 0,
 		...(typeof options.requestOptions.service_tier === "string" ? { serviceTier: options.requestOptions.service_tier as never } : {}),
 		...(options.requestOptions.text?.verbosity ? { textVerbosity: options.requestOptions.text.verbosity } : {}),
@@ -149,6 +165,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 				model: options.runtime.model,
 				contextWindow: options.runtime.currentModel.contextWindow,
 			}), tokensBefore: options.tokensBefore });
+			compactionDiagnostic.rewrittenToolOutputs = request.rewrittenOutputs;
 			return {
 				...requestBody,
 				input: [...request.request.input, { type: "compaction_trigger" }],
@@ -182,7 +199,7 @@ async function runAttempt(options: ExecuteRemoteCompactionV2Options, streamSimpl
 	if (compactions.length !== 1) {
 		return { ok: false, reason: "invalid-output", errorMessage: `Responses compaction v2 expected exactly one compaction output item, got ${compactions.length} from ${outputItems.length} output items` };
 	}
-	return { ok: true, compaction: compactions[0]!, responseId: completed.responseId, createdAt: new Date().toISOString(), usage: compactionUsage(completed) };
+	return { ok: true, compaction: compactions[0]!, responseId: completed.responseId, createdAt: new Date().toISOString(), usage: compactionUsage(completed, compactionDiagnostic) };
 }
 
 export async function executeRemoteCompactionV2(options: ExecuteRemoteCompactionV2Options): Promise<RemoteCompactionV2Result> {

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-history.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-history.ts
@@ -128,7 +128,7 @@ export function buildRemoteCompactionV2Window(
 	for (let index = retained.length - 1; index >= 0; index--) {
 		const item = retained[index]!;
 		const tokens = Math.max(1, messageTextTokenCount(item));
-		if (tokens <= remaining || reversed.length === 0) {
+		if (tokens <= remaining) {
 			reversed.push(item);
 			remaining = Math.max(0, remaining - tokens);
 		} else break;

--- a/packages/pi-codex-conversion/src/adapter/compaction/types.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/types.ts
@@ -1,4 +1,5 @@
 import type { CompactionEntry, CompactionResult } from "@earendil-works/pi-coding-agent";
+import { isCodexCompactionDiagnostic, type CodexCompactionDiagnostic } from "./diagnostics.ts";
 
 const LEGACY_NATIVE_COMPACTION_STRATEGY = "openai-native-compact-v1";
 export const NATIVE_COMPACTION_STRATEGY = "openai-responses-compaction-v2";
@@ -31,6 +32,7 @@ export type NativeCompactionUsage = {
 	cachedInputTokens: number;
 	cacheWriteInputTokens: number;
 	outputTokens: number;
+	diagnostic?: CodexCompactionDiagnostic | undefined;
 };
 
 export type NativeCompactionIdentity = {
@@ -155,7 +157,8 @@ export function isNativeCompactionRequestMeta(value: unknown): value is NativeCo
 
 export function isNativeCompactionUsage(value: unknown): value is NativeCompactionUsage {
 	if (!isRecord(value)) return false;
-	return [value["inputTokens"], value["cachedInputTokens"], value["cacheWriteInputTokens"], value["outputTokens"]].every(isFiniteNonNegativeNumber);
+	return [value["inputTokens"], value["cachedInputTokens"], value["cacheWriteInputTokens"], value["outputTokens"]].every(isFiniteNonNegativeNumber)
+		&& (value["diagnostic"] === undefined || isCodexCompactionDiagnostic(value["diagnostic"]));
 }
 
 export function isNativeCompactionDetails(value: unknown): value is NativeCompactionDetails {

--- a/packages/pi-codex-conversion/src/adapter/provider-request.ts
+++ b/packages/pi-codex-conversion/src/adapter/provider-request.ts
@@ -81,7 +81,13 @@ export async function rewriteCodexProviderRequest(payload: unknown, ctx: Extensi
 		const piCompactionPayload = await injectPendingNativeWindowIntoPiCompactionRequest(configuredPayload, ctx, state);
 		rewrittenPayload = piCompactionPayload ?? (await rewriteCodexCompactedProviderRequest(configuredPayload, ctx, state)) ?? configuredPayload;
 	}
-	return applyCodexRuntimePayload(rewrittenPayload, isCodeModeRuntime(plan));
+	const finalPayload = applyCodexRuntimePayload(rewrittenPayload, isCodeModeRuntime(plan));
+	// Stock Responses providers and configured Code Mode overlays have no
+	// post-serialization callback. Keep native replay on the instructions that
+	// reached this final hook boundary; the custom Codex provider captures again
+	// after its transport-specific transforms.
+	if (state.pendingActiveProviderPromptCapture) captureActiveProviderSystemPrompt(finalPayload, state);
+	return finalPayload;
 }
 
 export function rewriteCodexPrewarmProviderRequest(

--- a/packages/pi-codex-conversion/src/apply-patch-display.ts
+++ b/packages/pi-codex-conversion/src/apply-patch-display.ts
@@ -1,0 +1,74 @@
+import type {
+	EntryRenderer,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import {
+	APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+	APPLY_PATCH_DISPLAY_PROTOCOL,
+	APPLY_PATCH_DISPLAY_REQUEST_CHANNEL,
+	type ApplyPatchDisplayBroker,
+	isApplyPatchDisplayBroker,
+} from "./tools/apply-patch/display-protocol.js";
+import type { ApplyPatchToolDetails } from "./tools/apply-patch/render-state.js";
+
+export interface ApplyPatchDisplayData {
+	toolCallId: string;
+	input: string;
+	details?: ApplyPatchToolDetails | undefined;
+	content?: string | undefined;
+	error?: string | undefined;
+	isError: boolean;
+	source: "direct" | "nested";
+}
+
+export interface ApplyPatchDisplayOptions {
+	customType: string;
+	render: EntryRenderer<ApplyPatchDisplayData>;
+}
+
+export interface ApplyPatchDisplayRegistration {
+	readonly available: boolean;
+	dispose(): void;
+}
+
+export function registerApplyPatchDisplay(
+	pi: ExtensionAPI,
+	options: ApplyPatchDisplayOptions,
+): ApplyPatchDisplayRegistration {
+	const customType = options.customType.trim();
+	if (!customType)
+		throw new Error("apply_patch display customType cannot be empty");
+	pi.registerEntryRenderer(customType, options.render);
+
+	let broker: ApplyPatchDisplayBroker | undefined;
+	let unregisterDisplay: (() => void) | undefined;
+	let disposed = false;
+	const unregisterAvailable = pi.events.on(
+		APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+		(value) => {
+			if (disposed || !isApplyPatchDisplayBroker(value) || value === broker)
+				return;
+			unregisterDisplay?.();
+			broker = value;
+			unregisterDisplay = value.register(customType);
+		},
+	);
+	const registration: ApplyPatchDisplayRegistration = {
+		get available() {
+			return !disposed && (broker?.isActive() ?? false);
+		},
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			unregisterAvailable();
+			unregisterDisplay?.();
+			unregisterDisplay = undefined;
+			broker = undefined;
+		},
+	};
+	pi.on("session_shutdown", () => registration.dispose());
+	pi.events.emit(APPLY_PATCH_DISPLAY_REQUEST_CHANNEL, {
+		protocol: APPLY_PATCH_DISPLAY_PROTOCOL,
+	});
+	return registration;
+}

--- a/packages/pi-codex-conversion/src/diagnostics/logger.ts
+++ b/packages/pi-codex-conversion/src/diagnostics/logger.ts
@@ -61,6 +61,12 @@ function eventFields(event: CodexDiagnosticsEvent): Array<string | undefined> {
 		field("previous_response_id", event.previousResponseId),
 		field("full_input_items", event.fullInputItems),
 		field("sent_input_items", event.sentInputItems),
+		field("model", event.model),
+		field("compaction_source", event.compaction?.inputSource),
+		field("compaction_replay", event.compaction?.canonicalReplay),
+		field("checkpoint_reused", event.compaction?.checkpointReused),
+		field("checkpoint_model", event.compaction?.checkpointModel),
+		field("rewritten_tool_outputs", event.compaction?.rewrittenToolOutputs),
 	];
 	if (event.type === "usage") {
 		const totalInput = event.inputTokens + event.cachedInputTokens + event.cacheWriteInputTokens;

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -191,12 +191,11 @@ export function registerCodexEvents(
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const failures: unknown[] = [];
+		await runShutdownStep(failures, () => ui.invalidateBackgroundWidget());
 		await runShutdownStep(failures, () => runtime.lanVoice.stop(ctx));
 		await runShutdownStep(failures, () => runtime.voice.stop({ announce: true }));
 		await runShutdownStep(failures, () => runtime.shutdownTransport(ctx.sessionManager.getSessionId()));
 		await runShutdownStep(failures, () => runtime.shutdownDiagnostics());
-		await runShutdownStep(failures, () => ui.clearBackgroundWidget());
-		runtime.backgroundWidget.ctx = undefined;
 		await runShutdownStep(failures, () => sessions.shutdown());
 		await runShutdownStep(failures, () => proxyProvider.shutdown());
 		await runShutdownStep(failures, () => codeMode.shutdown());

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -227,7 +227,11 @@ export function registerCodexEvents(
 		const update = event.assistantMessageEvent;
 		if (update.type === "text_delta" && typeof update.delta === "string") runtime.voice.streamDelta(update.delta);
 	});
-	pi.on("agent_start", async () => { runtime.voice.agentStarted(); runtime.lanVoice.agentStarted(); });
+	pi.on("agent_start", async () => {
+		runtime.cancelCacheKeepalive();
+		runtime.voice.agentStarted();
+		runtime.lanVoice.agentStarted();
+	});
 	pi.on("agent_settled", async (_event, ctx) => {
 		state.pendingActiveProviderPromptCapture = false;
 		state.voiceSystemPromptOverride = undefined;
@@ -235,6 +239,7 @@ export function registerCodexEvents(
 		runtime.voice.settleTurn();
 		runtime.lanVoice.agentSettled();
 		if (!state.config.voiceFeaturesOnly) void ui.refreshUsageStatus(ctx);
+		runtime.armCacheKeepalive(ctx);
 	});
 	pi.on("before_provider_request", async (event, ctx) => {
 		state.cwd = ctx.cwd;

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -17,6 +17,7 @@ import { parseRealtimeVoicePrompt, REALTIME_VOICE_PROMPT_CHANNEL } from "../real
 import { initializeBashParser } from "../shell/bash.ts";
 import { prepareVoiceDelegation } from "../voice/delegation-preflight.ts";
 import { appendNotebookTreeEpoch } from "../tools/notebook-mode/session-identity.ts";
+import { formatCompactionCacheDiagnostic } from "../adapter/compaction/diagnostics.ts";
 import type { CodexExtensionRuntime } from "./runtime.ts";
 import type { CodexToolRegistration } from "./tools.ts";
 import type { CodexUiController } from "./ui.ts";
@@ -24,7 +25,8 @@ import type { CodexUiController } from "./ui.ts";
 function formatCompactionUsage(usage: NativeCompactionUsage): string {
 	const ratio = usage.inputTokens > 0 ? `${((usage.cachedInputTokens / usage.inputTokens) * 100).toFixed(1)}%` : "0%";
 	const tokens = (value: number) => Math.round(value).toLocaleString("en-US");
-	return `Compaction V2 · input ${tokens(usage.inputTokens)} · cache read ${tokens(usage.cachedInputTokens)} (${ratio}) · cache write ${tokens(usage.cacheWriteInputTokens)} · output ${tokens(usage.outputTokens)}`;
+	const diagnostic = formatCompactionCacheDiagnostic(usage, usage.diagnostic);
+	return `Compaction V2 · input ${tokens(usage.inputTokens)} · cache read ${tokens(usage.cachedInputTokens)} (${ratio}) · cache write ${tokens(usage.cacheWriteInputTokens)} · output ${tokens(usage.outputTokens)}${diagnostic ? ` ${diagnostic}` : ""}`;
 }
 
 function commandArg(args: unknown): string | undefined {

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerCodeModeProxyProvider } from "../providers/code-mode-proxy-provider.ts";
 import { registerOpenAICodexCustomProvider } from "../providers/openai-codex-custom-provider.ts";
+import { registerApplyPatchDisplayBroker } from "../tools/apply-patch/display-broker.ts";
 import { registerCodexCommand } from "../ui/settings/command.ts";
 import { registerCodexCodeMode } from "../adapter/code-mode.ts";
 import { prepareCodeModeHost, registerCanonicalAliasEndpointPreflight, registerCodexEvents } from "./events.ts";
@@ -13,6 +14,7 @@ import { captureActiveProviderSystemPrompt } from "../adapter/provider-request.t
 
 export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 	registerCodexVoiceRenderer(pi);
+	registerApplyPatchDisplayBroker(pi);
 	const runtime = createCodexExtensionRuntime(pi);
 	registerCanonicalAliasEndpointPreflight(pi, runtime);
 	const codeMode = await registerCodexCodeMode(pi, runtime);

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -47,6 +47,9 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 						&& config.openai.cacheDiagnostics === "status-and-log",
 				);
 			}
+			if (config.openai.cacheKeepalive !== previousConfig.openai.cacheKeepalive) {
+				runtime.cancelCacheKeepalive();
+			}
 			if (
 				config.voiceFeaturesOnly !== previousConfig.voiceFeaturesOnly
 				|| executionModeChanged

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -12,7 +12,7 @@ import { buildCodexSystemPrompt, type PiSystemPromptOptions } from "../prompt/bu
 import { closeOpenAICodexWebSocketSessions, prewarmOpenAICodexWebSocket } from "../providers/openai-codex-custom-provider.ts";
 import { resetOpenAICodexWebSocketSessions } from "../providers/openai-codex/websocket.ts";
 import { createCodexTurnState } from "../providers/openai-codex/turn-state.ts";
-import type { OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
+import type { CodexPrewarmUsage, OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
 import { createExecCommandTracker } from "../tools/exec/command-state.ts";
 import { createExecSessionManager } from "../tools/exec/session-manager.ts";
 import { getBundledToolBinaryPath } from "../tools/native/binary.ts";
@@ -26,7 +26,8 @@ import type { CodexDiagnosticsSink } from "../providers/openai-codex/types.ts";
 export type CodexContext = ExtensionContext;
 
 export type CodexPrewarmResult =
-	| { status: "ready" }
+	| { status: "ready"; usage?: CodexPrewarmUsage | undefined; socketReused?: boolean | undefined }
+	| { status: "skipped" }
 	| { status: "aborted" }
 	| { status: "failed"; error: Error };
 
@@ -41,6 +42,9 @@ export interface CodexExtensionRuntime {
 	codexSystemPrompt(basePrompt: string, ctx: CodexContext, skills?: AdapterState["promptSkills"], systemPromptOptions?: PiSystemPromptOptions): string;
 	startPrewarm(ctx: CodexContext, systemPrompt?: string, prepared?: boolean): Promise<CodexPrewarmResult> | undefined;
 	startCompactionPrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
+	startKeepalivePrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
+	armCacheKeepalive(ctx: CodexContext): void;
+	cancelCacheKeepalive(): void;
 	resetTransport(sessionId?: string): void;
 	resetTransportAfterCompaction(sessionId: string): void;
 	shutdownTransport(sessionId: string): void;
@@ -50,6 +54,8 @@ export interface CodexExtensionRuntime {
 	diagnosticsSink(): CodexDiagnosticsSink | undefined;
 	shutdownDiagnostics(): Promise<void>;
 }
+
+const CACHE_KEEPALIVE_INTERVAL_MS = 25 * 60 * 1000;
 
 function activeToolContext(pi: ExtensionAPI): NonNullable<Context["tools"]> {
 	// Pi ToolInfo omits constrainedSampling; restore our owned exec contract so
@@ -78,9 +84,14 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	});
 	let prewarmController: AbortController | undefined;
 	let prewarmPromise: Promise<CodexPrewarmResult> | undefined;
-	let prewarmTransportSettlement: Promise<void> | undefined;
+	let prewarmTransportSettlement: Promise<unknown> | undefined;
 	let pendingPrewarmKey: string | undefined;
 	let prewarmedIdentity: string | undefined;
+	let activePrewarmKind: "ordinary" | "keepalive" | undefined;
+	let cacheKeepaliveTimer: ReturnType<typeof setTimeout> | undefined;
+	let cacheKeepaliveEpoch = 0;
+	let consecutiveRedKeepalives = 0;
+	let cacheKeepalivePaused = false;
 	const voice = new CodexVoiceController(pi);
 	const diagnostics = createLazyCodexDiagnostics();
 	const buildPrewarmPlan = (
@@ -88,12 +99,13 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		systemPrompt: string,
 		prepared: boolean,
 		messages: Context["messages"],
-		rewriteCompactedReplay: boolean,
+		rewriteFinalRequest: boolean,
 	) => {
 		const model = ctx.model;
 		const config = structuredClone(state.config);
 		const executionMode = state.executionMode;
-		if (!model || model.provider !== "openai-codex" || !isAdapterRuntime(resolveCodexRuntimePlan(ctx, config, executionMode)) || !config.openai.forceCachedWebSockets) return undefined;
+		const runtimePlan = resolveCodexRuntimePlan(ctx, config, executionMode);
+		if (!model || !runtimePlan.codexTransport || !isAdapterRuntime(runtimePlan) || !config.openai.forceCachedWebSockets) return undefined;
 		const preparedSystemPrompt = prepared
 			? systemPrompt
 			: runtime.codexSystemPrompt(systemPrompt, ctx);
@@ -111,7 +123,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		const key = JSON.stringify({
 			identity,
 			messages,
-			rewriteCompactedReplay,
+			rewriteFinalRequest,
 		});
 		return {
 			model,
@@ -129,18 +141,21 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		systemPrompt = ctx.getSystemPrompt(),
 		prepared = false,
 		messages: Context["messages"] = [],
-		rewriteCompactedReplay = false,
+		rewriteFinalRequest = false,
+		force = false,
+		kind: "ordinary" | "keepalive" = "ordinary",
 	): Promise<CodexPrewarmResult> | undefined => {
-		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteCompactedReplay);
+		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteFinalRequest);
 		if (!plan) return undefined;
 		const { model, config, executionMode, preparedSystemPrompt, tools, reasoning, identity, key: prewarmKey } = plan;
 		if (pendingPrewarmKey === prewarmKey) return prewarmPromise;
-		if (!pendingPrewarmKey && prewarmedIdentity === identity) return undefined;
+		if (!force && !pendingPrewarmKey && prewarmedIdentity === identity) return undefined;
 		const previousTransportSettlement = prewarmTransportSettlement;
 		prewarmedIdentity = undefined;
 		prewarmController?.abort();
 		const controller = new AbortController();
 		prewarmController = controller;
+		activePrewarmKind = kind;
 		pendingPrewarmKey = prewarmKey;
 		const promise = (async () => {
 			if (previousTransportSettlement) await previousTransportSettlement.catch(() => undefined);
@@ -166,7 +181,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 						...reasoning,
 						textVerbosity: config.openai.verbosity,
 						...(config.openai.fast ? { serviceTier: "priority" as const } : {}),
-						onPayload: (body) => rewriteCompactedReplay
+						onPayload: (body) => rewriteFinalRequest
 							? rewriteCodexProviderRequest(body, ctx, { ...state, config, executionMode })
 							: rewriteCodexPrewarmProviderRequest(body, ctx, { ...state, config, executionMode }),
 					},
@@ -179,7 +194,11 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 				);
 				prewarmTransportSettlement = transportSettlement;
 				try {
-					await transportSettlement;
+					const result = await transportSettlement;
+					if (controller.signal.aborted) return { status: "aborted" } as const;
+					if (!result) return { status: "skipped" } as const;
+					prewarmedIdentity = identity;
+					return { status: "ready", ...(result.usage ? { usage: result.usage } : {}), socketReused: result.socketReused } as const;
 				} finally {
 					if (prewarmTransportSettlement === transportSettlement) prewarmTransportSettlement = undefined;
 				}
@@ -191,18 +210,96 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 				}
 				return { status: "failed", error: failure } as const;
 			}
-			if (controller.signal.aborted) return { status: "aborted" } as const;
-			prewarmedIdentity = identity;
-			return { status: "ready" } as const;
 		})().finally(() => {
 			if (prewarmPromise === promise) {
 				prewarmPromise = undefined;
 				if (pendingPrewarmKey === prewarmKey) pendingPrewarmKey = undefined;
 			}
-			if (prewarmController === controller) prewarmController = undefined;
+			if (prewarmController === controller) {
+				prewarmController = undefined;
+				activePrewarmKind = undefined;
+			}
 		});
 		prewarmPromise = promise;
 		return promise;
+	};
+
+	const currentContextPrewarm = (ctx: CodexContext, force: boolean) => {
+		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
+			.filter((message) => !isProviderContextExcludedMessage(message));
+		const activeSystemPrompt = state.activeProviderSystemPrompt;
+		return startPrewarm(
+			ctx,
+			activeSystemPrompt ?? ctx.getSystemPrompt(),
+			activeSystemPrompt !== undefined,
+			convertToLlm(messages),
+			true,
+			force,
+			force ? "keepalive" : "ordinary",
+		);
+	};
+
+	const cancelCacheKeepalive = () => {
+		cacheKeepaliveEpoch++;
+		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
+		cacheKeepaliveTimer = undefined;
+		if (activePrewarmKind === "keepalive") prewarmController?.abort();
+	};
+
+	const formatKeepaliveMetrics = (usage: CodexPrewarmUsage, socketReused: boolean | undefined) => {
+		const total = usage.inputTokens + usage.cachedInputTokens;
+		const ratio = total > 0 ? usage.cachedInputTokens / total : undefined;
+		return {
+			ratio,
+			message: `Codex cache keepalive · input ${usage.inputTokens.toLocaleString("en-US")} · read ${usage.cachedInputTokens.toLocaleString("en-US")} · write ${usage.cacheWriteInputTokens.toLocaleString("en-US")} · ${ratio === undefined ? "cache unavailable" : `${(ratio * 100).toFixed(1)}%`} · WS ${socketReused ? "reused" : "new"}`,
+		};
+	};
+
+	const scheduleCacheKeepalive = (ctx: CodexContext, epoch: number) => {
+		if (cacheKeepalivePaused || !state.config.openai.cacheKeepalive) return;
+		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
+		cacheKeepaliveTimer = setTimeout(() => {
+			cacheKeepaliveTimer = undefined;
+			if (epoch !== cacheKeepaliveEpoch || !ctx.isIdle()) return;
+			const keepalive = currentContextPrewarm(ctx, true);
+			if (!keepalive) return;
+			void keepalive.then((result) => {
+				if (epoch !== cacheKeepaliveEpoch || result.status === "aborted" || result.status === "skipped") return;
+				if (result.status === "failed") {
+					ctx.ui.notify(`Codex cache keepalive failed: ${result.error.message}`, "warning");
+					scheduleCacheKeepalive(ctx, epoch);
+					return;
+				}
+				if (!result.usage) {
+					consecutiveRedKeepalives = 0;
+					ctx.ui.notify("Codex cache keepalive completed without usage metrics", "warning");
+					scheduleCacheKeepalive(ctx, epoch);
+					return;
+				}
+				const metrics = formatKeepaliveMetrics(result.usage, result.socketReused);
+				if (metrics.ratio !== undefined && metrics.ratio <= 0.1) {
+					consecutiveRedKeepalives++;
+					ctx.ui.notify(metrics.message, "error");
+					if (consecutiveRedKeepalives >= 2) {
+						cacheKeepalivePaused = true;
+						ctx.ui.notify("Codex cache keepalive paused after two consecutive ≤10% reads", "error");
+						return;
+					}
+				} else {
+					consecutiveRedKeepalives = 0;
+					ctx.ui.notify(metrics.message, metrics.ratio !== undefined && metrics.ratio < 0.5 ? "warning" : "info");
+				}
+				scheduleCacheKeepalive(ctx, epoch);
+			});
+		}, CACHE_KEEPALIVE_INTERVAL_MS);
+		cacheKeepaliveTimer.unref?.();
+	};
+
+	const armCacheKeepalive = (ctx: CodexContext) => {
+		cancelCacheKeepalive();
+		consecutiveRedKeepalives = 0;
+		cacheKeepalivePaused = false;
+		scheduleCacheKeepalive(ctx, cacheKeepaliveEpoch);
 	};
 
 	const runtime: CodexExtensionRuntime = {
@@ -237,18 +334,19 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			return startPrewarm(ctx, systemPrompt, prepared);
 		},
 		startCompactionPrewarm(ctx) {
-			const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
-				.filter((message) => !isProviderContextExcludedMessage(message));
-			const activeSystemPrompt = state.activeProviderSystemPrompt;
-			return startPrewarm(
-				ctx,
-				activeSystemPrompt ?? ctx.getSystemPrompt(),
-				activeSystemPrompt !== undefined,
-				convertToLlm(messages),
-				true,
-			);
+			return currentContextPrewarm(ctx, false);
+		},
+		startKeepalivePrewarm(ctx) {
+			return currentContextPrewarm(ctx, true);
+		},
+		armCacheKeepalive(ctx) {
+			armCacheKeepalive(ctx);
+		},
+		cancelCacheKeepalive() {
+			cancelCacheKeepalive();
 		},
 		resetTransport(sessionId) {
+			cancelCacheKeepalive();
 			prewarmController?.abort();
 			prewarmController = undefined;
 			pendingPrewarmKey = undefined;
@@ -262,6 +360,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			closeOpenAICodexWebSocketSessions(sessionId);
 		},
 		shutdownTransport(sessionId) {
+			cancelCacheKeepalive();
 			runtime.resetTransport(sessionId);
 			closeOpenAICodexWebSocketSessions(sessionId);
 		},

--- a/packages/pi-codex-conversion/src/extension/ui.ts
+++ b/packages/pi-codex-conversion/src/extension/ui.ts
@@ -10,6 +10,7 @@ import { fetchCodexWeeklyUsageLeft } from "../codex-usage/client.ts";
 
 export interface CodexUiController {
 	clearBackgroundWidget(): void;
+	invalidateBackgroundWidget(): void;
 	renderBackgroundWidget(): void;
 	invalidateUsageStatus(): void;
 	applyConfig(config: CodexConversionConfig, ctx: ExtensionContext, previousConfig: CodexConversionConfig): void;
@@ -18,13 +19,25 @@ export interface CodexUiController {
 
 export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime): CodexUiController {
 	let renderTimer: ReturnType<typeof setTimeout> | undefined;
+	let backgroundWidgetGeneration = 0;
 	let usageGeneration = 0;
-	const clearBackgroundWidget = () => {
+	const cancelScheduledBackgroundRender = () => {
+		backgroundWidgetGeneration += 1;
 		if (renderTimer) clearTimeout(renderTimer);
 		renderTimer = undefined;
+	};
+	const clearBackgroundWidget = () => {
+		cancelScheduledBackgroundRender();
 		runtime.backgroundWidget.ctx?.ui.setWidget(BACKGROUND_BASH_WIDGET_ID, undefined);
 	};
-	const renderBackgroundWidget = () => {
+	const invalidateBackgroundWidget = () => {
+		cancelScheduledBackgroundRender();
+		const ctx = runtime.backgroundWidget.ctx;
+		runtime.backgroundWidget.ctx = undefined;
+		ctx?.ui.setWidget(BACKGROUND_BASH_WIDGET_ID, undefined);
+	};
+	const renderBackgroundWidget = (generation = backgroundWidgetGeneration) => {
+		if (generation !== backgroundWidgetGeneration) return;
 		const ctx = runtime.backgroundWidget.ctx;
 		if (!ctx) return;
 		if (runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.backgroundShellWidget) {
@@ -64,14 +77,14 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 		if (!runtime.backgroundWidget.ctx || runtime.state.config.voiceFeaturesOnly || !runtime.state.config.ui.backgroundShellWidget) return;
 		if (reason === "output") {
 			if (renderTimer) return;
+			const generation = backgroundWidgetGeneration;
 			renderTimer = setTimeout(() => {
 				renderTimer = undefined;
-				renderBackgroundWidget();
+				renderBackgroundWidget(generation);
 			}, 250);
 			return;
 		}
-		if (renderTimer) clearTimeout(renderTimer);
-		renderTimer = undefined;
+		cancelScheduledBackgroundRender();
 		renderBackgroundWidget();
 	});
 	const invalidateUsageStatus = () => {
@@ -100,6 +113,7 @@ export function registerCodexUi(pi: ExtensionAPI, runtime: CodexExtensionRuntime
 
 	return {
 		clearBackgroundWidget,
+		invalidateBackgroundWidget,
 		renderBackgroundWidget,
 		invalidateUsageStatus,
 		refreshUsageStatus,

--- a/packages/pi-codex-conversion/src/index.ts
+++ b/packages/pi-codex-conversion/src/index.ts
@@ -7,4 +7,18 @@ export default async function codexConversion(pi: ExtensionAPI): Promise<void> {
 	await registerCodexConversion(pi);
 }
 
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchRenderCall,
+	ApplyPatchRenderResult,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+	ApplyPatchToolOptions,
+	ExecutePatchResult,
+} from "./tools/apply-patch/tool.ts";
+export {
+	createApplyPatchTool,
+	isApplyPatchToolDetails,
+	registerApplyPatchResultEvent,
+} from "./tools/apply-patch/tool.ts";
 export { getCodexSkillPaths, mergeAdapterTools, restoreTools, stripAdapterTools };

--- a/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
+++ b/packages/pi-codex-conversion/src/prompt/build-system-prompt.ts
@@ -63,9 +63,8 @@ const CODE_MODE_GUIDELINES = [
 
 const NOTEBOOK_MODE_GUIDELINES = [
 	"exec is a persistent Deno/TypeScript Jupyter notebook; project globals may come from earlier agents and sessions",
-	"Before repeating discovery or rebuilding helpers, use notebook status and reuse matching bindings",
-	"Keep one-offs block-local; store compact reusable values and self-contained helpers on purpose-named globalThis properties",
-	"Turn repeatable project work into callable helpers; pin reusable project state worth protecting",
+	"Check notebook status and reuse matching retained globals before rebuilding; inspect description/usage before constructing reusable ones",
+	"Keep one-offs block-local; store cheap reusable state and repeatable helpers on purpose-named globalThis properties as unpinned scratch, pin only important prune-resistant state; give helpers concise description/usage with a safe inspection recipe",
 	...CODE_MODE_GUIDELINES,
 	"Use notebook status to inspect retained state or memory, release/prune disposable state, and diagnostics after broken state or helpers",
 	"Filter retained data inside exec and return only needed findings; never dump the namespace",

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -8,7 +8,7 @@ import { buildRequestBody } from "./openai-codex/request-body.ts";
 import { openAICodexModelsWithDaybreak } from "./openai-codex/model-catalog.ts";
 import { supportsResponsesLiteModel } from "./openai-codex/responses-lite-model.ts";
 import { applyResponsesLiteRequest, applyResponsesLiteWebSocketMetadata, isResponsesLiteRequest, namespaceExistingResponsesLiteRequest, prepareResponsesLiteRequestImages } from "./openai-codex/responses-lite.ts";
-import type { CodexDiagnosticsSink, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
+import type { CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { recordWebSocketSseFallback } from "./openai-codex/websocket.ts";
 import { isWebSocketMessageTooBigError, isWebSocketUpgradeRequiredError } from "./openai-codex/websocket-connection.ts";
 import { prewarmWebSocket } from "./openai-codex/websocket-stream.ts";
@@ -60,7 +60,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 		turnState?: CodexTurnState | undefined;
 		getDiagnostics?: (() => CodexDiagnosticsSink | undefined) | undefined;
 	},
-): Promise<void> {
+): Promise<CodexPrewarmResult | undefined> {
 	const runtimeConfig = deps.getConfig?.();
 	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai, options.sessionId) === "sse") return;
 	if (!options.apiKey || !options.sessionId) return;
@@ -83,7 +83,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	const websocketBody = withCodexTurnState(responsesLite ? applyResponsesLiteWebSocketMetadata(body) : body, deps.turnState);
 	const diagnostics = noThrowCodexDiagnosticsSink(deps.getDiagnostics?.());
 	try {
-		await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, deps.turnState, diagnostics);
+		return await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, deps.turnState, diagnostics);
 	} catch (error) {
 		if (!options.signal?.aborted && (isWebSocketUpgradeRequiredError(error) || isWebSocketMessageTooBigError(error))) {
 			recordWebSocketSseFallback(options.sessionId);

--- a/packages/pi-codex-conversion/src/providers/openai-codex/session-continuity.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/session-continuity.ts
@@ -1,5 +1,6 @@
 import type { CanonicalHistoryDecision, ResponsesBody } from "./types.ts";
 import { responseInputsEqual } from "./websocket-continuation.ts";
+import type { CodexCompactionReplayDecision } from "../../adapter/compaction/diagnostics.ts";
 
 export type CanonicalSessionToken = {
 	laneIdentity: symbol;
@@ -126,15 +127,29 @@ export function canonicalCompactionPromptInput(
 	identity?: { url: string; accountId: string } | undefined,
 	reconstructedInput?: readonly unknown[] | undefined,
 ): unknown[] | undefined {
+	return resolveCanonicalCompactionPromptInput(sessionId, model, identity, reconstructedInput).input;
+}
+
+export function resolveCanonicalCompactionPromptInput(
+	sessionId: string,
+	model: string,
+	identity?: { url: string; accountId: string } | undefined,
+	reconstructedInput?: readonly unknown[] | undefined,
+): { input?: unknown[] | undefined; decision: CodexCompactionReplayDecision } {
 	const state = canonicalSessions.get(sessionId);
-	if (!state || state.requestBody.model !== model) return undefined;
-	if (identity && (state.url !== identity.url || state.accountId !== identity.accountId)) return undefined;
-	if (!reconstructedInput) return structuredClone(materializedInput(state));
-	return replayCanonicalInput(
+	if (!state) return { decision: "no_state" };
+	if (state.requestBody.model !== model) return { decision: "model_mismatch" };
+	if (identity && (state.url !== identity.url || state.accountId !== identity.accountId)) return { decision: "identity_mismatch" };
+	if (!reconstructedInput) return { input: structuredClone(materializedInput(state)), decision: "validated" };
+	const replay = replayCanonicalInput(
 		state,
 		reconstructedInput,
 		responsesLiteRequestPrefixLength(state.reconstructedRequestInput),
-	).input;
+	);
+	return {
+		...(replay.input ? { input: replay.input } : {}),
+		decision: replay.decision === "compaction" ? "validated" : replay.decision,
+	};
 }
 
 export function canonicalCompactionRequestBody(

--- a/packages/pi-codex-conversion/src/providers/openai-codex/transport-recovery.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/transport-recovery.ts
@@ -369,6 +369,15 @@ export function createCodexTransportStream<TApi extends Api>(
 				if (attempt > 0) output = createInitialAssistantMessage(model);
 				const responseItems: unknown[] = [];
 				try {
+					if (effectiveOptions?.compactionDiagnostics) {
+						Object.assign(effectiveOptions.compactionDiagnostics, {
+							transport: "sse",
+							continuation: undefined,
+							previousResponseId: false,
+							fullInputItems: body.input.length,
+							sentInputItems: body.input.length,
+						});
+					}
 					diagnostics?.({
 						type: "request",
 						lane,
@@ -376,7 +385,9 @@ export function createCodexTransportStream<TApi extends Api>(
 						attempt: attempt + 1,
 						fullInputItems: body.input.length,
 						sentInputItems: body.input.length,
+						model: body.model,
 						...(canonicalHistory ? { canonicalHistory } : {}),
+						...(effectiveOptions?.compactionDiagnostics ? { compaction: structuredClone(effectiveOptions.compactionDiagnostics) } : {}),
 					});
 					const response = await openCodexSSE(model, sseBody, baseSseHeaders, effectiveOptions, deps.turnState);
 					if (!response.body) throw new Error("No response body");

--- a/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
@@ -173,6 +173,17 @@ export interface ResponsesBody {
 	[key: string]: unknown;
 }
 
+export interface CodexPrewarmUsage {
+	inputTokens: number;
+	cachedInputTokens: number;
+	cacheWriteInputTokens: number;
+}
+
+export interface CodexPrewarmResult {
+	socketReused: boolean;
+	usage?: CodexPrewarmUsage | undefined;
+}
+
 export interface ResponseEnvelope {
 	id?: string | undefined;
 	status?: string | undefined;

--- a/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import type { CodexCompactionDiagnostic } from "../../adapter/compaction/diagnostics.ts";
 
 export interface WebSocketLike {
 	readyState?: number | undefined;
@@ -78,9 +79,11 @@ export type CodexDiagnosticsEvent =
 			attempt: number;
 			fullInputItems: number;
 			sentInputItems: number;
+			model?: string | undefined;
 			socketReused?: boolean | undefined;
 			continuation?: WebSocketContinuationDecision | undefined;
 			canonicalHistory?: CanonicalHistoryDecision | undefined;
+			compaction?: CodexCompactionDiagnostic | undefined;
 			previousResponseId?: boolean | undefined;
 	  }
 	| {
@@ -143,6 +146,7 @@ export type OpenAICodexStreamOptions = CodexProviderStreamOptions & {
 	websocketConnectTimeoutMs?: number | undefined;
 	env?: ProviderEnv | undefined;
 	canonicalCompaction?: boolean | undefined;
+	compactionDiagnostics?: CodexCompactionDiagnostic | undefined;
 };
 
 export interface ResponsesBody {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -3,7 +3,7 @@ import { normalizeTimeoutMs } from "./sse.ts";
 import { buildCachedWebSocketRequestBody } from "./websocket-continuation.ts";
 import { acquireWebSocket, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket.ts";
 import { assertSuccessfulCodexOutput, assertSuccessfulCodexStatus, mapCodexEvents, processMappedCodexResponsesStream } from "./stream-events.ts";
-import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
+import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
 import type { CodexTurnState } from "./turn-state.ts";
 import { DEFAULT_STREAM_IDLE_TIMEOUT_MS, DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS } from "./constants.ts";
 import { codexDiagnosticsFailure, noThrowCodexDiagnosticsSink } from "./diagnostic-failure.ts";
@@ -143,7 +143,7 @@ export async function prewarmWebSocket(
 	options: OpenAICodexStreamOptions,
 	turnState?: CodexTurnState,
 	diagnostics?: CodexDiagnosticsSink | undefined,
-): Promise<void> {
+): Promise<CodexPrewarmResult> {
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics);
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
 	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, options.sessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
@@ -151,6 +151,7 @@ export async function prewarmWebSocket(
 	const responseItems: unknown[] = [];
 	let responseId: string | undefined;
 	let responseStatus: string | undefined;
+	let usage: CodexPrewarmResult["usage"];
 	const idleTimeoutMs = normalizeTimeoutMs(options.timeoutMs ?? options.websocketConnectTimeoutMs ?? DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS, "timeoutMs");
 	try {
 		recordDiagnostics?.({
@@ -170,6 +171,16 @@ export async function prewarmWebSocket(
 			if (event.type === "response.completed") {
 				if (event.response?.id) responseId = event.response.id;
 				responseStatus = event.response?.status;
+				const responseUsage = event.response?.usage;
+				if (responseUsage) {
+					const cacheRead = responseUsage.input_tokens_details?.cached_tokens ?? 0;
+					const cacheWrite = responseUsage.input_tokens_details?.cache_write_tokens ?? 0;
+					usage = {
+						inputTokens: Math.max(0, (responseUsage.input_tokens ?? 0) - cacheRead - cacheWrite),
+						cachedInputTokens: cacheRead,
+						cacheWriteInputTokens: cacheWrite,
+					};
+				}
 			}
 		}
 		assertSuccessfulCodexStatus(responseStatus);
@@ -177,6 +188,7 @@ export async function prewarmWebSocket(
 			entry.continuation = { lastRequestBody: body, lastResponseId: responseId, lastResponseItems: responseItems };
 		}
 		recordDiagnostics?.({ type: "prewarm-ready", transport: "websocket", socketReused: reused });
+		return { socketReused: reused, ...(usage ? { usage } : {}) };
 	} catch (error) {
 		keepConnection = false;
 		recordDiagnostics?.({

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -45,6 +45,15 @@ export async function processWebSocketStream<TApi extends Api>(
 		: { body: fullBody, decision: useCachedContext ? "no_session_cache_entry" : "disabled" } satisfies CachedWebSocketRequestBodyResult;
 	const requestBody = cachedRequest.body;
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics?.record);
+	if (options?.compactionDiagnostics) {
+		Object.assign(options.compactionDiagnostics, {
+			transport: "websocket",
+			continuation: cachedRequest.decision,
+			previousResponseId: Boolean(requestBody.previous_response_id),
+			fullInputItems: fullBody.input.length,
+			sentInputItems: requestBody.input.length,
+		});
+	}
 
 	const releaseOnce = (releaseOptions?: { keep?: boolean | undefined }) => {
 		if (released) return;
@@ -61,9 +70,11 @@ export async function processWebSocketStream<TApi extends Api>(
 				attempt: diagnostics.attempt,
 				fullInputItems: fullBody.input.length,
 				sentInputItems: requestBody.input.length,
+				model: fullBody.model,
 				socketReused: reused,
 				continuation: cachedRequest.decision,
 				...(canonical?.decision ? { canonicalHistory: canonical.decision } : {}),
+				...(options?.compactionDiagnostics ? { compaction: structuredClone(options.compactionDiagnostics) } : {}),
 				previousResponseId: Boolean(requestBody.previous_response_id),
 			});
 		}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/display-broker.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/display-broker.ts
@@ -1,0 +1,311 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ApplyPatchDisplayData } from "../../apply-patch-display.js";
+import {
+	APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL,
+	APPLY_PATCH_DISPLAY_PROTOCOL,
+	APPLY_PATCH_DISPLAY_REQUEST_CHANNEL,
+	type ApplyPatchDisplayBroker,
+	isApplyPatchDisplayRequest,
+} from "./display-protocol.js";
+import {
+	type ApplyPatchToolDetails,
+	isApplyPatchToolDetails,
+} from "./render-state.js";
+
+interface ApplyPatchDisplayEvent {
+	toolName: string;
+	toolCallId: string;
+	input: unknown;
+	content: unknown;
+	details: unknown;
+	isError: boolean;
+}
+
+interface NestedTrace {
+	id?: unknown;
+	name?: unknown;
+	input?: unknown;
+	status?: unknown;
+	result?: unknown;
+	error?: unknown;
+}
+
+interface CapturedApplyPatchCall {
+	input: string;
+	content?: string | undefined;
+	details?: ApplyPatchToolDetails | undefined;
+	error?: string | undefined;
+	isError?: boolean | undefined;
+}
+
+export interface CapturedApplyPatchOutcome {
+	content?: string | undefined;
+	details?: ApplyPatchToolDetails | undefined;
+	error?: string | undefined;
+	isError: boolean;
+}
+
+const MAX_DISPLAY_IDS = 256;
+
+interface ActiveApplyPatchDisplay {
+	shouldCompact(toolCallId?: string, executionStarted?: boolean): boolean;
+	recordInput(toolCallId: string, input: string): void;
+	recordOutcome(toolCallId: string, outcome: CapturedApplyPatchOutcome): void;
+}
+
+let activeDisplay: ActiveApplyPatchDisplay | undefined;
+
+export function shouldCompactApplyPatchDisplay(
+	toolCallId?: string,
+	executionStarted?: boolean,
+): boolean {
+	return activeDisplay?.shouldCompact(toolCallId, executionStarted) ?? false;
+}
+
+export function recordApplyPatchDisplayInput(
+	toolCallId: string,
+	input: string,
+): void {
+	activeDisplay?.recordInput(toolCallId, input);
+}
+
+export function recordApplyPatchDisplayOutcome(
+	toolCallId: string,
+	outcome: CapturedApplyPatchOutcome,
+): void {
+	activeDisplay?.recordOutcome(toolCallId, outcome);
+}
+
+export function registerApplyPatchDisplayBroker(pi: ExtensionAPI): void {
+	const registrations = new Map<string, number>();
+	const captured = new Map<string, CapturedApplyPatchCall>();
+	const pending = new Map<string, ApplyPatchDisplayData>();
+	const emitted = new Set<string>();
+	const activeCalls = new Set<string>();
+	const displayedCalls = new Set<string>();
+	let active = true;
+
+	const broker: ApplyPatchDisplayBroker = {
+		protocol: APPLY_PATCH_DISPLAY_PROTOCOL,
+		isActive: () => active,
+		register(customType) {
+			if (!active) return () => {};
+			registrations.set(customType, (registrations.get(customType) ?? 0) + 1);
+			return () => {
+				const count = registrations.get(customType) ?? 0;
+				if (count <= 1) registrations.delete(customType);
+				else registrations.set(customType, count - 1);
+			};
+		},
+	};
+	const controller: ActiveApplyPatchDisplay = {
+		shouldCompact(toolCallId, executionStarted) {
+			if (!active || !toolCallId) return false;
+			if (displayedCalls.has(toolCallId)) return true;
+			if (registrations.size === 0) return false;
+			if (executionStarted === false) return false;
+			return activeCalls.has(toolCallId);
+		},
+		recordInput(toolCallId, input) {
+			if (!active || registrations.size === 0) return;
+			activeCalls.add(toolCallId);
+			captured.set(toolCallId, { ...captured.get(toolCallId), input });
+			boundMap(captured);
+		},
+		recordOutcome(toolCallId, outcome) {
+			if (!active || registrations.size === 0) return;
+			activeCalls.add(toolCallId);
+			const call = captured.get(toolCallId);
+			if (!call) return;
+			captured.set(toolCallId, { ...call, ...outcome });
+		},
+	};
+	activeDisplay = controller;
+
+	const announce = () => {
+		if (active) pi.events.emit(APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL, broker);
+	};
+	pi.events.on(APPLY_PATCH_DISPLAY_REQUEST_CHANNEL, (value) => {
+		if (isApplyPatchDisplayRequest(value)) announce();
+	});
+	pi.on("tool_execution_start", (event) => {
+		if (event.toolName === "apply_patch" && active && registrations.size > 0)
+			activeCalls.add(event.toolCallId);
+	});
+	pi.on("tool_result", (event) => {
+		if (!active || registrations.size === 0) return undefined;
+		for (const data of collectApplyPatchDisplayData(event, captured)) {
+			if (!emitted.has(data.toolCallId)) pending.set(data.toolCallId, data);
+		}
+		return undefined;
+	});
+	pi.on("turn_end", () => {
+		for (const [toolCallId, data] of pending) {
+			let appended = false;
+			for (const customType of registrations.keys()) {
+				pi.appendEntry(customType, data);
+				appended = true;
+			}
+			if (appended) {
+				emitted.add(toolCallId);
+				boundSet(emitted);
+				displayedCalls.add(toolCallId);
+			}
+			captured.delete(toolCallId);
+		}
+		pending.clear();
+		activeCalls.clear();
+	});
+	pi.on("session_start", (_event, ctx) => {
+		for (const entry of ctx.sessionManager.getEntries()) {
+			if (
+				entry.type !== "custom" ||
+				!registrations.has(entry.customType) ||
+				!entry.data ||
+				typeof entry.data !== "object" ||
+				typeof (entry.data as { toolCallId?: unknown }).toolCallId !== "string"
+			)
+				continue;
+			displayedCalls.add((entry.data as { toolCallId: string }).toolCallId);
+		}
+	});
+	pi.on("session_before_switch", () => {
+		captured.clear();
+		pending.clear();
+		emitted.clear();
+		activeCalls.clear();
+		displayedCalls.clear();
+	});
+	pi.on("session_shutdown", () => {
+		active = false;
+		registrations.clear();
+		captured.clear();
+		pending.clear();
+		emitted.clear();
+		activeCalls.clear();
+		displayedCalls.clear();
+		if (activeDisplay === controller) activeDisplay = undefined;
+	});
+	announce();
+}
+
+function collectApplyPatchDisplayData(
+	event: ApplyPatchDisplayEvent,
+	captured: Map<string, CapturedApplyPatchCall>,
+): ApplyPatchDisplayData[] {
+	if (event.toolName === "apply_patch") {
+		const input = patchInput(event.input);
+		if (input === undefined) return [];
+		const text = textContent(event.content);
+		const isError = event.isError || isPartialFailure(event.details);
+		return [
+			{
+				toolCallId: event.toolCallId,
+				input,
+				...(isApplyPatchToolDetails(event.details)
+					? { details: event.details }
+					: {}),
+				...text,
+				...(isError && text.content ? { error: text.content } : {}),
+				isError,
+				source: "direct",
+			},
+		];
+	}
+
+	if (event.toolName !== "exec" && event.toolName !== "wait") return [];
+	return nestedTraces(event.details).flatMap((trace) => {
+		if (
+			trace.name !== "apply_patch" ||
+			trace.status === "running" ||
+			typeof trace.id !== "string"
+		)
+			return [];
+		const call = captured.get(trace.id);
+		const input = call?.input ?? patchInput(trace.input);
+		if (input === undefined) return [];
+		const result = trace.result;
+		const traceDetails =
+			result && typeof result === "object" && "details" in result
+				? (result as { details?: unknown }).details
+				: undefined;
+		const traceContent =
+			result && typeof result === "object" && "content" in result
+				? textContent((result as { content?: unknown }).content).content
+				: undefined;
+		const details = isApplyPatchToolDetails(traceDetails)
+			? traceDetails
+			: call?.details;
+		const content = traceContent ?? call?.content;
+		const error =
+			call?.error ??
+			(typeof trace.error === "string" ? trace.error : undefined);
+		return [
+			{
+				toolCallId: trace.id,
+				input,
+				...(details ? { details } : {}),
+				...(content ? { content } : {}),
+				...(error ? { error } : {}),
+				isError:
+					trace.status === "error" ||
+					call?.isError === true ||
+					isPartialFailure(details),
+				source: "nested",
+			},
+		];
+	});
+}
+
+function isPartialFailure(value: unknown): boolean {
+	return isApplyPatchToolDetails(value) && value.status === "partial_failure";
+}
+
+function nestedTraces(details: unknown): NestedTrace[] {
+	if (!details || typeof details !== "object" || !("traces" in details))
+		return [];
+	const traces = (details as { traces?: unknown }).traces;
+	return Array.isArray(traces)
+		? traces.filter((trace): trace is NestedTrace =>
+				Boolean(trace && typeof trace === "object"),
+			)
+		: [];
+}
+
+function patchInput(input: unknown): string | undefined {
+	if (typeof input === "string") return input;
+	if (!input || typeof input !== "object") return undefined;
+	for (const key of ["input", "patchText", "patch"]) {
+		const value = (input as Record<string, unknown>)[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+function textContent(content: unknown): { content?: string | undefined } {
+	if (!Array.isArray(content)) return {};
+	const text = content
+		.filter((item): item is { type: "text"; text: string } =>
+			Boolean(
+				item &&
+					typeof item === "object" &&
+					(item as { type?: unknown }).type === "text" &&
+					typeof (item as { text?: unknown }).text === "string",
+			),
+		)
+		.map((item) => item.text)
+		.join("\n");
+	return text ? { content: text } : {};
+}
+
+function boundMap(map: Map<string, unknown>): void {
+	if (map.size <= MAX_DISPLAY_IDS) return;
+	const oldest = map.keys().next().value;
+	if (typeof oldest === "string") map.delete(oldest);
+}
+
+function boundSet(set: Set<string>): void {
+	if (set.size <= MAX_DISPLAY_IDS) return;
+	const oldest = set.values().next().value;
+	if (typeof oldest === "string") set.delete(oldest);
+}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/display-protocol.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/display-protocol.ts
@@ -1,0 +1,34 @@
+export const APPLY_PATCH_DISPLAY_PROTOCOL =
+	"@howaboua/pi-codex-conversion/apply-patch-display/v1";
+export const APPLY_PATCH_DISPLAY_REQUEST_CHANNEL = `${APPLY_PATCH_DISPLAY_PROTOCOL}/request`;
+export const APPLY_PATCH_DISPLAY_AVAILABLE_CHANNEL = `${APPLY_PATCH_DISPLAY_PROTOCOL}/available`;
+
+export interface ApplyPatchDisplayBroker {
+	protocol: typeof APPLY_PATCH_DISPLAY_PROTOCOL;
+	isActive(): boolean;
+	register(customType: string): () => void;
+}
+
+export function isApplyPatchDisplayRequest(value: unknown): boolean {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"protocol" in value &&
+			value.protocol === APPLY_PATCH_DISPLAY_PROTOCOL,
+	);
+}
+
+export function isApplyPatchDisplayBroker(
+	value: unknown,
+): value is ApplyPatchDisplayBroker {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"protocol" in value &&
+			value.protocol === APPLY_PATCH_DISPLAY_PROTOCOL &&
+			"isActive" in value &&
+			typeof value.isActive === "function" &&
+			"register" in value &&
+			typeof value.register === "function",
+	);
+}

--- a/packages/pi-codex-conversion/src/tools/apply-patch/render-state.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/render-state.ts
@@ -27,7 +27,30 @@ export type ApplyPatchToolDetails = ApplyPatchSuccessDetails | ApplyPatchPartial
 const applyPatchRenderStates = new Map<string, ApplyPatchRenderState>();
 
 export function isApplyPatchToolDetails(details: unknown): details is ApplyPatchToolDetails {
-	return typeof details === "object" && details !== null && "status" in details && "result" in details;
+	if (!details || typeof details !== "object") return false;
+	const record = details as Record<string, unknown>;
+	if (record["status"] !== "success" && record["status"] !== "partial_failure") return false;
+	const result = record["result"];
+	if (!result || typeof result !== "object") return false;
+	const patchResult = result as Record<string, unknown>;
+	if (
+		!isStringArray(patchResult["changedFiles"]) ||
+		!isStringArray(patchResult["createdFiles"]) ||
+		!isStringArray(patchResult["deletedFiles"]) ||
+		!isStringArray(patchResult["movedFiles"]) ||
+		typeof patchResult["fuzz"] !== "number" ||
+		!Number.isFinite(patchResult["fuzz"])
+	)
+		return false;
+	return (
+		record["status"] === "success" ||
+		record["failedTargets"] === undefined ||
+		isStringArray(record["failedTargets"])
+	);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 export function clearApplyPatchRenderState(): void {

--- a/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
+++ b/packages/pi-codex-conversion/src/tools/apply-patch/tool.ts
@@ -1,19 +1,24 @@
 import { Type } from "typebox";
-import { type ExtensionAPI, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, type ToolDefinition, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { parsePatchActions } from "../../patch/parser.ts";
 import { resolvePatchPath } from "../../patch/paths.ts";
 import { ExecutePatchError, type ExecutePatchResult } from "../../patch/types.ts";
 import { getExperimentalToolSampling } from "../tool-sampling.ts";
+import {
+	recordApplyPatchDisplayInput,
+	recordApplyPatchDisplayOutcome,
+	shouldCompactApplyPatchDisplay,
+} from "./display-broker.ts";
 import { formatPatchTarget } from "./rendering.ts";
 import { executePatchWithRust } from "./executor.ts";
 import {
-	clearApplyPatchRenderState,
 	isApplyPatchToolDetails,
 	markApplyPatchFailure,
 	markApplyPatchPartialFailure,
 	renderApplyPatchCallFromState,
 	setApplyPatchRenderState,
+	type ApplyPatchToolDetails,
 	type ApplyPatchPartialFailureDetails,
 	type ApplyPatchSuccessDetails,
 } from "./render-state.ts";
@@ -27,14 +32,22 @@ const APPLY_PATCH_PARAMETERS = Type.Object({
 interface ApplyPatchRenderContextLike {
 	toolCallId?: string | undefined;
 	cwd?: string | undefined;
+	executionStarted?: boolean | undefined;
 	expanded?: boolean | undefined;
 	argsComplete?: boolean | undefined;
 }
 
-interface ApplyPatchToolOptions {
+type ApplyPatchToolDefinition = ToolDefinition<typeof APPLY_PATCH_PARAMETERS, ApplyPatchToolDetails>;
+
+export type ApplyPatchRenderCall = NonNullable<ApplyPatchToolDefinition["renderCall"]>;
+export type ApplyPatchRenderResult = NonNullable<ApplyPatchToolDefinition["renderResult"]>;
+
+export interface ApplyPatchToolOptions {
 	customRustBinariesDir?: string | undefined;
 	promptSnippet?: boolean | undefined;
 	showDiffWhenCollapsed?: boolean | undefined;
+	renderCall?: ApplyPatchRenderCall | undefined;
+	renderResult?: ApplyPatchRenderResult | undefined;
 }
 
 function parseApplyPatchParams(params: unknown): { patchText: string } {
@@ -133,7 +146,12 @@ function describeFailedActions(error: ExecutePatchError, cwd: string): string[] 
 }
 
 export type { ExecutePatchResult } from "../../patch/types.ts";
-export { clearApplyPatchRenderState };
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+} from "./render-state.ts";
+export { clearApplyPatchRenderState, isApplyPatchToolDetails } from "./render-state.ts";
 
 const renderApplyPatchCallWithOptionalContext = (
 	args: { input?: unknown | undefined },
@@ -142,8 +160,30 @@ const renderApplyPatchCallWithOptionalContext = (
 	options: ApplyPatchToolOptions = {},
 ) => new Text(renderApplyPatchCallFromState(args, theme, { ...context, showCollapsedDiff: options.showDiffWhenCollapsed }), 0, 0);
 
-export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
+function renderCompactApplyPatchCall(theme: { fg(role: string, text: string): string; bold(text: string): string }): Text {
+	return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
+}
+
+export function createApplyPatchTool(options: ApplyPatchToolOptions = {}): ApplyPatchToolDefinition {
 	const constrainedSampling = getExperimentalToolSampling("apply_patch");
+	const compactRendering = (context?: ApplyPatchRenderContextLike) => shouldCompactApplyPatchDisplay(context?.toolCallId, context?.executionStarted);
+	const defaultRenderCall: ApplyPatchRenderCall = (args, theme, context) =>
+		compactRendering(context) ? renderCompactApplyPatchCall(theme) : renderApplyPatchCallWithOptionalContext(args, theme, context, options);
+	const defaultRenderResult: ApplyPatchRenderResult = (result, { isPartial }, theme, context) => {
+		if (compactRendering(context)) {
+			if (isPartial) return renderCompactApplyPatchCall(theme);
+			if (isApplyPatchToolDetails(result.details)) {
+				if (result.details.status === "partial_failure") return new Text(theme.fg("error", "• Patch partially failed"), 0, 0);
+				return new Text(theme.fg("dim", `• Applied patch (${summarizePatchCounts(result.details.result)})`), 0, 0);
+			}
+			if (context.isError) return new Text(theme.fg("error", "• Patch failed"), 0, 0);
+			return new Container();
+		}
+		if (isPartial) return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
+		if (!isApplyPatchToolDetails(result.details)) return new Container();
+		if (result.details.status === "partial_failure") return new Container();
+		return new Container();
+	};
 	return {
 		name: "apply_patch",
 		label: "apply_patch",
@@ -157,6 +197,7 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 			if (signal?.aborted) throw new Error("apply_patch aborted");
 
 			const typedParams = parseApplyPatchParams(params);
+			recordApplyPatchDisplayInput(toolCallId, typedParams.patchText);
 			setApplyPatchRenderState(toolCallId, typedParams.patchText, ctx.cwd);
 			let result: ExecutePatchResult;
 			try {
@@ -176,20 +217,35 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 						const appliedFiles = getAppliedPaths(error.result, failedFiles);
 						const recoveryMessage = buildPartialFailureMessage(rawMessage, failedFiles, appliedFiles);
 						markApplyPatchPartialFailure(toolCallId, failedTargets);
+						const details = {
+							status: "partial_failure",
+							result: error.result,
+							failedTargets,
+						} satisfies ApplyPatchPartialFailureDetails;
+						recordApplyPatchDisplayOutcome(toolCallId, {
+							content: recoveryMessage,
+							details,
+							error: recoveryMessage,
+							isError: true,
+						});
 						return {
 							content: [{ type: "text", text: recoveryMessage }],
-							details: {
-								status: "partial_failure",
-								result: error.result,
-								failedTargets,
-							} satisfies ApplyPatchPartialFailureDetails,
+							details,
 						};
 					}
 					const message = addContextRecovery(rawMessage, error.message, failedTargets);
 					markApplyPatchFailure(toolCallId, "failed", failedTargets);
+					recordApplyPatchDisplayOutcome(toolCallId, {
+						error: message,
+						isError: true,
+					});
 					throw new Error(message);
 				}
 				markApplyPatchFailure(toolCallId, "failed");
+				recordApplyPatchDisplayOutcome(toolCallId, {
+					error: error instanceof Error ? error.message : String(error),
+					isError: true,
+				});
 				throw error;
 			}
 			const summary = [
@@ -201,16 +257,17 @@ export function createApplyPatchTool(options: ApplyPatchToolOptions = {}) {
 				`Fuzz: ${result.fuzz}`,
 			].join("\n");
 
-			return { content: [{ type: "text", text: summary }], details: { status: "success", result } satisfies ApplyPatchSuccessDetails };
+			const details = { status: "success", result } satisfies ApplyPatchSuccessDetails;
+			recordApplyPatchDisplayOutcome(toolCallId, {
+				content: summary,
+				details,
+				isError: false,
+			});
+			return { content: [{ type: "text", text: summary }], details };
 		},
-		renderCall: ((args: { input?: unknown | undefined }, theme: { fg(role: string, text: string): string; bold(text: string): string }, context?: ApplyPatchRenderContextLike) => renderApplyPatchCallWithOptionalContext(args, theme, context, options)) as any,
-		renderResult(result, { isPartial }, theme) {
-			if (isPartial) return new Text(`${theme.fg("dim", "•")} ${theme.bold("Patching")}`, 0, 0);
-			if (!isApplyPatchToolDetails(result.details)) return new Container();
-			if (result.details.status === "partial_failure") return new Container();
-			return new Container();
-		},
-	} satisfies Parameters<ExtensionAPI["registerTool"]>[0];
+		renderCall: options.renderCall ?? defaultRenderCall,
+		renderResult: options.renderResult ?? defaultRenderResult,
+	} satisfies ApplyPatchToolDefinition;
 }
 
 export function registerApplyPatchTool(pi: ExtensionAPI, options: ApplyPatchToolOptions = {}): void {

--- a/packages/pi-codex-conversion/src/tools/code-mode/delegate-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/delegate-runtime.ts
@@ -22,6 +22,7 @@ interface DelegateController {
 type SendMessage = (message: unknown) => void;
 
 export class CodeModeDelegateRuntime {
+	private readonly traceRuntimeGeneration = crypto.randomUUID();
 	private readonly cellContexts = new Map<string, ToolExecutionContext>();
 	private readonly cellTools = new Map<string, Map<string, CodeModeToolDefinition>>();
 	private readonly controllers = new Map<string, DelegateController>();
@@ -194,7 +195,12 @@ export class CodeModeDelegateRuntime {
 		const context = this.cellContexts.get(cellId);
 		if (!tool) throw new Error(`Unknown custom tool: ${toolName}`);
 		if (!context) throw new Error("Code-mode cell context is unavailable");
-		const trace = this.traces.start(cellId, traceId, tool.name, input);
+		const trace = this.traces.start(
+			cellId,
+			`${this.traceRuntimeGeneration}:${cellId}:${traceId}`,
+			tool.name,
+			input,
+		);
 		const invocationContext: ToolExecutionContext = {
 			...context,
 			toolCallId: trace.id,

--- a/packages/pi-codex-conversion/src/tools/code-mode/notebook-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/notebook-tool.ts
@@ -2,31 +2,45 @@ import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-age
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { getExperimentalToolSampling } from "../tool-sampling.ts";
+import { canExecuteNotebookControlInsideExec } from "../notebook-mode/control-contract.ts";
 import type { SharedCodeModeRuntime } from "./shared-runtime.ts";
-import type { NotebookControlRequest, ToolExecutionContext } from "./types.ts";
+import type {
+	NotebookControlRequest,
+	NotebookControlResult,
+	ProgrammaticCodeModeToolDefinition,
+	ToolExecutionContext,
+} from "./types.ts";
 
-const NOTEBOOK_PARAMETERS = Type.Object({
+export const NOTEBOOK_PARAMETERS = Type.Object({
 	action: StringEnum(["status", "list", "checkpoint", "save", "load", "pin", "unpin", "release", "prune", "restart", "diagnostics", "reset"]),
 	query: Type.Optional(Type.String()),
 	name: Type.Optional(Type.String()),
 	names: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
 });
 
+const NOTEBOOK_DESCRIPTION = "Control persistent notebook state: status inspects memory/bindings by query glob; checkpoint; pin/unpin/release names; prune unpinned matches; list/save/load profiles; restart; diagnostics; reset";
+
+type NotebookToolParameters = {
+	action: string;
+	query?: string | undefined;
+	name?: string | undefined;
+	names?: string[] | undefined;
+};
+
 export function registerNotebookTool(pi: ExtensionAPI, runtime: SharedCodeModeRuntime): void {
 	const constrainedSampling = getExperimentalToolSampling("notebook");
 	pi.registerTool({
 		name: "notebook",
 		label: "Notebook",
-		description: "Control persistent notebook state: status inspects memory/bindings by query glob; checkpoint; pin/unpin/release names; prune unpinned matches; list/save/load profiles; restart; diagnostics; reset",
+		description: NOTEBOOK_DESCRIPTION,
 		promptSnippet: "Inspect, recover, or control notebook state",
 		parameters: NOTEBOOK_PARAMETERS,
 		...(constrainedSampling ? { constrainedSampling } : {}),
 		async execute(_id, params, signal, _onUpdate, ctx) {
-			const result = await runtime.controlNotebook(
-				normalizeNotebookRequest(params),
-				{ cwd: ctx.cwd, extensionContext: ctx } as ToolExecutionContext,
-				signal,
-			);
+			const result = await executeNotebookControl(runtime, params, {
+				cwd: ctx.cwd,
+				extensionContext: ctx,
+			}, signal);
 			return {
 				content: [{ type: "text", text: result.message }],
 				details: result.details,
@@ -35,12 +49,55 @@ export function registerNotebookTool(pi: ExtensionAPI, runtime: SharedCodeModeRu
 	} satisfies ToolDefinition<typeof NOTEBOOK_PARAMETERS>);
 }
 
-export function normalizeNotebookRequest(params: {
-	action: string;
-	query?: string | undefined;
-	name?: string | undefined;
-	names?: string[] | undefined;
-}): NotebookControlRequest {
+export function createNotebookControlProxy(
+	runtime: SharedCodeModeRuntime,
+): ProgrammaticCodeModeToolDefinition {
+	return {
+		name: "notebook",
+		usage: "await tools.notebook({ action, query?, name?, names? })",
+		description: NOTEBOOK_DESCRIPTION,
+		deferLoading: true,
+		kind: "function",
+		inputSchema: NOTEBOOK_PARAMETERS,
+		invoke: (input, context, signal) =>
+			executeNotebookExecControl(runtime, input as NotebookToolParameters, context, signal),
+	};
+}
+
+export async function executeNotebookControl(
+	runtime: SharedCodeModeRuntime,
+	params: NotebookToolParameters,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	return executeNormalizedNotebookControl(runtime, normalizeNotebookRequest(params), context, signal);
+}
+
+export async function executeNotebookExecControl(
+	runtime: SharedCodeModeRuntime,
+	params: NotebookToolParameters,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	const request = normalizeNotebookRequest(params);
+	if (!canExecuteNotebookControlInsideExec(request))
+		return {
+			message: `Notebook ${request.action} was not run because it needs the active exec cell to finish. After exec returns, call notebook with ${JSON.stringify(request)}.`,
+			details: { notRun: true, action: request.action, retry: request },
+		};
+	return executeNormalizedNotebookControl(runtime, request, context, signal);
+}
+
+function executeNormalizedNotebookControl(
+	runtime: SharedCodeModeRuntime,
+	request: NotebookControlRequest,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	return runtime.controlNotebook(request, context, signal);
+}
+
+export function normalizeNotebookRequest(params: NotebookToolParameters): NotebookControlRequest {
 	params = {
 		action: params.action,
 		...(params.query == null ? {} : { query: params.query }),

--- a/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
@@ -1,5 +1,6 @@
 import { ensureCodeModeHostBinary } from "./binary.js";
 import { CodeModeHostClient } from "./host-client.js";
+import { createNotebookControlProxy } from "./notebook-tool.ts";
 import type {
 	CodeModeToolDefinition,
 	NotebookControlRequest,
@@ -62,14 +63,14 @@ export class SharedCodeModeRuntime {
 	}
 
 	collectTools(ctx?: unknown): CodeModeToolDefinition[] {
-		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		const tools = this.collectProviderTools(ctx);
 		return this.customPromptToolsSnapshot
 			? applyCustomPromptState(tools, this.customPromptToolsSnapshot)
 			: tools;
 	}
 
 	refreshPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
-		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		const tools = this.collectProviderTools(ctx);
 		this.customPromptToolsSnapshot = tools.filter(isCustomTool);
 		return tools;
 	}
@@ -81,10 +82,8 @@ export class SharedCodeModeRuntime {
 
 	collectPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
 		if (!this.customPromptToolsSnapshot) return this.refreshPromptTools(ctx);
-		const liveProgrammaticTools = collectUniqueTools(
-			this.activeProviders(ctx),
-			ctx,
-		).filter((tool) => !isCustomTool(tool));
+		const liveProgrammaticTools = this.collectProviderTools(ctx)
+			.filter((tool) => !isCustomTool(tool));
 		return [...liveProgrammaticTools, ...this.customPromptToolsSnapshot];
 	}
 
@@ -218,6 +217,14 @@ export class SharedCodeModeRuntime {
 				// Startup failure already reached the caller.
 			}
 		}
+	}
+
+	private collectProviderTools(ctx?: unknown): CodeModeToolDefinition[] {
+		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		if (this.executionKind(ctx) !== "notebook") return tools;
+		if (tools.some((tool) => tool.name === "notebook"))
+			throw new Error("Duplicate code-mode tool: notebook");
+		return [...tools, createNotebookControlProxy(this)];
 	}
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/cell.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/cell.ts
@@ -21,6 +21,7 @@ export class NotebookCell {
 	private outputChars = 0;
 	private outputTruncated = false;
 	private cursor = 0;
+	private completedValue = false;
 	private yielded = deferred();
 	private readonly completed = deferred();
 
@@ -51,7 +52,12 @@ export class NotebookCell {
 	}
 
 	markCompleted(): void {
+		this.completedValue = true;
 		this.completed.resolve();
+	}
+
+	isCompleted(): boolean {
+		return this.completedValue;
 	}
 
 	waitForCompletion(): Promise<void> {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-format.ts
@@ -1,6 +1,8 @@
+import type { ProjectBindingMetadata } from "./project-state-format.ts";
+
 export const CHECKPOINT_SCHEMA = 1;
 
-export interface CheckpointEntry {
+export interface CheckpointEntry extends ProjectBindingMetadata {
 	name: string;
 	kind: "value" | "function";
 	offset: number;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-manager.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-manager.ts
@@ -1,10 +1,7 @@
 import { writeNotebookCheckpoint, type NotebookCheckpointIdentity } from "./checkpoint.ts";
 import type { DenoJupyterKernel } from "./jupyter-kernel.ts";
-import {
-	type ProjectStateBaseline,
-	writeProjectState,
-} from "./project-state.ts";
-import type { ProjectStatePinUpdate } from "./project-state-merge.ts";
+import { type ProjectStateBaseline, writeProjectState } from "./project-state.ts";
+import { projectStateEntryFingerprint, type ProjectStatePinUpdate } from "./project-state-merge.ts";
 
 const CHECKPOINT_DEBOUNCE_MS = 1_500;
 
@@ -127,9 +124,11 @@ export class NotebookCheckpointManager {
 				options.pins,
 			);
 			this.projectBaseline = project.baseline;
-			const sessionHashes = new Map(project.baseline.entries.map(({ name, hash }) => [name, hash]));
-			for (const { name, hash } of project.restored) {
-				if (sessionHashes.get(name) === hash) projectExclusions.add(name);
+			const sessionEntries = new Map(project.baseline.entries.map((entry) => [entry.name, entry]));
+			for (const entry of project.restored) {
+				if (projectStateEntryFingerprint(sessionEntries.get(entry.name)) === projectStateEntryFingerprint(entry)) {
+					projectExclusions.add(entry.name);
+				}
 			}
 			if (project.conflicts.length > 0) {
 				this.reportNotice(`Project notebook conflicts preserved without overwrite: ${project.conflicts.join(", ")}`, false);

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint-runtime.ts
@@ -1,5 +1,10 @@
 import { CHECKPOINT_SCHEMA, type CheckpointManifest, type NotebookCheckpointIdentity } from "./checkpoint-format.ts";
-import { MAX_PROJECT_MANIFEST_BYTES } from "./project-state-format.ts";
+import {
+	MAX_PROJECT_DESCRIPTION_BYTES,
+	MAX_PROJECT_MANIFEST_BYTES,
+	MAX_PROJECT_USAGE_BYTES,
+	MAX_PROJECT_USAGE_LINES,
+} from "./project-state-format.ts";
 
 export function checkpointSource(options: {
 	candidates: string[];
@@ -34,8 +39,16 @@ export function checkpointSource(options: {
       if (__bytes.byteLength > __max) __skip(${JSON.stringify(name)}, "exceeds per-variable checkpoint cap");
       else if (__total + __bytes.byteLength > __max) __skip(${JSON.stringify(name)}, "exceeds total checkpoint cap");
       else {
+		const __metadata = __readBindingMetadata(__value);
 		await __writeAll(__bytes);
-		__entries.push({ name: ${JSON.stringify(name)}, kind: __kind, offset: __total, length: __bytes.byteLength });
+		__entries.push({
+		  name: ${JSON.stringify(name)},
+		  kind: __kind,
+		  offset: __total,
+		  length: __bytes.byteLength,
+		  ...(__metadata.description === undefined ? {} : { description: __metadata.description }),
+		  ...(__metadata.usage === undefined ? {} : { usage: __metadata.usage }),
+		});
         __total += __bytes.byteLength;
       }
     }
@@ -48,6 +61,31 @@ export function checkpointSource(options: {
   const __entries = [];
   const __skipped = ${JSON.stringify(options.skippedInvalid)};
   let __total = 0;
+  const __readBindingMetadata = (__value) => {
+    if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return {};
+    const __metadata = {};
+    for (const [__key, __max, __multiline, __lines] of [
+      ["description", ${MAX_PROJECT_DESCRIPTION_BYTES}, false, 1],
+      ["usage", ${MAX_PROJECT_USAGE_BYTES}, true, ${MAX_PROJECT_USAGE_LINES}],
+    ]) {
+      const __descriptor = Object.getOwnPropertyDescriptor(__value, __key);
+      if (!__descriptor || !("value" in __descriptor) || typeof __descriptor.value !== "string") continue;
+      const __text = __descriptor.value;
+      if (!__text || new TextEncoder().encode(__text).byteLength > __max || __text.includes("\\r")) continue;
+      const __textLines = __text.split("\\n");
+      if (__textLines.length > __lines) continue;
+      let __valid = true;
+      for (const __character of __text) {
+        const __codePoint = __character.codePointAt(0);
+        if ((__codePoint < 0x20 && __codePoint !== 0x0a) || __codePoint === 0x7f || !__multiline && __codePoint === 0x0a) {
+          __valid = false;
+          break;
+        }
+      }
+      if (__valid) __metadata[__key] = __text;
+    }
+    return __metadata;
+  };
   const __skip = (name, reason) => __skipped.push({ name, reason: String(reason).slice(0, 240) });
 	const __file = await Deno.open(${JSON.stringify(options.payloadPath)}, { create: true, write: true, truncate: true, mode: 0o600 });
 	const __writeAll = async (__bytes) => {
@@ -101,14 +139,30 @@ export function restoreSource(manifest: CheckpointManifest, payloadPath: string,
 	const __functions = [];
   for (const __entry of __entries) {
 	const __captured = deserialize(__payload.slice(__entry.offset, __entry.offset + __entry.length));
-	if (__entry.kind === "function") __functions.push([__entry.name, __captured]);
-	else __values.push([__entry.name, __captured]);
-  }
-	for (const [__name, __value] of __values) {
+	if (__entry.kind === "function") __functions.push([__entry.name, __captured, __entry]);
+	else __values.push([__entry.name, __captured, __entry]);
+	}
+	const __applyMetadata = (__value, __entry) => {
+	  if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return;
+	  for (const __key of ["description", "usage"]) {
+	    if (typeof __entry[__key] !== "string") continue;
+	    try {
+	      Object.defineProperty(__value, __key, {
+	        value: __entry[__key],
+	        writable: true,
+	        configurable: true,
+	        enumerable: true,
+	      });
+	    } catch {}
+	  }
+	};
+	for (const [__name, __value, __entry] of __values) {
+	  __applyMetadata(__value, __entry);
 	  Object.defineProperty(globalThis, __name, { value: __value, writable: true, configurable: true, enumerable: true });
 	}
-	for (const [__name, __source] of __functions) {
+	for (const [__name, __source, __entry] of __functions) {
 	  const __value = (0, eval)("(" + __source + ")");
+	  __applyMetadata(__value, __entry);
 	  Object.defineProperty(globalThis, __name, { value: __value, writable: true, configurable: true, enumerable: true });
 	}
   undefined;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/checkpoint.ts
@@ -13,6 +13,7 @@ import {
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
 	MAX_PROJECT_NAME_BYTES,
+	parseProjectBindingMetadata,
 	type ProjectStateBaseline,
 } from "./project-state-format.ts";
 
@@ -254,12 +255,14 @@ function isValidCheckpointPayload(manifest: CheckpointManifest, path: string, ma
 function parseEntry(value: unknown): CheckpointEntry | undefined {
 	if (!isRecord(value)) return undefined;
 	const { name, offset, length, kind } = value;
+	const metadata = parseProjectBindingMetadata(value);
 	return typeof name === "string" && IDENTIFIER.test(name)
 		&& Buffer.byteLength(name) <= MAX_PROJECT_NAME_BYTES
 		&& (kind === undefined || kind === "value" || kind === "function")
 		&& Number.isSafeInteger(offset) && (offset as number) >= 0
 		&& Number.isSafeInteger(length) && (length as number) >= 0
-		? { name, kind: kind === "function" ? "function" : "value", offset: offset as number, length: length as number }
+		&& metadata !== undefined
+		? { name, kind: kind === "function" ? "function" : "value", offset: offset as number, length: length as number, ...metadata }
 		: undefined;
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/client.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/client.ts
@@ -42,6 +42,7 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 			startClean: async (context, signal) => { await session.restart(context, signal, true); },
 			checkpointEmpty: () => session.checkpoints.flush({ force: true, requireIdle: true }),
 			configuredProfileActive: () => session.configuredProfileLoaded(),
+			runtimeHealth: (context) => session.runtimeHealthFor(context),
 		});
 		this.lifecycle = new NotebookLifecycleController({
 			prepare: (context, signal) => this.prepareSession(context, signal),
@@ -70,6 +71,7 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 			baselineNames: () => session.baselineNames(),
 			profileStorage: () => ({ agentDir: options.agentDir, maxBytes: session.checkpointMaxBytes }),
 			metadata: () => session.metadata(),
+			runtimeHealth: () => session.runtimeHealth(),
 		});
 	}
 
@@ -103,7 +105,12 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 		excludeNames?: ReadonlySet<string>,
 		pins?: { names: readonly string[]; pinned: boolean },
 	): Promise<void> {
-		await this.session.checkpoints.flush({ requireIdle: true, force: true, excludeNames, pins });
+		try {
+			await this.session.checkpoints.flush({ requireIdle: true, force: true, excludeNames, pins });
+		} catch (error) {
+			await this.session.recoverFromBootstrapFailure(error);
+			throw error;
+		}
 		try {
 			this.session.materializeJournal();
 		} catch (error) {
@@ -117,7 +124,13 @@ export class NotebookCodeModeClient implements CodeModeExecutionClient {
 		context: ToolExecutionContext,
 		signal?: AbortSignal,
 	): Promise<NotebookControlResult> {
-		const result = await this.lifecycle.control(request, context, signal);
+		let result: NotebookControlResult;
+		try {
+			result = await this.lifecycle.control(request, context, signal);
+		} catch (error) {
+			await this.session.recoverFromBootstrapFailure(error);
+			throw error;
+		}
 		const notice = this.session.takeNotice();
 		return notice
 			? { message: `${notice}\n${result.message}`, details: { ...result.details, startupNotice: notice } }

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/control-contract.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/control-contract.ts
@@ -1,0 +1,10 @@
+export const NOTEBOOK_EXEC_ACTIONS = ["status", "list", "diagnostics"] as const;
+
+export function canExecuteNotebookControlInsideExec(request: { action: string; query?: string | undefined }): boolean {
+	return NOTEBOOK_EXEC_ACTIONS.includes(request.action as typeof NOTEBOOK_EXEC_ACTIONS[number])
+		&& (request.action !== "status" || request.query === undefined);
+}
+
+export function notebookExecStartupNotice(): string {
+	return `Inside exec tools.notebook supports ${NOTEBOOK_EXEC_ACTIONS.join(", ")}; all others use the top-level notebook tool after exec returns`;
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/execution-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/execution-runtime.ts
@@ -17,8 +17,10 @@ import type {
 import { NotebookBridgeServer } from "./bridge-server.ts";
 import { NotebookCell } from "./cell.ts";
 import { beginNotebookJournalCell, finishNotebookJournalCell } from "./journal.ts";
+import { NOTEBOOK_INTERRUPTED_NOTICE } from "./runtime-health.ts";
 import type { NotebookSessionRuntime } from "./session-runtime.ts";
 
+const CANCEL_GRACE_MS = 250;
 const TERMINATE_GRACE_MS = 1_500;
 
 export class NotebookExecutionRuntime {
@@ -94,8 +96,10 @@ export class NotebookExecutionRuntime {
 			.map((tool) => ({ name: tool.name, description: formatCodeModeToolHelp(tool) }));
 		const toolNames = Object.fromEntries(tools.map((tool) => [tool.name, resolveCodeModeToolIdentity(tool)]));
 		const wrapped = [
+			`if (typeof globalThis.__piNotebook?.begin !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.begin");`,
 			`await globalThis.__piNotebook.begin(${JSON.stringify(id)}, ${JSON.stringify(metadata)}, ${JSON.stringify(toolNames)});`,
 			code,
+			`if (typeof globalThis.__piNotebook?.flush !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.flush");`,
 			`await globalThis.__piNotebook.flush(${JSON.stringify(id)});`,
 			"undefined;",
 		].join("\n");
@@ -159,16 +163,19 @@ export class NotebookExecutionRuntime {
 		try {
 			const result = await session.kernel()!.execute(source, {
 				signal: cell.controller.signal,
+				interruptOnAbort: false,
 				onOutput: (item) => cell.emit([item]),
 			});
 			const normalized = result.errorName === "PiNotebookExit" && result.errorValue === this.bridge.exitToken
 				? { ...result, status: "ok" as const, errorText: undefined, errorName: undefined, errorValue: undefined }
 				: result;
 			cell.result = normalized;
-			await this.endCellRuntime(cell);
-			if (cell.result.status === "ok") {
-				await session.recordNpmImports(cell.source);
-				session.checkpoints.schedule();
+			if (!(await session.recoverFromBootstrapFailure(normalized))) {
+				await this.endCellRuntime(cell);
+				if (cell.result.status === "ok") {
+					await session.recordNpmImports(cell.source);
+					session.checkpoints.schedule();
+				}
 			}
 		} catch (error) {
 			this.delegate.cancelCell(cell.id);
@@ -200,7 +207,8 @@ export class NotebookExecutionRuntime {
 		const kernel = this.session().kernel();
 		if (!kernel) return;
 		const id = JSON.stringify(cell.id);
-		const result = await kernel.execute(`await globalThis.__piNotebook.finish(${id}); undefined;`);
+		const result = await kernel.execute(`if (typeof globalThis.__piNotebook?.finish !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.finish"); await globalThis.__piNotebook.finish(${id}); undefined;`);
+		await this.session().recoverFromBootstrapFailure(result);
 		if (result.status !== "ok" && cell.result?.status === "ok") {
 			cell.result = { status: "error", items: [], errorText: result.errorText ?? "Notebook helper flush failed" };
 		}
@@ -240,13 +248,18 @@ export class NotebookExecutionRuntime {
 	}
 
 	private async stopCellInner(cell: NotebookCell): Promise<void> {
+		const isolateKernel = !cell.isCompleted();
 		cell.terminated = true;
 		cell.controller.abort();
 		this.delegate.cancelCell(cell.id);
-		await this.session().kernel()?.interrupt().catch(() => undefined);
+		await Promise.race([cell.waitForCompletion(), delay(CANCEL_GRACE_MS)]);
+		if (!cell.isCompleted()) {
+			const kernel = this.session().kernel();
+			try { await kernel?.interrupt(); } catch {}
+		}
+		if (isolateKernel) await this.session().invalidateKernel(NOTEBOOK_INTERRUPTED_NOTICE);
 		await Promise.race([cell.waitForCompletion(), delay(TERMINATE_GRACE_MS)]);
-		if (!cell.result) {
-			await this.session().discardKernel();
+		if (!cell.isCompleted()) {
 			cell.result = { status: "aborted", items: [] };
 			cell.markCompleted();
 		}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/jupyter-kernel.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/jupyter-kernel.ts
@@ -38,6 +38,7 @@ export class DenoJupyterKernel {
 	private readonly deno: string;
 	private readonly env: NodeJS.ProcessEnv;
 	private readonly maxHeapMiB: number;
+	private readonly onFailure: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
 	private readonly session = randomUUID();
 	private process: ChildProcess | undefined;
 	private tempDir: string | undefined;
@@ -51,14 +52,24 @@ export class DenoJupyterKernel {
 	private active: ActiveKernelExecution | undefined;
 	private readonly shellReplies = new Map<string, ShellReplyWaiter>();
 	private stderr = "";
+	private terminalFailure: Error | undefined;
 
-	constructor(options: { deno: string; maxHeapMiB: number; env?: NodeJS.ProcessEnv | undefined }) {
+	constructor(options: {
+		deno: string;
+		maxHeapMiB: number;
+		env?: NodeJS.ProcessEnv | undefined;
+		onFailure?: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
+	}) {
 		this.deno = options.deno;
 		this.env = options.env ?? process.env;
 		this.maxHeapMiB = options.maxHeapMiB;
+		this.onFailure = options.onFailure;
 	}
 
 	async start(signal?: AbortSignal): Promise<void> {
+		if (this.terminalFailure) {
+			throw new Error(`Deno Jupyter kernel is unavailable: ${this.terminalFailure.message}`, { cause: this.terminalFailure });
+		}
 		if (!this.startup) this.startup = this.startInner(signal).catch((error) => {
 			this.startup = undefined;
 			this.dispose();
@@ -69,7 +80,11 @@ export class DenoJupyterKernel {
 
 	async execute(
 		code: string,
-		options: { signal?: AbortSignal | undefined; onOutput?: ((item: RuntimeContentItem) => void) | undefined } = {},
+		options: {
+			signal?: AbortSignal | undefined;
+			onOutput?: ((item: RuntimeContentItem) => void) | undefined;
+			interruptOnAbort?: boolean | undefined;
+		} = {},
 	): Promise<KernelExecutionResult> {
 		await this.start(options.signal);
 		options.signal?.throwIfAborted();
@@ -101,7 +116,7 @@ export class DenoJupyterKernel {
 		let abortTimer: ReturnType<typeof setTimeout> | undefined;
 		let finished = false;
 		const abort = () => {
-			void this.interrupt().catch(() => undefined);
+			if (options.interruptOnAbort !== false) void this.interrupt().catch(() => undefined);
 			abortTimer = setTimeout(() => {
 				if (!finished) {
 					this.failKernel(options.signal?.reason instanceof Error
@@ -144,7 +159,11 @@ export class DenoJupyterKernel {
 				throw new Error(`Deno Jupyter returned ${reply.header.msg_type} for execute_request`);
 			}
 			const replied = applyExecuteReplyError(result, reply);
-			return options.signal?.aborted ? { ...replied, status: "aborted" } : replied;
+			if (options.signal?.aborted) {
+				if (options.interruptOnAbort !== false) this.failKernel(new Error("Deno Jupyter execution was aborted"));
+				return { ...replied, status: "aborted" };
+			}
+			return replied;
 		} catch (error) {
 			if (this.active === execution) this.active = undefined;
 			throw error;
@@ -380,6 +399,10 @@ export class DenoJupyterKernel {
 	}
 
 	private failKernel(error: Error): void {
+		if (!this.terminalFailure) {
+			this.terminalFailure = error;
+			this.onFailure?.(this, error);
+		}
 		const active = this.active;
 		this.active = undefined;
 		active?.reject(error);

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/kernel-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/kernel-runtime.ts
@@ -252,3 +252,37 @@ export function notebookBootstrapSource(origin: string, token: string, exitToken
   };
 }`;
 }
+
+export function notebookExampleSource(marker: string, occupied = false): string {
+	return `{
+	  const __conflict = ${occupied} || "foo" in globalThis || "bar" in globalThis;
+  let __injected = [];
+  if (!__conflict) {
+    const __foo = [
+      { id: "alpha", value: "first example record" },
+      { id: "bravo", value: "second example record" },
+    ];
+    const __bar = (__item) => Object.fromEntries(Object.entries(__item).slice(0, 4));
+    Object.defineProperties(__foo, {
+      description: { value: "Example records for reusable helper patterns", writable: true, configurable: true },
+      usage: { value: "Inspect: foo.map((item, index) => ({ index, keys: Object.keys(item) }))", writable: true, configurable: true },
+    });
+    Object.defineProperties(__bar, {
+      description: { value: "Summarize one foo item without mutating foo", writable: true, configurable: true },
+      usage: { value: "Inspect: foo.map((item, index) => ({ index, keys: Object.keys(item) }))\\nRun: bar(foo[index])", writable: true, configurable: true },
+    });
+    try {
+      Object.defineProperties(globalThis, {
+        foo: { value: __foo, writable: true, configurable: true, enumerable: true },
+        bar: { value: __bar, writable: true, configurable: true, enumerable: true },
+      });
+      __injected = ["foo", "bar"];
+    } catch {
+      delete globalThis.foo;
+      delete globalThis.bar;
+    }
+  }
+  console.log(${JSON.stringify(marker)} + JSON.stringify(__injected));
+  undefined;
+}`;
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle-result.ts
@@ -19,6 +19,8 @@ export interface NotebookStatusDetails extends Record<string, unknown> {
 		bytes?: number | undefined;
 		updatedAt?: string | undefined;
 		pinned?: boolean | undefined;
+		description?: string | undefined;
+		usage?: string | undefined;
 	}> | undefined;
 	omittedMatches?: number | undefined;
 	retainedBindings: number;
@@ -27,6 +29,7 @@ export interface NotebookStatusDetails extends Record<string, unknown> {
 	pinned: RetainedProjectBinding[];
 	omittedPinned: number;
 	largestUnpinned: RetainedProjectBinding[];
+	omittedLargestUnpinned: number;
 }
 
 export function withinNameBudget(names: string[]): string[] {
@@ -52,6 +55,10 @@ export function takeDetailValues<T>(values: T[], budget: { remaining: number }):
 		selected.push(value);
 	}
 	return selected;
+}
+
+export function remainingDetailsBudget(base: unknown): { remaining: number } {
+	return { remaining: Math.max(0, NOTEBOOK_DETAILS_BUDGET - Buffer.byteLength(JSON.stringify(base))) };
 }
 
 export function boundedReleaseDetails(
@@ -91,25 +98,34 @@ export function formatStatus(details: NotebookStatusDetails): string {
 	];
 	if (details.query === undefined && details.pinned.length > 0) {
 		lines.push("Pinned project bindings:");
-		for (const binding of details.pinned) lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}`);
+		for (const binding of details.pinned) lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
 		if (details.omittedPinned > 0) lines.push(`${details.omittedPinned} additional pinned binding(s) omitted; use status with a query glob`);
 	}
-	if (details.query === undefined && details.largestUnpinned.length > 0) {
-		lines.push("Largest unpinned retained bindings:");
-		for (const binding of details.largestUnpinned) {
-			lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}`);
+	if (details.query === undefined && (details.largestUnpinned.length > 0 || details.omittedLargestUnpinned > 0)) {
+		if (details.largestUnpinned.length > 0) {
+			lines.push("Largest unpinned retained bindings:");
+			for (const binding of details.largestUnpinned) {
+				lines.push(`- ${binding.name}: ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt)}${formatBindingMetadata(binding)}`);
+			}
 		}
-		lines.push("Use status with a query glob for details; pin intentional state before pruning disposable matches");
+		if (details.omittedLargestUnpinned > 0) lines.push(`${details.omittedLargestUnpinned} additional unpinned binding(s) omitted; use status with a query glob`);
+		lines.push("Use status with a query glob for details; unpinned state is reusable scratch, pin valuable state before pruning");
 	}
 	if (details.query !== undefined) {
 		lines.push(`Bindings matching ${JSON.stringify(details.query)}:`);
 		for (const binding of details.matches ?? []) {
-			lines.push(`- ${binding.name}: ${binding.kind}${binding.constructor ? ` ${binding.constructor}` : ` ${binding.type}`}${binding.disposable ? ` · ${binding.disposable} disposable` : ""}${binding.bytes === undefined ? "" : ` · ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt!)}`}${binding.pinned ? " · pinned" : ""}`);
+			lines.push(`- ${binding.name}: ${binding.kind}${binding.constructor ? ` ${binding.constructor}` : ` ${binding.type}`}${binding.disposable ? ` · ${binding.disposable} disposable` : ""}${binding.bytes === undefined ? "" : ` · ${formatBytes(binding.bytes)} · updated ${formatAge(binding.updatedAt!)}`}${binding.pinned ? " · pinned" : ""}${formatBindingMetadata(binding)}`);
 		}
 		if ((details.matches?.length ?? 0) === 0) lines.push("- none");
 		if ((details.omittedMatches ?? 0) > 0) lines.push(`${details.omittedMatches} additional match(es) omitted; narrow query`);
 	}
 	return boundMessage(lines.filter(Boolean).join("\n"));
+}
+
+function formatBindingMetadata(binding: { description?: string | undefined; usage?: string | undefined }): string {
+	const description = binding.description === undefined ? "" : ` · ${binding.description}`;
+	const usage = binding.usage === undefined ? "" : ` · usage: ${binding.usage.replaceAll("\n", "\n  ")}`;
+	return `${description}${usage}`;
 }
 
 export function formatRelease(result: NotebookReleaseResult, restarted: boolean): string {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
@@ -15,6 +15,7 @@ import {
 	formatRelease,
 	formatStatus,
 	NOTEBOOK_DETAILS_BUDGET,
+	remainingDetailsBudget,
 	takeDetailValues,
 	withinNameBudget,
 	type NotebookStatusDetails,
@@ -121,7 +122,6 @@ export class NotebookLifecycleController {
 			);
 		}
 		const metadata = this.host.metadata();
-		const detailBudget = { remaining: NOTEBOOK_DETAILS_BUDGET };
 		const inspectedMatches = (runtime?.bindings ?? []).map((binding) => {
 			const retainedBinding = retainedByName.get(binding.name);
 			return {
@@ -130,13 +130,17 @@ export class NotebookLifecycleController {
 					bytes: retainedBinding.bytes,
 					updatedAt: retainedBinding.updatedAt,
 					pinned: retainedBinding.pinned,
+					...(retainedBinding.description === undefined ? {} : { description: retainedBinding.description }),
+					...(retainedBinding.usage === undefined ? {} : { usage: retainedBinding.usage }),
 				} : {}),
 			};
 		});
-		const reportedMatches = takeDetailValues(inspectedMatches, detailBudget);
 		const pinned = retained.filter((binding) => binding.pinned);
-		const reportedPinned = takeDetailValues(pinned, detailBudget);
-		const details: NotebookStatusDetails = {
+		const unpinned = retained
+			.filter(({ pinned }) => !pinned)
+			.sort((left, right) => right.bytes - left.bytes);
+		const largestUnpinned = unpinned.slice(0, 8);
+		const baseDetails: NotebookStatusDetails = {
 			state: activeCell ? "running" : "idle",
 			...(activeCell ? { activeCell } : {}),
 			userBindings: activeCell ? undefined : allNames.length,
@@ -147,14 +151,27 @@ export class NotebookLifecycleController {
 			retainedBindings: retained.length,
 			retainedBytes: retained.reduce((total, binding) => total + binding.bytes, 0),
 			pinnedBindings: pinned.length,
-			pinned: reportedPinned,
-			omittedPinned: pinned.length - reportedPinned.length,
-			largestUnpinned: retained
-				.filter(({ pinned }) => !pinned)
-				.sort((left, right) => right.bytes - left.bytes)
-				.slice(0, 8),
+			pinned: [],
+			omittedPinned: pinned.length,
+			largestUnpinned: [],
+			omittedLargestUnpinned: unpinned.length,
 			...(query === undefined ? {} : {
 				query,
+				matches: [],
+				omittedMatches: matches.length,
+			}),
+		};
+		const detailBudget = remainingDetailsBudget(baseDetails);
+		const reportedMatches = takeDetailValues(inspectedMatches, detailBudget);
+		const reportedPinned = takeDetailValues(pinned, detailBudget);
+		const reportedLargestUnpinned = takeDetailValues(largestUnpinned, detailBudget);
+		const details: NotebookStatusDetails = {
+			...baseDetails,
+			pinned: reportedPinned,
+			omittedPinned: pinned.length - reportedPinned.length,
+			largestUnpinned: reportedLargestUnpinned,
+			omittedLargestUnpinned: unpinned.length - reportedLargestUnpinned.length,
+			...(query === undefined ? {} : {
 				matches: reportedMatches,
 				omittedMatches: Math.max(0, matches.length - reportedMatches.length),
 			}),

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/lifecycle.ts
@@ -28,6 +28,7 @@ import {
 	type NotebookReleaseResult,
 } from "./lifecycle-runtime.ts";
 import { NotebookProfileController } from "./profile-lifecycle.ts";
+import type { NotebookRuntimeHealth } from "./runtime-health.ts";
 
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 const STATUS_TIMEOUT_MS = 8_000;
@@ -47,6 +48,7 @@ interface NotebookLifecycleHost {
 	rollback(context: ExtensionContext): Promise<void>;
 	baselineNames(): ReadonlySet<string>;
 	profileStorage(): { agentDir: string; maxBytes: number };
+	runtimeHealth(): NotebookRuntimeHealth;
 	metadata(): {
 		startedAt?: number | undefined;
 		userCells: number;
@@ -72,6 +74,7 @@ export class NotebookLifecycleController {
 		if (request.action === "list") return this.profiles.list(request.query);
 		if (request.action === "diagnostics") return this.host.diagnostics(context, signal);
 		if (request.action === "reset") return this.host.reset(context, signal);
+		if (request.action === "restart" && this.host.runtimeHealth().state !== "ready") return this.restart(context, signal);
 		await this.host.prepare(context, signal);
 		switch (request.action) {
 			case "status": return this.status(request.query, signal);
@@ -264,7 +267,15 @@ export class NotebookLifecycleController {
 
 	private async restart(context: ToolExecutionContext, signal?: AbortSignal): Promise<NotebookControlResult> {
 		const activeCell = await this.host.stopActive();
-		if (!activeCell) await this.host.checkpoint();
+		let checkpointNotice: string | undefined;
+		if (!activeCell && this.host.runtimeHealth().state === "ready") {
+			try {
+				await this.host.checkpoint();
+			} catch (error) {
+				if (this.host.runtimeHealth().state !== "invalidated") throw error;
+				checkpointNotice = `Checkpoint skipped after runtime invalidation: ${error instanceof Error ? error.message : String(error)}`;
+			}
+		}
 		const disposal = await this.disposeAll(signal).catch((error) => ({
 			released: [],
 			disposed: [],
@@ -283,6 +294,7 @@ export class NotebookLifecycleController {
 			message: [
 				`Notebook kernel restarted from the last completed checkpoint${activeCell ? `; terminated ${activeCell}` : ""}`,
 				disposal && disposal.failures.length > 0 ? `${disposal.failures.length} resource cleanup failure${disposal.failures.length === 1 ? "" : "s"}; restart continued` : undefined,
+				checkpointNotice,
 				restoreNotice,
 			].filter(Boolean).join(". "),
 			details,

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/notebook-diagnostics.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/notebook-diagnostics.ts
@@ -2,9 +2,13 @@ import { pathToFileURL } from "node:url";
 import type { NotebookControlResult } from "../code-mode/types.ts";
 import { readNotebookJournalCodeCells } from "./journal.ts";
 import { OneShotLspProcess } from "./lsp-process.ts";
+import type { NotebookRuntimeHealthState } from "./runtime-health.ts";
 
 const DIAGNOSTIC_TIMEOUT_MS = 30_000;
 const MESSAGE_BUDGET = 16 * 1024;
+const DETAILS_BUDGET = 16 * 1024;
+const MAX_DIAGNOSTIC_TEXT_BYTES = 2 * 1024;
+const MAX_DIAGNOSTIC_SAMPLES = 3;
 const HOST_BINDINGS = new Set([
 	"ALL_TOOLS",
 	"exit",
@@ -18,7 +22,7 @@ const HOST_BINDINGS = new Set([
 	"yield_control",
 ]);
 
-interface NotebookDiagnostic {
+export interface NotebookDiagnostic {
 	cellId: string;
 	cellIndex: number;
 	line: number;
@@ -28,7 +32,18 @@ interface NotebookDiagnostic {
 	severity: "error" | "warning" | "information" | "hint" | "unknown";
 	code?: string | number | undefined;
 	source?: string | undefined;
+	name?: string | undefined;
 	message: string;
+}
+
+export interface NotebookDiagnosticGroup {
+	count: number;
+	severity: NotebookDiagnostic["severity"];
+	code?: string | number | undefined;
+	source?: string | undefined;
+	name?: string | undefined;
+	message: string;
+	samples: Array<Pick<NotebookDiagnostic, "cellId" | "cellIndex" | "line" | "column" | "endLine" | "endColumn">>;
 }
 
 export async function diagnoseNotebook(options: {
@@ -36,20 +51,27 @@ export async function diagnoseNotebook(options: {
 	cwd: string;
 	path: string;
 	runtimeBindings?: ReadonlySet<string> | undefined;
+	runtimeHealth?: NotebookRuntimeHealthState | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<NotebookControlResult> {
+	const runtimeHealth = options.runtimeHealth ?? "not_started";
+	const healthMessage = formatRuntimeHealth(runtimeHealth);
+	const path = boundText(options.path);
 	let cells;
 	try {
 		cells = readNotebookJournalCodeCells(options.path);
 	} catch (error) {
-		const reason = error instanceof Error ? error.message : String(error);
-		return {
-			message: `Notebook diagnostics could not read ${options.path}: ${reason}`,
-			details: { path: options.path, error: reason },
-		};
+		const reason = boundText(error instanceof Error ? error.message : String(error));
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNotebook diagnostics could not read ${path}: ${reason}`,
+			{ path, runtime: { state: runtimeHealth }, error: reason },
+		);
 	}
 	if (cells.length === 0) {
-		return { message: `No code cells to diagnose in ${options.path}`, details: { path: options.path, cells: 0, diagnostics: [] } };
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNo historical static code cells to diagnose in ${path}`,
+			{ path, cells: 0, runtime: { state: runtimeHealth }, diagnosticGroups: [] },
+		);
 	}
 
 	const timeout = AbortSignal.timeout(DIAGNOSTIC_TIMEOUT_MS);
@@ -101,7 +123,16 @@ export async function diagnoseNotebook(options: {
 			notebookDocument: { uri: notebookUri },
 			cellTextDocuments: documents.map(({ uri }) => ({ uri })),
 		});
-		return formatDiagnostics(options.path, cells.length, diagnostics);
+		return formatNotebookDiagnostics(options.path, cells.length, diagnostics, runtimeHealth);
+	} catch (error) {
+		if (options.signal?.aborted) throw error;
+		const reason = boundText(timeout.aborted
+			? `Deno diagnostics timed out after ${DIAGNOSTIC_TIMEOUT_MS}ms`
+			: error instanceof Error ? error.message : String(error));
+		return boundedDiagnosticResult(
+			`${healthMessage}\nNotebook diagnostics could not complete: ${reason}`,
+			{ path, cells: cells.length, runtime: { state: runtimeHealth }, error: reason },
+		);
 	} finally {
 		await lsp.shutdown();
 	}
@@ -117,6 +148,7 @@ function parseDiagnosticReport(
 		if (!isRecord(item) || typeof item["message"] !== "string" || !isRange(item["range"])) return [];
 		const range = item["range"];
 		if (isRuntimeDiagnostic(item, range, cell.source, runtimeBindings)) return [];
+		const message = boundText(item["message"]);
 		return [{
 			cellId: cell.id,
 			cellIndex: cell.index,
@@ -127,7 +159,8 @@ function parseDiagnosticReport(
 			severity: severityName(item["severity"]),
 			...(typeof item["code"] === "string" || typeof item["code"] === "number" ? { code: item["code"] } : {}),
 			...(typeof item["source"] === "string" ? { source: item["source"] } : {}),
-			message: item["message"],
+			...(diagnosticName(message) ? { name: diagnosticName(message) } : {}),
+			message,
 		}];
 	});
 }
@@ -147,25 +180,127 @@ function isRuntimeDiagnostic(
 	return line !== undefined && /globalThis\s*\.\s*$/.test(line.slice(0, range.start.character));
 }
 
-function formatDiagnostics(path: string, cells: number, diagnostics: NotebookDiagnostic[]): NotebookControlResult {
-	if (diagnostics.length === 0) {
-		return { message: `No Deno diagnostics in ${path} (${cells} code cells)`, details: { path, cells, diagnostics: [] } };
-	}
-	const lines = [`Deno diagnostics for ${path}:`];
-	const included: NotebookDiagnostic[] = [];
-	for (const diagnostic of diagnostics) {
-		const code = diagnostic.code === undefined ? "" : ` ${diagnostic.source ?? "deno"}-${diagnostic.code}`;
-		const line = `- ${diagnostic.cellId} cell ${diagnostic.cellIndex + 1}:${diagnostic.line}:${diagnostic.column} ${diagnostic.severity}${code}: ${diagnostic.message.replaceAll("\n", " ")}`;
-		if (lines.join("\n").length + line.length + 1 > MESSAGE_BUDGET) break;
+export function formatNotebookDiagnostics(path: string, cells: number, diagnostics: NotebookDiagnostic[], runtimeHealth: NotebookRuntimeHealthState = "not_started"): NotebookControlResult {
+	const groups = groupDiagnostics(diagnostics);
+	const reportedPath = boundText(path);
+	const lines = [formatRuntimeHealth(runtimeHealth), `Historical static diagnostics for ${reportedPath} (${cells} code cells):`];
+	const included: NotebookDiagnosticGroup[] = [];
+	for (const group of groups) {
+		const line = formatDiagnosticGroup(group);
+		const candidate = [...included, group];
+		const candidateDetails = diagnosticDetails(reportedPath, cells, runtimeHealth, diagnostics.length, candidate, groups.length - candidate.length);
+		if (Buffer.byteLength(JSON.stringify(candidateDetails), "utf8") > DETAILS_BUDGET) break;
+		if (Buffer.byteLength(`${lines.join("\n")}\n${line}`, "utf8") + 64 > MESSAGE_BUDGET) break;
 		lines.push(line);
-		included.push(diagnostic);
+		included.push(group);
 	}
-	const omitted = diagnostics.length - included.length;
-	if (omitted > 0) lines.push(`${omitted} additional diagnostic${omitted === 1 ? "" : "s"} omitted; repair these and run diagnostics again`);
+	const omittedGroups = groups.length - included.length;
+	if (groups.length === 0) lines.push("No historical static Deno diagnostics");
+	if (omittedGroups > 0) lines.push(`${omittedGroups} additional historical diagnostic group${omittedGroups === 1 ? "" : "s"} omitted by the output bound`);
+	return boundedDiagnosticResult(
+		lines.join("\n"),
+		diagnosticDetails(reportedPath, cells, runtimeHealth, diagnostics.length, included, omittedGroups),
+	);
+}
+
+function diagnosticDetails(
+	path: string,
+	cells: number,
+	runtimeHealth: NotebookRuntimeHealthState,
+	diagnosticCount: number,
+	diagnosticGroups: NotebookDiagnosticGroup[],
+	omittedGroups: number,
+): Record<string, unknown> {
+	return { path, cells, runtime: { state: runtimeHealth }, diagnosticCount, diagnosticGroups, omittedGroups };
+}
+
+function groupDiagnostics(diagnostics: NotebookDiagnostic[]): NotebookDiagnosticGroup[] {
+	const groups = new Map<string, NotebookDiagnosticGroup>();
+	for (const diagnostic of diagnostics) {
+		const key = JSON.stringify([
+			diagnostic.code ?? null,
+			diagnostic.message,
+			diagnostic.name ?? null,
+			diagnostic.severity,
+			diagnostic.source ?? null,
+		]);
+		let group = groups.get(key);
+		if (!group) {
+			group = {
+				count: 0,
+				severity: diagnostic.severity,
+				...(diagnostic.code === undefined ? {} : { code: diagnostic.code }),
+				...(diagnostic.source === undefined ? {} : { source: diagnostic.source }),
+				...(diagnostic.name === undefined ? {} : { name: diagnostic.name }),
+				message: diagnostic.message,
+				samples: [],
+			};
+			groups.set(key, group);
+		}
+		group.count += 1;
+		if (group.samples.length < MAX_DIAGNOSTIC_SAMPLES) group.samples.push({
+			cellId: diagnostic.cellId,
+			cellIndex: diagnostic.cellIndex,
+			line: diagnostic.line,
+			column: diagnostic.column,
+			endLine: diagnostic.endLine,
+			endColumn: diagnostic.endColumn,
+		});
+	}
+	return [...groups.values()];
+}
+
+function formatDiagnosticGroup(group: NotebookDiagnosticGroup): string {
+	const code = group.code === undefined ? "" : ` ${group.source ?? "deno"}-${group.code}`;
+	const name = group.name ? ` [${group.name}]` : "";
+	const samples = group.samples.map((sample) => `${sample.cellId} cell ${sample.cellIndex + 1}:${sample.line}:${sample.column}`).join(", ");
+	return `- ${group.count} occurrence${group.count === 1 ? "" : "s"} ${group.severity}${code}${name}: ${group.message.replaceAll("\n", " ")}; samples: ${samples}`;
+}
+
+function formatRuntimeHealth(state: NotebookRuntimeHealthState): string {
+	switch (state) {
+		case "ready": return "Notebook runtime health: ready; bootstrap is available";
+		case "invalidated": return "Notebook runtime health: invalidated; exec or restart will recreate it from the last completed checkpoint. Durable project bindings are preserved; external side effects were not rolled back";
+		case "not_started": return "Notebook runtime health: not started; exec or restart will create it from the last completed checkpoint";
+	}
+}
+
+function diagnosticName(message: string): string | undefined {
+	return /(?:Cannot redeclare block-scoped variable|Duplicate identifier) ['"]([^'"]+)['"]/.exec(message)?.[1];
+}
+
+function boundText(value: string): string {
+	return boundUtf8(value, MAX_DIAGNOSTIC_TEXT_BYTES, " [diagnostic text truncated]");
+}
+
+function boundedDiagnosticResult(message: string, details: Record<string, unknown>): NotebookControlResult {
+	const boundedMessage = boundUtf8(message, MESSAGE_BUDGET, "\n[diagnostics output truncated]");
+	if (Buffer.byteLength(JSON.stringify(details), "utf8") <= DETAILS_BUDGET) {
+		return { message: boundedMessage, details };
+	}
 	return {
-		message: lines.join("\n"),
-		details: { path, cells, diagnostics: included, omitted },
+		message: boundedMessage,
+		details: {
+			...(isRecord(details["runtime"]) ? { runtime: details["runtime"] } : {}),
+			detailsOmitted: true,
+		},
 	};
+}
+
+function boundUtf8(value: string, maxBytes: number, suffix: string): string {
+	if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+	const available = Math.max(0, maxBytes - Buffer.byteLength(suffix, "utf8"));
+	let low = 0;
+	let high = value.length;
+	while (low < high) {
+		const middle = Math.ceil((low + high) / 2);
+		if (Buffer.byteLength(value.slice(0, middle), "utf8") <= available) low = middle;
+		else high = middle - 1;
+	}
+	let prefix = value.slice(0, low);
+	const last = prefix.charCodeAt(prefix.length - 1);
+	if (last >= 0xd800 && last <= 0xdbff) prefix = prefix.slice(0, -1);
+	return `${prefix}${suffix}`;
 }
 
 function notebookCellUri(path: string, index: number, id: string): string {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/npm-imports.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/npm-imports.ts
@@ -55,12 +55,6 @@ export async function recordNotebookNpmImports(
 	return readNotebookNpmImports(identity);
 }
 
-export async function resetNotebookNpmImports(identity: { project: string; agentDir: string }): Promise<void> {
-	const paths = npmImportPaths(identity);
-	mkdirSync(paths.directory, { recursive: true });
-	await withProjectStateLock(paths.lock, async () => { rmSync(paths.manifest, { force: true }); });
-}
-
 export function formatNotebookNpmImportsNotice(imports: string[]): string {
 	const prefix = `Available npm imports previously established in this project: ${imports.length === 0 ? "none" : boundedImportList(imports)}`;
 	return `${prefix}. All npm packages are unsafe by default; ask the user before first use of any unlisted package and use an exact-version npm: specifier`;

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/profile-state-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/profile-state-format.ts
@@ -5,6 +5,7 @@ import {
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
 	MAX_PROJECT_NAME_BYTES,
+	parseProjectBindingMetadata,
 	type ProjectStateEntry,
 } from "./project-state-format.ts";
 
@@ -140,12 +141,14 @@ export function hashProfileBytes(bytes: Uint8Array): string {
 function parseEntry(value: unknown): ProjectStateEntry | undefined {
 	if (!isRecord(value)) return undefined;
 	const { name, kind, offset, length, hash } = value;
+	const metadata = parseProjectBindingMetadata(value);
 	return typeof name === "string" && IDENTIFIER.test(name) && Buffer.byteLength(name) <= MAX_PROJECT_NAME_BYTES
 		&& (kind === "value" || kind === "function")
 		&& Number.isSafeInteger(offset) && (offset as number) >= 0
 		&& Number.isSafeInteger(length) && (length as number) >= 0
 		&& typeof hash === "string" && HASH.test(hash)
-		? { name, kind, offset: offset as number, length: length as number, hash }
+		&& metadata !== undefined
+		? { name, kind, offset: offset as number, length: length as number, hash, ...metadata }
 		: undefined;
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-format.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-format.ts
@@ -6,6 +6,9 @@ export const PROJECT_STATE_SCHEMA = 2;
 export const MAX_PROJECT_ENTRIES = 10_000;
 export const MAX_PROJECT_NAME_BYTES = 4 * 1024;
 export const MAX_PROJECT_MANIFEST_BYTES = 8 * 1024 * 1024;
+export const MAX_PROJECT_DESCRIPTION_BYTES = 256;
+export const MAX_PROJECT_USAGE_BYTES = 512;
+export const MAX_PROJECT_USAGE_LINES = 4;
 const PAYLOAD_NAME = /^project-[0-9a-f-]+\.bin$/;
 const CONFLICT_PAYLOAD_NAME = /^[0-9]+-[0-9a-f-]+\.bin$/;
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
@@ -16,8 +19,15 @@ export interface ProjectStateEntry {
 	offset: number;
 	length: number;
 	hash: string;
+	description?: string | undefined;
+	usage?: string | undefined;
 	updatedAt?: string | undefined;
 	pinned?: true | undefined;
+}
+
+export interface ProjectBindingMetadata {
+	description?: string | undefined;
+	usage?: string | undefined;
 }
 
 export interface ProjectStateManifest {
@@ -43,7 +53,7 @@ export interface ProjectStateCandidate {
 
 export interface ProjectStateBaseline {
 	generation: string;
-	entries: Array<{ name: string; hash: string }>;
+	entries: Array<{ name: string; hash: string } & ProjectBindingMetadata>;
 }
 
 export interface ProjectStateSummary {
@@ -187,7 +197,15 @@ export function readProjectConflictRecord(path: string): ProjectConflictRecord |
 }
 
 export function baselineFromProjectManifest(manifest: ProjectStateManifest): ProjectStateBaseline {
-	return { generation: manifest.generation, entries: manifest.entries.map(({ name, hash }) => ({ name, hash })) };
+	return {
+		generation: manifest.generation,
+		entries: manifest.entries.map(({ name, hash, description, usage }) => ({
+			name,
+			hash,
+			...(description === undefined ? {} : { description }),
+			...(usage === undefined ? {} : { usage }),
+		})),
+	};
 }
 
 export function emptyProjectStateSummary(): ProjectStateSummary {
@@ -211,15 +229,40 @@ function parseEntry(value: unknown, payloadLength: number, requireHash: boolean)
 		|| updatedAt !== undefined && (typeof updatedAt !== "string" || !Number.isFinite(Date.parse(updatedAt)))
 		|| pinned !== undefined && pinned !== true
 	) return undefined;
+	const metadata = parseProjectBindingMetadata(value);
+	if (!metadata) return undefined;
 	const entry: Omit<ProjectStateEntry, "hash"> = {
 		name,
 		kind: kind as ProjectStateEntry["kind"],
 		offset: offset as number,
 		length: length as number,
+		...metadata,
 		...(typeof updatedAt === "string" ? { updatedAt } : {}),
 		...(pinned === true ? { pinned: true as const } : {}),
 	};
 	return requireHash ? { ...entry, hash: hash as string } : entry;
+}
+
+export function parseProjectBindingMetadata(value: Record<string, unknown>): ProjectBindingMetadata | undefined {
+	const description = parseMetadataText(value["description"], MAX_PROJECT_DESCRIPTION_BYTES, false);
+	const usage = parseMetadataText(value["usage"], MAX_PROJECT_USAGE_BYTES, true);
+	if (description === null || usage === null) return undefined;
+	return {
+		...(description === undefined ? {} : { description }),
+		...(usage === undefined ? {} : { usage }),
+	};
+}
+
+function parseMetadataText(value: unknown, maxBytes: number, multiline: boolean): string | undefined | null {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string" || value.length === 0 || Buffer.byteLength(value) > maxBytes) return null;
+	const lines = value.split("\n");
+	if ((!multiline && lines.length !== 1) || lines.length > MAX_PROJECT_USAGE_LINES || value.includes("\r")) return null;
+	for (const character of value) {
+		const codePoint = character.codePointAt(0)!;
+		if (codePoint < 0x20 && codePoint !== 0x0a || codePoint === 0x7f) return null;
+	}
+	return value;
 }
 
 function parseSkipped(value: unknown): { name: string; reason: string } | undefined {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-merge.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-merge.ts
@@ -32,7 +32,7 @@ export function mergeProjectState(options: {
 	currentPayload: Buffer;
 	pins?: ProjectStatePinUpdate | undefined;
 }): ProjectStateMerge {
-	const base = new Map(options.baseline.entries.map(({ name, hash }) => [name, hash]));
+	const base = new Map(options.baseline.entries.map((entry) => [entry.name, entry]));
 	const current = new Map((options.current?.entries ?? []).map((entry) => [entry.name, entry]));
 	const candidate = new Map(options.candidate.entries.map((entry) => [entry.name, {
 		...entry,
@@ -52,18 +52,19 @@ export function mergeProjectState(options: {
 	let conflictOffset = 0;
 	const capturedAt = new Date().toISOString();
 	for (const name of names) {
-		const baseHash = base.get(name);
+		const baseEntry = base.get(name);
 		const currentEntry = current.get(name);
 		const candidateEntry = candidate.get(name);
-		const candidateHash = skipped.has(name) ? baseHash : candidateEntry?.hash;
-		const currentHash = currentEntry?.hash;
-		const candidateChanged = !skipped.has(name) && candidateHash !== baseHash;
-		const currentChanged = currentHash !== baseHash;
+		const baseFingerprint = projectStateEntryFingerprint(baseEntry);
+		const candidateFingerprint = skipped.has(name) ? baseFingerprint : projectStateEntryFingerprint(candidateEntry);
+		const currentFingerprint = projectStateEntryFingerprint(currentEntry);
+		const candidateChanged = !skipped.has(name) && candidateFingerprint !== baseFingerprint;
+		const currentChanged = currentFingerprint !== baseFingerprint;
 		let selected: { entry: ProjectStateEntry; payload: Buffer } | undefined;
 		if (candidateChanged && !candidateEntry && currentEntry?.pinned) {
 			conflicts.push(name);
 			selected = { entry: currentEntry, payload: options.currentPayload };
-		} else if (candidateChanged && currentChanged && candidateHash !== currentHash) {
+		} else if (candidateChanged && currentChanged && candidateFingerprint !== currentFingerprint) {
 			conflicts.push(name);
 			if (candidateEntry) {
 				const bytes = options.candidatePayload.subarray(candidateEntry.offset, candidateEntry.offset + candidateEntry.length);
@@ -77,7 +78,7 @@ export function mergeProjectState(options: {
 			if (candidateEntry) selected = {
 				entry: {
 					...candidateEntry,
-					updatedAt: candidateHash === currentHash
+					updatedAt: candidateFingerprint === currentFingerprint
 						? currentEntry?.updatedAt ?? options.current?.createdAt ?? capturedAt
 						: capturedAt,
 					...(currentEntry?.pinned ? { pinned: true } : {}),
@@ -113,17 +114,19 @@ export function mergeProjectState(options: {
 			};
 		}
 	}
-	const currentShape = JSON.stringify((options.current?.entries ?? []).map(({ name, kind, hash, pinned }) => [name, kind, hash, pinned === true]));
-	const mergedShape = JSON.stringify(entries.map(({ name, kind, hash, pinned }) => [name, kind, hash, pinned === true]));
+	const currentShape = JSON.stringify((options.current?.entries ?? []).map(projectStateEntryShape));
+	const mergedShape = JSON.stringify(entries.map(projectStateEntryShape));
 	const skippedBaseline = options.baseline.entries.filter(({ name }) => skipped.has(name));
 	return {
 		changed: mergedShape !== currentShape,
 		baseline: {
 			generation: options.baseline.generation,
-			entries: [
-				...skippedBaseline,
-				...[...candidate.values()].map(({ name, hash }) => ({ name, hash })),
-			].sort((left, right) => left.name.localeCompare(right.name)),
+			entries: [...skippedBaseline, ...[...candidate.values()].map(({ name, hash, description, usage }) => ({
+				name,
+				hash,
+				...(description === undefined ? {} : { description }),
+				...(usage === undefined ? {} : { usage }),
+			}))].sort((left, right) => left.name.localeCompare(right.name)),
 		},
 		entries,
 		payload: Buffer.concat(parts),
@@ -133,4 +136,18 @@ export function mergeProjectState(options: {
 		conflictDeletions,
 		conflictPayload: Buffer.concat(conflictParts),
 	};
+}
+
+export function projectStateEntryFingerprint(entry: {
+	hash?: string | undefined;
+	description?: string | undefined;
+	usage?: string | undefined;
+} | undefined): string | undefined {
+	return entry === undefined
+		? undefined
+		: JSON.stringify([entry.hash ?? null, entry.description ?? null, entry.usage ?? null]);
+}
+
+function projectStateEntryShape(entry: ProjectStateEntry): [string, string, string, boolean, string | null, string | null] {
+	return [entry.name, entry.kind, entry.hash, entry.pinned === true, entry.description ?? null, entry.usage ?? null];
 }

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-metadata.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-metadata.ts
@@ -12,6 +12,8 @@ export interface RetainedProjectBinding {
 	bytes: number;
 	updatedAt: string;
 	pinned: boolean;
+	description?: string | undefined;
+	usage?: string | undefined;
 }
 
 export function readRetainedProjectBindings(
@@ -31,6 +33,8 @@ export function readRetainedProjectBindings(
 		bytes: entry.length,
 		updatedAt: entry.updatedAt ?? manifest.createdAt,
 		pinned: entry.pinned === true,
+		...(entry.description === undefined ? {} : { description: entry.description }),
+		...(entry.usage === undefined ? {} : { usage: entry.usage }),
 	}));
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
@@ -8,7 +8,7 @@ import type { KernelExecutionResult } from "./jupyter-kernel.ts";
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 export function projectBindingNamesSource(marker: string): string {
-	return `console.log(${JSON.stringify(marker)} + JSON.stringify(globalThis.__piNotebook.projectBindings())); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.projectBindings !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.projectBindings"); console.log(${JSON.stringify(marker)} + JSON.stringify(globalThis.__piNotebook.projectBindings())); undefined;`;
 }
 
 export function parseProjectBindingNames(result: KernelExecutionResult, marker: string): string[] {
@@ -28,11 +28,11 @@ export function parseProjectBindingNames(result: KernelExecutionResult, marker: 
 }
 
 export function promoteProjectBindingsSource(names: string[]): string {
-	return `globalThis.__piNotebook.promote(${JSON.stringify(names)}); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.promote !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.promote"); globalThis.__piNotebook.promote(${JSON.stringify(names)}); undefined;`;
 }
 
 export function syncProjectBindingsSource(names: string[]): string {
-	return `globalThis.__piNotebook.syncProjectBindings(${JSON.stringify(names)}); undefined;`;
+	return `if (typeof globalThis.__piNotebook?.syncProjectBindings !== "function") throw new Error("Notebook runtime bootstrap unavailable: __piNotebook.syncProjectBindings"); globalThis.__piNotebook.syncProjectBindings(${JSON.stringify(names)}); undefined;`;
 }
 
 export function projectStateCaptureSource(options: {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state-runtime.ts
@@ -1,6 +1,9 @@
 import {
+	MAX_PROJECT_DESCRIPTION_BYTES,
 	MAX_PROJECT_ENTRIES,
 	MAX_PROJECT_MANIFEST_BYTES,
+	MAX_PROJECT_USAGE_BYTES,
+	MAX_PROJECT_USAGE_LINES,
 	type ProjectStateManifest,
 } from "./project-state-format.ts";
 import type { KernelExecutionResult } from "./jupyter-kernel.ts";
@@ -59,8 +62,16 @@ export function projectStateCaptureSource(options: {
     const __bytes = serialize(__captured);
     if (__bytes.byteLength > __max) throw new Error("exceeds per-value checkpoint cap");
     if (__total + __bytes.byteLength > __max) throw new Error("exceeds total project checkpoint cap");
+	const __metadata = __readBindingMetadata(__value);
 	await __writeAll(__bytes);
-    __entries.push({ name: ${JSON.stringify(name)}, kind: __kind, offset: __total, length: __bytes.byteLength });
+	    __entries.push({
+	      name: ${JSON.stringify(name)},
+	      kind: __kind,
+	      offset: __total,
+	      length: __bytes.byteLength,
+	      ...(__metadata.description === undefined ? {} : { description: __metadata.description }),
+	      ...(__metadata.usage === undefined ? {} : { usage: __metadata.usage }),
+	    });
     __total += __bytes.byteLength;
   } catch (__error) {
     __skipped.push({ name: ${JSON.stringify(name)}, reason: String(__error instanceof Error ? __error.message : __error).slice(0, 240) });
@@ -68,9 +79,34 @@ export function projectStateCaptureSource(options: {
 	return `{
   const { serialize } = await import("node:v8");
   const __max = ${options.maxBytes};
-  const __entries = [];
-  const __skipped = [];
-  let __total = 0;
+	  const __entries = [];
+	  const __skipped = [];
+	  let __total = 0;
+	const __readBindingMetadata = (__value) => {
+	  if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return {};
+	  const __metadata = {};
+	  for (const [__key, __max, __multiline, __lines] of [
+	    ["description", ${MAX_PROJECT_DESCRIPTION_BYTES}, false, 1],
+	    ["usage", ${MAX_PROJECT_USAGE_BYTES}, true, ${MAX_PROJECT_USAGE_LINES}],
+	  ]) {
+	    const __descriptor = Object.getOwnPropertyDescriptor(__value, __key);
+	    if (!__descriptor || !("value" in __descriptor) || typeof __descriptor.value !== "string") continue;
+	    const __text = __descriptor.value;
+	    if (!__text || new TextEncoder().encode(__text).byteLength > __max || __text.includes("\\r")) continue;
+	    const __textLines = __text.split("\\n");
+	    if (__textLines.length > __lines) continue;
+	    let __valid = true;
+	    for (const __character of __text) {
+	      const __codePoint = __character.codePointAt(0);
+	      if ((__codePoint < 0x20 && __codePoint !== 0x0a) || __codePoint === 0x7f || !__multiline && __codePoint === 0x0a) {
+	        __valid = false;
+	        break;
+	      }
+	    }
+	    if (__valid) __metadata[__key] = __text;
+	  }
+	  return __metadata;
+	};
 	const __file = await Deno.open(${JSON.stringify(options.payloadPath)}, { create: true, write: true, truncate: true, mode: 0o600 });
 	const __writeAll = async (__bytes) => {
 	  let __offset = 0;
@@ -130,6 +166,20 @@ export function projectStateRestoreSource(
   const __matches = (__currentValue, __restore) => __restore.kind === "function"
     ? typeof __currentValue === "function" && Function.prototype.toString.call(__currentValue) === __restore.captured
     : __sameBytes(__currentValue, __restore.value);
+  const __applyMetadata = (__value, __entry) => {
+    if (__value === null || (typeof __value !== "object" && typeof __value !== "function")) return;
+    for (const __key of ["description", "usage"]) {
+      if (typeof __entry[__key] !== "string") continue;
+      try {
+        Object.defineProperty(__value, __key, {
+          value: __entry[__key],
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
+      } catch {}
+    }
+  };
   const __slot = "__piNotebookRebind_" + crypto.randomUUID().replaceAll("-", "");
   const __assign = (__name, __value) => {
     globalThis[__slot] = __value;
@@ -156,8 +206,10 @@ export function projectStateRestoreSource(
   for (const __restore of __restores) {
     if (__current.has(__restore.name)) {
       if (!__matches(__current.get(__restore.name), __restore)) __assign(__restore.name, __restore.value);
+      __applyMetadata(globalThis[__restore.name], __restore);
       continue;
     }
+    __applyMetadata(__restore.value, __restore);
     Object.defineProperty(globalThis, __restore.name, {
       value: __restore.value,
       writable: true,

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/project-state.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/project-state.ts
@@ -52,44 +52,6 @@ export async function restoreProjectState(
 	return withProjectStateLock(paths.lock, () => restoreProjectStateLocked(kernel, identity, paths), identity.signal);
 }
 
-export async function resetProjectState(identity: {
-	project: string;
-	session: string;
-	agentDir: string;
-}): Promise<{ previousBindings: number; generation: string }> {
-	const paths = projectStatePaths(identity.project, identity.agentDir);
-	mkdirSync(paths.directory, { recursive: true });
-	return withProjectStateLock(paths.lock, async () => {
-		const current = readProjectStateManifest(paths.manifest);
-		if (!current) {
-			rmSync(paths.manifest, { force: true });
-			removeProjectArtifacts(paths.directory);
-			return { previousBindings: 0, generation: "root" };
-		}
-		const generation = randomUUID();
-		const payload = `project-${generation}.bin`;
-		const manifest: ProjectStateManifest = {
-			schema: PROJECT_STATE_SCHEMA,
-			project: resolve(identity.project),
-			generation,
-			parentGeneration: current.generation,
-			deno: current.deno,
-			v8: current.v8,
-			payload,
-			createdAt: new Date().toISOString(),
-			sourceSession: identity.session,
-			entries: [],
-			skipped: [],
-		};
-		writeFileSync(join(paths.directory, payload), Buffer.alloc(0), { mode: 0o600 });
-		const temporary = `${paths.manifest}.${randomUUID()}.tmp`;
-		writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
-		renameSync(temporary, paths.manifest);
-		removeProjectArtifacts(paths.directory, new Set([payload]));
-		return { previousBindings: current.entries.length, generation };
-	});
-}
-
 export function projectStateBindingNames(identity: { project: string; agentDir: string }, maxBytes: number): string[] {
 	const paths = projectStatePaths(identity.project, identity.agentDir);
 	const manifest = readProjectStateManifest(paths.manifest);
@@ -306,18 +268,6 @@ function writeMergedProjectState(
 		try { rmSync(join(paths.directory, current.payload), { force: true }); } catch {}
 	}
 	return manifest;
-}
-
-function removeProjectArtifacts(directory: string, keep = new Set<string>()): void {
-	for (const name of readDirectoryNames(directory)) {
-		if (keep.has(name) || name === "project.json" || name === "write.lock") continue;
-		if (
-			name === "conflicts"
-			|| /^project-[0-9a-f-]+\.bin$/.test(name)
-			|| /^candidate-[0-9a-f-]+\.(?:bin|json)$/.test(name)
-			|| name.endsWith(".tmp")
-		) rmSync(join(directory, name), { recursive: true, force: true });
-	}
 }
 
 function writeProjectConflict(

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/recovery.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/recovery.ts
@@ -7,11 +7,12 @@ import {
 } from "./checkpoint.ts";
 import { ensureNotebookDenoBinary } from "./deno-binary.ts";
 import { initializeNotebookJournal } from "./journal.ts";
-import { resetNotebookNpmImports } from "./npm-imports.ts";
 import { diagnoseNotebook } from "./notebook-diagnostics.ts";
 import { resolveNotebookProject } from "./project-identity.ts";
 import { notebookProfileBindingNames } from "./profile-state.ts";
-import { projectStateBindingNames, resetProjectState } from "./project-state.ts";
+import { projectStateBindingNames } from "./project-state.ts";
+import { readRetainedProjectBindings } from "./project-state-metadata.ts";
+import type { NotebookRuntimeHealth } from "./runtime-health.ts";
 import { notebookSessionIdentity } from "./session-identity.ts";
 
 interface NotebookRecoveryHost {
@@ -19,6 +20,7 @@ interface NotebookRecoveryHost {
 	startClean(context: ExtensionContext, signal?: AbortSignal): Promise<void>;
 	checkpointEmpty(): Promise<void>;
 	configuredProfileActive(): boolean;
+	runtimeHealth(context: ExtensionContext): NotebookRuntimeHealth;
 }
 
 export class NotebookRecoveryController {
@@ -48,25 +50,26 @@ export class NotebookRecoveryController {
 				? notebookProfileBindingNames(this.profile, this.agentDir, this.maxBytes)
 				: []),
 		]);
-		return diagnoseNotebook({ deno, cwd: identity.project, path: journal.path, runtimeBindings, signal });
+		return diagnoseNotebook({ deno, cwd: identity.project, path: journal.path, runtimeBindings, runtimeHealth: this.host.runtimeHealth(requireExtensionContext(context, "diagnostics")).state, signal });
 	}
 
 	async reset(context: ToolExecutionContext, signal?: AbortSignal): Promise<NotebookControlResult> {
 		signal?.throwIfAborted();
 		const extension = requireExtensionContext(context, "reset");
 		const identity = notebookIdentity(extension, this.agentDir);
+		const retained = readRetainedProjectBindings(identity, this.maxBytes);
+		const pinned = retained.filter(({ pinned: isPinned }) => isPinned).length;
 		const activeCell = await this.host.stopWithoutCheckpoint();
-		const projectReset = await resetProjectState(identity);
-		await resetNotebookNpmImports(identity);
 		removeNotebookCheckpoint(identity);
 		await this.host.startClean(extension, signal);
 		await this.host.checkpointEmpty();
 		return {
-			message: `Notebook reset to empty state; discarded ${projectReset.previousBindings} project binding${projectReset.previousBindings === 1 ? "" : "s"}${activeCell ? ` and terminated ${activeCell}` : ""}. Saved notebook and named profiles were preserved; use exec to establish repaired state`,
+			message: `Notebook reset to durable project state; preserved ${retained.length} project binding${retained.length === 1 ? "" : "s"}${pinned > 0 ? ` including ${pinned} pinned` : ""}${activeCell ? ` and terminated ${activeCell}` : ""}. The session checkpoint was discarded; saved notebook and named profiles were preserved`,
 			details: {
 				project: identity.project,
-				projectGeneration: projectReset.generation,
-				discardedProjectBindings: projectReset.previousBindings,
+				preservedProjectBindings: retained.length,
+				preservedPinnedBindings: pinned,
+				discardedSessionCheckpoint: true,
 				...(activeCell ? { terminatedCell: activeCell } : {}),
 			},
 		};

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/runtime-health.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/runtime-health.ts
@@ -1,0 +1,35 @@
+export type NotebookRuntimeHealthState = "not_started" | "ready" | "invalidated";
+
+export interface NotebookRuntimeHealth {
+	state: NotebookRuntimeHealthState;
+}
+
+export const NOTEBOOK_INTERRUPTED_NOTICE =
+	"Notebook runtime was invalidated by an interrupted cell. The next operation will recreate it from the last completed checkpoint; durable project bindings were preserved. External side effects were not rolled back";
+
+export const NOTEBOOK_BOOTSTRAP_NOTICE =
+	"Notebook runtime bootstrap was unavailable. The kernel was discarded; the next operation will recreate it from the last completed checkpoint. Durable project bindings were preserved";
+
+export const NOTEBOOK_KERNEL_FAILURE_NOTICE =
+	"Notebook runtime became unavailable during a host operation. The next operation will recreate it from the last completed checkpoint; durable project bindings were preserved. External side effects were not rolled back";
+
+export function isNotebookBootstrapFailure(value: unknown): boolean {
+	const text = errorText(value);
+	return text.includes("Notebook runtime bootstrap unavailable: __piNotebook.");
+}
+
+function errorText(value: unknown, depth = 0): string {
+	if (depth > 2) return "";
+	if (typeof value === "string") return value;
+	if (value instanceof Error) return [value.message, errorText(value.cause, depth + 1)].filter(Boolean).join(" ");
+	if (value && typeof value === "object") {
+		const result = value as Record<string, unknown>;
+		return [
+			typeof result["errorText"] === "string" ? result["errorText"] : undefined,
+			typeof result["errorName"] === "string" ? result["errorName"] : undefined,
+			typeof result["errorValue"] === "string" ? result["errorValue"] : undefined,
+			errorText(result["cause"], depth + 1),
+		].filter(Boolean).join(" ");
+	}
+	return "";
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-runtime.ts
@@ -10,6 +10,14 @@ import type { DenoJupyterKernel } from "./jupyter-kernel.ts";
 import { extractNotebookNpmImports, recordNotebookNpmImports } from "./npm-imports.ts";
 import { resolveNotebookProject } from "./project-identity.ts";
 import { readRetainedProjectBindings, type RetainedProjectBinding } from "./project-state-metadata.ts";
+import {
+	NOTEBOOK_INTERRUPTED_NOTICE,
+	NOTEBOOK_BOOTSTRAP_NOTICE,
+	isNotebookBootstrapFailure,
+	NOTEBOOK_KERNEL_FAILURE_NOTICE,
+	type NotebookRuntimeHealth,
+	type NotebookRuntimeHealthState,
+} from "./runtime-health.ts";
 import { startNotebookSession } from "./session-startup.ts";
 import { notebookSessionIdentity } from "./session-identity.ts";
 
@@ -22,6 +30,7 @@ export class NotebookSessionRuntime {
 	private readonly bridge: NotebookBridgeServer;
 	private readonly runningCellId: () => string | undefined;
 	private kernelValue: DenoJupyterKernel | undefined;
+	private runtimeHealthValue: NotebookRuntimeHealthState = "not_started";
 	private identityValue: string | undefined;
 	private checkpointIdentityValue: NotebookCheckpointIdentity | undefined;
 	private startup: Promise<void> | undefined;
@@ -74,6 +83,7 @@ export class NotebookSessionRuntime {
 		try { this.materializeJournal(); } catch {}
 		const previous = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		await this.checkpoints.discard();
 		this.memoryValue = undefined;
@@ -86,15 +96,23 @@ export class NotebookSessionRuntime {
 		return this.takeNotice();
 	}
 
-	async discardKernel(): Promise<void> {
+	async invalidateKernel(notice = NOTEBOOK_INTERRUPTED_NOTICE): Promise<void> {
 		const kernel = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "invalidated";
 		this.startup = undefined;
 		this.memoryValue = undefined;
 		this.startedAtValue = undefined;
 		this.profileLoaded = false;
 		this.checkpointIdentityValue = undefined;
+		this.addNotice(notice);
 		await kernel?.shutdown().catch(() => undefined);
+	}
+
+	async recoverFromBootstrapFailure(value: unknown): Promise<boolean> {
+		if (!isNotebookBootstrapFailure(value)) return false;
+		if (this.kernelValue) await this.invalidateKernel(NOTEBOOK_BOOTSTRAP_NOTICE);
+		return true;
 	}
 
 	async stopWithoutCheckpoint(): Promise<void> {
@@ -102,6 +120,7 @@ export class NotebookSessionRuntime {
 		await this.startup?.catch(() => undefined);
 		const previous = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		await this.checkpoints.discard();
 		this.memoryValue = undefined;
@@ -122,6 +141,7 @@ export class NotebookSessionRuntime {
 		try { this.materializeJournal(); } catch {}
 		const kernel = this.kernelValue;
 		this.kernelValue = undefined;
+		this.runtimeHealthValue = "not_started";
 		this.startup = undefined;
 		this.startupAbort = undefined;
 		this.identityValue = undefined;
@@ -139,6 +159,10 @@ export class NotebookSessionRuntime {
 	}
 
 	kernel(): DenoJupyterKernel | undefined { return this.kernelValue; }
+	runtimeHealth(): NotebookRuntimeHealth { return { state: this.runtimeHealthValue }; }
+	runtimeHealthFor(context: ExtensionContext): NotebookRuntimeHealth {
+		return this.identityMatches(context) ? this.runtimeHealth() : { state: "not_started" };
+	}
 	journal(): NotebookJournal | undefined { return this.journalValue; }
 	materializeJournal(): void {
 		if (this.journalValue) materializeNotebookJournal(this.journalValue);
@@ -195,6 +219,7 @@ export class NotebookSessionRuntime {
 				: this.options,
 			bridge: this.bridge,
 			checkpointMaxBytes: this.checkpointMaxBytes,
+			onKernelFailure: (kernel) => this.handleKernelFailure(kernel),
 			...(signal ? { signal } : {}),
 		});
 		this.kernelValue = started.kernel;
@@ -203,10 +228,23 @@ export class NotebookSessionRuntime {
 		this.checkpointIdentityValue = started.checkpointIdentity;
 		this.baseline = started.baselineNames;
 		this.profileLoaded = started.configuredProfileLoaded;
+		this.runtimeHealthValue = "ready";
 		this.checkpoints.configure(started.checkpointIdentity, started.baselineNames, started.projectBaseline);
 		if (started.restoreNotice) {
 			this.addNotice(started.restoreNotice);
 		}
+	}
+
+	private handleKernelFailure(kernel: DenoJupyterKernel): void {
+		if (this.kernelValue !== kernel) return;
+		this.kernelValue = undefined;
+		this.runtimeHealthValue = "invalidated";
+		this.startup = undefined;
+		this.memoryValue = undefined;
+		this.startedAtValue = undefined;
+		this.profileLoaded = false;
+		this.checkpointIdentityValue = undefined;
+		this.addNotice(NOTEBOOK_KERNEL_FAILURE_NOTICE);
 	}
 
 	private beginStartup(context: ExtensionContext, signal?: AbortSignal, skipProfile = false): Promise<void> {

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { NotebookRuntimeOptions } from "../code-mode/shared-runtime.ts";
+import { notebookExecStartupNotice } from "./control-contract.ts";
 import type { NotebookBridgeServer } from "./bridge-server.ts";
 import {
 	garbageCollectSupersededNotebookCheckpoints,
@@ -106,7 +107,7 @@ export async function startNotebookSession(options: {
 		const exampleNotice = exampleNames.length === 2
 			? "Notebook example foo/bar available; inspect foo.description, foo.usage, bar.description, and bar.usage before constructing a reusable global"
 			: undefined;
-		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
+		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice, notebookExecStartupNotice()].filter(Boolean).join(". ") || undefined;
 		return {
 			kernel,
 			journal,

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -35,6 +35,7 @@ export async function startNotebookSession(options: {
 	runtime: NotebookRuntimeOptions;
 	bridge: NotebookBridgeServer;
 	checkpointMaxBytes: number;
+	onKernelFailure?: ((kernel: DenoJupyterKernel, error: Error) => void) | undefined;
 	signal?: AbortSignal | undefined;
 }): Promise<StartedNotebookSession> {
 	const { context, runtime, bridge, signal } = options;
@@ -54,7 +55,7 @@ export async function startNotebookSession(options: {
 		throw error;
 	}
 
-	const kernel = new DenoJupyterKernel({ deno, maxHeapMiB: runtime.maxHeapMiB });
+	const kernel = new DenoJupyterKernel({ deno, maxHeapMiB: runtime.maxHeapMiB, onFailure: options.onKernelFailure });
 	try {
 		await kernel.start(signal);
 		const bootstrap = await kernel.execute(notebookBootstrapSource(origin, bridge.token, bridge.exitToken, context.cwd), { signal });

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { NotebookRuntimeOptions } from "../code-mode/shared-runtime.ts";
 import type { NotebookBridgeServer } from "./bridge-server.ts";
@@ -9,7 +10,7 @@ import {
 import { ensureNotebookDenoBinary } from "./deno-binary.ts";
 import { initializeNotebookJournal, type NotebookJournal } from "./journal.ts";
 import { DenoJupyterKernel } from "./jupyter-kernel.ts";
-import { notebookBootstrapSource } from "./kernel-runtime.ts";
+import { notebookBootstrapSource, notebookExampleSource } from "./kernel-runtime.ts";
 import { formatNotebookNpmImportsNotice, readNotebookNpmImports } from "./npm-imports.ts";
 import {
 	formatProjectStateNotice,
@@ -98,9 +99,14 @@ export async function startNotebookSession(options: {
 				profileNotice = `Notebook profile ${runtime.profile} was not loaded: ${error instanceof Error ? error.message : String(error)}`;
 			}
 		}
+		const exampleNames = await installNotebookExamples(kernel, signal);
+		for (const name of exampleNames) baselineNames.add(name);
 		garbageCollectSupersededNotebookCheckpoints(checkpointIdentity);
 		const npmNotice = formatNotebookNpmImportsNotice(readNotebookNpmImports(checkpointIdentity));
-		const restoreNotice = [npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
+		const exampleNotice = exampleNames.length === 2
+			? "Notebook example foo/bar available; inspect foo.description, foo.usage, bar.description, and bar.usage before constructing a reusable global"
+			: undefined;
+		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
 		return {
 			kernel,
 			journal,
@@ -114,5 +120,25 @@ export async function startNotebookSession(options: {
 		await kernel.shutdown().catch(() => undefined);
 		await bridge.shutdown().catch(() => undefined);
 		throw error;
+	}
+}
+
+async function installNotebookExamples(kernel: DenoJupyterKernel, signal?: AbortSignal): Promise<string[]> {
+	const marker = `__PI_NOTEBOOK_EXAMPLES_${randomUUID()}__`;
+	signal?.throwIfAborted();
+	try {
+		const names = new Set(await kernel.complete("", 0, signal));
+		const result = await kernel.execute(notebookExampleSource(marker, names.has("foo") || names.has("bar")), { signal });
+		if (result.status !== "ok") return [];
+		const output = result.items.filter(({ type }) => type === "input_text").map(({ text }) => text ?? "").join("");
+		const start = output.indexOf(marker);
+		if (start === -1) return [];
+		const value = JSON.parse(output.slice(start + marker.length).split("\n", 1)[0]!) as unknown;
+		return Array.isArray(value) && value.every((name) => name === "foo" || name === "bar")
+			? [...new Set(value)]
+			: [];
+	} catch {
+		signal?.throwIfAborted();
+		return [];
 	}
 }

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -9,6 +9,7 @@ import {
 	readCodexConversionConfig,
 	readEffectiveCodexConversionConfig,
 	readLayeredCodexConversionConfig,
+	setProjectCodexCacheKeepalive,
 	type CodexConversionConfigScope,
 	writeCodexConversionConfig,
 } from "../../adapter/activation/config-store.ts";
@@ -54,7 +55,7 @@ export function registerCodexCommand(
 		const path = scope === "folder"
 			? getProjectCodexConversionConfigPath(ctx.cwd)
 			: getCodexConversionConfigPath();
-		const writeResult = writeCodexConversionConfig(nextConfig, path);
+		const writeResult = writeCodexConversionConfig(nextConfig, path, scope === "folder");
 		if (!writeResult.ok) {
 			ctx.ui.notify(`Failed to save Codex settings: ${writeResult.error}`, "error");
 			return false;
@@ -94,13 +95,32 @@ export function registerCodexCommand(
 				return;
 			}
 		}
-		const readSelectedConfig = () => configScope === "folder"
-			? readLayeredCodexConversionConfig({ cwd: ctx.cwd, projectTrusted: true })
-			: readCodexConversionConfig();
+		const readSelectedConfig = () => {
+			const selected = configScope === "folder"
+				? readLayeredCodexConversionConfig({ cwd: ctx.cwd, projectTrusted: true })
+				: readCodexConversionConfig();
+			return {
+				...selected,
+				openai: {
+					...selected.openai,
+					cacheKeepalive: effectiveConfig(ctx).openai.cacheKeepalive,
+				},
+			};
+		};
 		await openCodexSettingsScreen(ctx, {
 			initialConfig: readSelectedConfig(),
 			initialTab: tab,
 			onChange: (config) => saveAndApply(ctx, configScope, config),
+			onProjectCacheKeepalive: (enabled) => {
+				const result = setProjectCodexCacheKeepalive(ctx.cwd, ctx.isProjectTrusted(), enabled);
+				if (!result.ok) {
+					ctx.ui.notify(`Failed to save project cache keepalive: ${result.error}`, "error");
+					return undefined;
+				}
+				const previousConfig = state.config;
+				applyEffectiveConfig(ctx, previousConfig);
+				return readSelectedConfig();
+			},
 			configScope: {
 				current: () => configScope,
 				canUseFolder: ctx.isProjectTrusted(),

--- a/packages/pi-codex-conversion/src/ui/settings/config-editor.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-editor.ts
@@ -46,13 +46,14 @@ export function splitEditorCommand(command: string, platform: NodeJS.Platform = 
 
 export async function openCodexConfigInExternalEditor(
 	file: string,
+	preserveProjectCacheKeepalive: boolean,
 	stopTui: () => void,
 	startTui: () => void,
 	requestRender: (full?: boolean) => void,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
 	const editorCmd = editorCommand();
 	if (!editorCmd) return { ok: false, error: "Set $VISUAL or $EDITOR to edit the config file." };
-	writeCodexConversionConfig(readCodexConversionConfig(file), file);
+	writeCodexConversionConfig(readCodexConversionConfig(file), file, preserveProjectCacheKeepalive);
 	try {
 		stopTui();
 		const status = await new Promise<number | null>((resolve) => {

--- a/packages/pi-codex-conversion/src/ui/settings/config-items-openai.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-items-openai.ts
@@ -6,7 +6,7 @@ import {
 	normalizeV2UserMessageRetention,
 	V2_USER_MESSAGE_RETENTION_OPTIONS,
 } from "../../adapter/activation/config.ts";
-import { type ConfigSetting, setting, toggle } from "./config-items-shared.ts";
+import { type ConfigSetting, projectToggle, setting, toggle } from "./config-items-shared.ts";
 
 export function buildOpenAISettings(
 	config: CodexConversionConfig,
@@ -17,6 +17,11 @@ export function buildOpenAISettings(
 			...current,
 			openai: { ...current.openai, fast: enabled },
 		})),
+		projectToggle(
+			"cacheKeepalive",
+			"Experimental cache keepalive",
+			config.openai.cacheKeepalive,
+		),
 		setting(
 			{
 				id: "verbosity",

--- a/packages/pi-codex-conversion/src/ui/settings/config-items-shared.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-items-shared.ts
@@ -14,7 +14,7 @@ export interface ConfigSetting {
 	update?:
 		| ((value: string, config: CodexConversionConfig) => CodexConversionConfig)
 		| undefined;
-	action?: "edit-config" | undefined;
+	action?: "edit-config" | "project-cache-keepalive" | undefined;
 }
 
 export class TextSettingSubmenu extends Container implements Focusable {
@@ -75,4 +75,11 @@ export function toggle(
 		{ id, label, currentValue: current ? "on" : "off", values: ["off", "on"] },
 		(value, config) => update(value === "on", config),
 	);
+}
+
+export function projectToggle(id: string, label: string, current: boolean): ConfigSetting {
+	return {
+		item: { id, label, currentValue: current ? "on" : "off", values: ["off", "on"] },
+		action: "project-cache-keepalive",
+	};
 }

--- a/packages/pi-codex-conversion/src/ui/settings/screen.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/screen.ts
@@ -24,6 +24,7 @@ import { createUsageTab, type UsageTabOptions } from "./usage-tab.ts";
 export interface CodexSettingsScreenOptions extends UsageTabOptions {
 	initialConfig: CodexConversionConfig;
 	onChange: (nextConfig: CodexConversionConfig) => boolean;
+	onProjectCacheKeepalive: (enabled: boolean) => CodexConversionConfig | undefined;
 	initialTab?: SettingsTab | undefined;
 	configScope: {
 		current: () => CodexConversionConfigScope;
@@ -65,6 +66,7 @@ export async function openCodexSettingsScreen(
 			}
 			const result = await openCodexConfigInExternalEditor(
 				options.configScope.path(),
+				options.configScope.current() === "folder",
 				() => tui.stop(),
 				() => tui.start(),
 				(full) => tui.requestRender(full),
@@ -136,6 +138,17 @@ export async function openCodexSettingsScreen(
 					const definition = buildSettings().find(({ item }) => item.id === id);
 					if (definition?.action === "edit-config") {
 						void runEditConfig();
+						return;
+					}
+					if (definition?.action === "project-cache-keepalive") {
+						const nextDraft = options.onProjectCacheKeepalive(value === "on");
+						if (nextDraft) {
+							draft = nextDraft;
+							for (const { item } of buildSettings()) list.updateValue(item.id, item.currentValue);
+						} else {
+							list.updateValue(id, definition.item.currentValue);
+						}
+						tui.requestRender();
 						return;
 					}
 					if (id === "configScope") {

--- a/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
+++ b/packages/pi-codex-conversion/tests/apply-patch-tool.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	createEventBus,
+	type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { registerApplyPatchDisplay } from "../src/apply-patch-display.ts";
+import {
+	recordApplyPatchDisplayInput,
+	recordApplyPatchDisplayOutcome,
+	registerApplyPatchDisplayBroker,
+	shouldCompactApplyPatchDisplay,
+} from "../src/tools/apply-patch/display-broker.ts";
+
+function displayExtensionApi(bus = createEventBus()) {
+	const handlers = new Map<string, Array<(event: never) => unknown>>();
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	let renderedType: string | undefined;
+	const pi = {
+		events: { emit: bus.emit, on: bus.on },
+		registerEntryRenderer(customType: string) {
+			renderedType = customType;
+		},
+		on(event: string, handler: (event: never) => unknown) {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push({ customType, data });
+		},
+	} as unknown as ExtensionAPI;
+	return {
+		pi,
+		entries,
+		get renderedType() {
+			return renderedType;
+		},
+		emit(event: string, value: unknown = {}) {
+			return (handlers.get(event) ?? []).map((handler) =>
+				handler(value as never),
+			);
+		},
+	};
+}
+
+test("apply_patch display protocol routes scoped entries after tool results", () => {
+	const bus = createEventBus();
+	const consumer = displayExtensionApi(bus);
+	const registration = registerApplyPatchDisplay(consumer.pi, {
+		customType: "test-apply-patch-display",
+		render: (() => undefined) as never,
+	});
+	assert.equal(registration.available, false);
+	assert.equal(consumer.renderedType, "test-apply-patch-display");
+	const conversion = displayExtensionApi(bus);
+	registerApplyPatchDisplayBroker(conversion.pi);
+	assert.equal(registration.available, true);
+
+	const details = {
+		status: "success" as const,
+		result: {
+			changedFiles: ["file.ts"],
+			createdFiles: [],
+			deletedFiles: [],
+			movedFiles: [],
+			fuzz: 0,
+		},
+	};
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "apply_patch",
+			toolCallId: "direct-1",
+			input: { input: "*** Begin Patch\n*** End Patch" },
+			content: [{ type: "text", text: "Applied direct" }],
+			details,
+			isError: false,
+		}),
+		[undefined],
+	);
+	const fullInput = `*** Begin Patch\n${"+full patch line\n".repeat(1_100)}*** End Patch`;
+	const partialDetails = {
+		...details,
+		status: "partial_failure" as const,
+		failedTargets: ["file.ts"],
+	};
+	recordApplyPatchDisplayInput("runtime-1:cell-1:tool-1", fullInput);
+	recordApplyPatchDisplayOutcome("runtime-1:cell-1:tool-1", {
+		content: "Earlier actions were applied",
+		details: partialDetails,
+		error: "Earlier actions were applied",
+		isError: true,
+	});
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "exec",
+			toolCallId: "exec-1",
+			input: {},
+			content: [],
+			details: {
+				codeMode: true,
+				traces: [
+					{
+						id: "runtime-1:cell-1:tool-1",
+						name: "apply_patch",
+						input: `${fullInput.slice(0, 16_000)}[value truncated]`,
+						status: "error",
+						error: "Earlier actions were applied",
+					},
+				],
+			},
+			isError: false,
+		}),
+		[undefined],
+	);
+	const secondNestedId = "runtime-1:cell-2:tool-1";
+	const secondNestedInput = "*** Begin Patch\nsecond\n*** End Patch";
+	recordApplyPatchDisplayInput(secondNestedId, secondNestedInput);
+	recordApplyPatchDisplayOutcome(secondNestedId, {
+		content: "Applied again",
+		details,
+		isError: false,
+	});
+	assert.deepEqual(
+		conversion.emit("tool_result", {
+			toolName: "exec",
+			toolCallId: "exec-2",
+			input: {},
+			content: [],
+			details: {
+				codeMode: true,
+				traces: [
+					{
+						id: secondNestedId,
+						name: "apply_patch",
+						input: secondNestedInput,
+						status: "done",
+						result: {
+							content: [{ type: "text", text: "Applied again" }],
+							details,
+						},
+					},
+				],
+			},
+			isError: false,
+		}),
+		[undefined],
+	);
+
+	assert.deepEqual(conversion.entries, []);
+	conversion.emit("turn_end");
+	assert.deepEqual(conversion.entries, [
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: "direct-1",
+				input: "*** Begin Patch\n*** End Patch",
+				details,
+				content: "Applied direct",
+				isError: false,
+				source: "direct",
+			},
+		},
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: "runtime-1:cell-1:tool-1",
+				input: fullInput,
+				details: partialDetails,
+				content: "Earlier actions were applied",
+				error: "Earlier actions were applied",
+				isError: true,
+				source: "nested",
+			},
+		},
+		{
+			customType: "test-apply-patch-display",
+			data: {
+				toolCallId: secondNestedId,
+				input: secondNestedInput,
+				details,
+				content: "Applied again",
+				isError: false,
+				source: "nested",
+			},
+		},
+	]);
+
+	conversion.emit("tool_result", {
+		toolName: "apply_patch",
+		toolCallId: "pending-1",
+		input: { input: "pending" },
+		content: [{ type: "text", text: "Pending" }],
+		details,
+		isError: false,
+	});
+	registration.dispose();
+	conversion.emit("turn_end");
+
+	const lateConsumer = displayExtensionApi(bus);
+	const lateRegistration = registerApplyPatchDisplay(lateConsumer.pi, {
+		customType: "late-apply-patch-display",
+		render: (() => undefined) as never,
+	});
+	assert.equal(lateRegistration.available, true);
+	assert.equal(shouldCompactApplyPatchDisplay("pending-1", true), false);
+	assert.equal(shouldCompactApplyPatchDisplay("direct-1", true), true);
+	lateRegistration.dispose();
+	conversion.emit("session_shutdown");
+	assert.equal(registration.available, false);
+});

--- a/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
+++ b/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
@@ -58,9 +58,18 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 			attempt: 1,
 			fullInputItems: 43,
 			sentInputItems: 43,
+			model: "gpt-5.6-sol",
 			socketReused: false,
 			continuation: "no_continuation",
 			canonicalHistory: "validated",
+			compaction: {
+				model: "gpt-5.6-sol",
+				inputSource: "reconstructed",
+				canonicalReplay: "response_prefix_mismatch",
+				checkpointReused: true,
+				checkpointModel: "gpt-5.6-luna",
+				rewrittenToolOutputs: 2,
+			},
 			previousResponseId: false,
 		});
 		log.record({
@@ -76,6 +85,8 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 		assert.match(contents, /event="request" lane="compaction" transport="websocket"/);
 		assert.match(contents, /canonical_history="validated"/);
 		assert.match(contents, /full_input_items=43 sent_input_items=43/);
+		assert.match(contents, /model="gpt-5.6-sol"/);
+		assert.match(contents, /compaction_source="reconstructed" compaction_replay="response_prefix_mismatch" checkpoint_reused=true checkpoint_model="gpt-5.6-luna" rewritten_tool_outputs=2/);
 		assert.match(contents, /failure="authentication" code="invalid_token" status=401/);
 		assert.doesNotMatch(contents, /error=|resp_secret|echoed_prompt|Bearer/);
 		assert.deepEqual(errors, []);
@@ -134,6 +145,7 @@ test("provider diagnostics are authoritative and cannot alter or leak the stream
 			attempt: 1,
 			fullInputItems: 1,
 			sentInputItems: 1,
+			model: "gpt-5.6-luna",
 			socketReused: false,
 			continuation: "no_continuation",
 			previousResponseId: false,

--- a/packages/pi-codex-conversion/tests/config-store.test.ts
+++ b/packages/pi-codex-conversion/tests/config-store.test.ts
@@ -6,8 +6,10 @@ import test from "node:test";
 import {
 	clearFolderCodexConversionConfig,
 	getProjectCodexConversionConfigPath,
+	hasFolderCodexConversionConfig,
 	materializeFolderCodexConversionConfig,
 	readEffectiveCodexConversionConfig,
+	setProjectCodexCacheKeepalive,
 	writeCodexConversionConfig,
 } from "../src/adapter/activation/config-store.ts";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
@@ -17,7 +19,19 @@ test("trusted folder config overrides globals without crossing folder or process
 	try {
 		const globalPath = join(root, "agent", "pi-codex-conversion.json");
 		const project = join(root, "project");
+		const projectPath = getProjectCodexConversionConfigPath(project);
+		mkdirSync(join(root, "agent"), { recursive: true });
 		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(globalPath, JSON.stringify({ openai: { cacheKeepalive: true } }), { encoding: "utf8" });
+
+		assert.equal(readEffectiveCodexConversionConfig({ cwd: project, projectTrusted: true, globalConfigPath: globalPath, env: {} }).openai.cacheKeepalive, false);
+		assert.equal(setProjectCodexCacheKeepalive(project, true, true).ok, true);
+		assert.deepEqual(JSON.parse(readFileSync(projectPath, "utf8")), { openai: { cacheKeepalive: true } });
+		assert.equal(hasFolderCodexConversionConfig(project, true), false);
+		assert.equal(readEffectiveCodexConversionConfig({ cwd: project, projectTrusted: true, globalConfigPath: globalPath, env: {} }).openai.cacheKeepalive, true);
+		assert.equal(setProjectCodexCacheKeepalive(project, true, false).ok, true);
+		assert.equal(existsSync(projectPath), false);
+
 		writeCodexConversionConfig({
 			...structuredClone(DEFAULT_CODEX_CONVERSION_CONFIG),
 			openai: {

--- a/packages/pi-codex-conversion/tests/notebook-example.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-example.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { notebookExampleSource } from "../src/tools/notebook-mode/kernel-runtime.ts";
+
+test("Notebook seeds expose a self-describing foo/bar example and skip conflicts", async () => {
+	const previousFoo = Object.getOwnPropertyDescriptor(globalThis, "foo");
+	const previousBar = Object.getOwnPropertyDescriptor(globalThis, "bar");
+	const restore = (name: "foo" | "bar", descriptor: PropertyDescriptor | undefined) => {
+		if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+		else delete (globalThis as Record<string, unknown>)[name];
+	};
+	try {
+		delete (globalThis as Record<string, unknown>)["foo"];
+		delete (globalThis as Record<string, unknown>)["bar"];
+		let output = "";
+		const run = new Function("console", `return (async () => ${notebookExampleSource("EXAMPLE")})()`);
+		await run({ log(value: string) { output += value; } });
+		const foo = (globalThis as Record<string, unknown>)["foo"] as { description: string; usage: string }[] & { description: string; usage: string };
+		const bar = (globalThis as Record<string, unknown>)["bar"] as { description: string; usage: string } & ((item: unknown) => unknown);
+		assert.equal(foo.description, "Example records for reusable helper patterns");
+		assert.match(foo.usage, /^Inspect:/);
+		assert.equal(bar.description, "Summarize one foo item without mutating foo");
+		assert.match(bar.usage, /Run: bar\(foo\[index\]\)/);
+		assert.deepEqual(bar(foo[0]), { id: "alpha", value: "first example record" });
+		assert.equal(output, 'EXAMPLE["foo","bar"]');
+
+		delete (globalThis as Record<string, unknown>)["foo"];
+		delete (globalThis as Record<string, unknown>)["bar"];
+		output = "";
+		const runOccupied = new Function("console", `return (async () => ${notebookExampleSource("EXAMPLE", true)})()`);
+		await runOccupied({ log(value: string) { output += value; } });
+		assert.equal((globalThis as Record<string, unknown>)["foo"], undefined);
+		assert.equal((globalThis as Record<string, unknown>)["bar"], undefined);
+		assert.equal(output, "EXAMPLE[]");
+	} finally {
+		restore("foo", previousFoo);
+		restore("bar", previousBar);
+	}
+});

--- a/packages/pi-codex-conversion/tests/notebook-exec-bridge.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-exec-bridge.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCodeModeToolsPrompt } from "../src/tools/code-mode/custom-tool-prompt.ts";
+import { createNotebookControlProxy } from "../src/tools/code-mode/notebook-tool.ts";
+import { SharedCodeModeRuntime } from "../src/tools/code-mode/shared-runtime.ts";
+import type { NotebookControlRequest, ToolExecutionContext } from "../src/tools/code-mode/types.ts";
+
+test("Notebook exec proxy shares control normalization without changing the prompt", async () => {
+	const calls: Array<{
+		request: NotebookControlRequest;
+		context: ToolExecutionContext;
+		signal: AbortSignal | undefined;
+	}> = [];
+	const runtime = {
+		async controlNotebook(request, context, signal) {
+			calls.push({ request, context, signal });
+			return { message: `Ran ${request.action}`, details: { action: request.action } };
+		},
+	} as Pick<SharedCodeModeRuntime, "controlNotebook"> as SharedCodeModeRuntime;
+	const proxy = createNotebookControlProxy(runtime);
+	const context: ToolExecutionContext = { cwd: "/project", toolCallId: "nested-notebook" };
+	const controller = new AbortController();
+	const modes = new SharedCodeModeRuntime();
+	modes.addProvider({
+		getTools: () => [],
+		executionKind: (mode) => mode as "code" | "notebook",
+	});
+
+	assert.equal(proxy.deferLoading, true);
+	assert.equal(buildCodeModeToolsPrompt([proxy]), "");
+	assert.deepEqual(modes.collectTools("code"), []);
+	assert.equal(modes.collectTools("notebook").at(-1)?.name, "notebook");
+	for (const request of [
+		{ action: "status" },
+		{ action: "list", query: "saved*" },
+		{ action: "diagnostics" },
+	] as const) {
+		assert.deepEqual(
+			await proxy.invoke(request, context, controller.signal),
+			{ message: `Ran ${request.action}`, details: { action: request.action } },
+		);
+	}
+	assert.deepEqual(calls.map(({ request }) => request), [
+		{ action: "status" },
+		{ action: "list", query: "saved*" },
+		{ action: "diagnostics" },
+	]);
+	for (const request of [
+		{ action: "status", query: "bindings*" },
+		{ action: "checkpoint" },
+		{ action: "save", name: "profile" },
+		{ action: "load", name: "profile" },
+		{ action: "pin", names: ["alpha", "alpha"] },
+		{ action: "unpin", names: ["alpha"] },
+		{ action: "release", names: ["alpha"] },
+		{ action: "prune", query: "alpha*" },
+		{ action: "restart" },
+		{ action: "reset" },
+	] as const) {
+		const normalized = request.action === "pin"
+			? { action: "pin" as const, names: ["alpha"] }
+			: request;
+		assert.deepEqual(
+			await proxy.invoke(request, context, controller.signal),
+			{
+				message: `Notebook ${request.action} was not run because it needs the active exec cell to finish. After exec returns, call notebook with ${JSON.stringify(normalized)}.`,
+				details: { notRun: true, action: request.action, retry: normalized },
+			},
+		);
+	}
+	assert.equal(calls.length, 3);
+	assert.equal(calls.every((call) => call.context === context && call.signal === controller.signal), true);
+	await assert.rejects(
+		proxy.invoke({ action: "save", query: "wrong" }, context, controller.signal),
+		/notebook save accepts name only/,
+	);
+	assert.equal(calls.length, 3);
+});

--- a/packages/pi-codex-conversion/tests/notebook-project-metadata.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-project-metadata.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { formatStatus, type NotebookStatusDetails } from "../src/tools/notebook-mode/lifecycle-result.ts";
+import { projectStateCaptureSource, projectStateRestoreSource } from "../src/tools/notebook-mode/project-state-runtime.ts";
+
+test("durable binding metadata ignores getters, survives restore, and is shown by status", async () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-notebook-project-metadata-"));
+	let getterCalls = 0;
+	let payload = Buffer.alloc(0);
+	let candidate: { deno: string; v8: string; entries: Array<Record<string, unknown>> } | undefined;
+	function helper() {
+		throw new Error("helper should not run during discovery");
+	}
+	Object.defineProperty(helper, "description", {
+		get() {
+			getterCalls += 1;
+			throw new Error("description getter invoked");
+		},
+	});
+	Object.defineProperty(helper, "usage", { value: 'await helper("check")' });
+	const captureDeno = {
+		version: { deno: "2.9.5", v8: "test" },
+		async open() {
+			return {
+				async write(bytes: Uint8Array) {
+					payload = Buffer.concat([payload, Buffer.from(bytes)]);
+					return bytes.byteLength;
+				},
+				close() {},
+			};
+		},
+		async writeTextFile(_path: string, text: string) {
+			candidate = JSON.parse(text) as typeof candidate;
+		},
+	};
+	try {
+		const capture = new Function("Deno", "probe", `return (async () => ${projectStateCaptureSource({
+			candidates: ["probe"],
+			payloadPath: join(root, "candidate.bin"),
+			manifestPath: join(root, "candidate.json"),
+			maxBytes: 8 * 1024 * 1024,
+		})})()`);
+		await capture(captureDeno, helper);
+		assert.equal(getterCalls, 0);
+		assert.deepEqual(candidate?.entries[0], {
+			name: "probe",
+			kind: "function",
+			offset: 0,
+			length: payload.length,
+			usage: 'await helper("check")',
+		});
+
+		const entry = { ...candidate!.entries[0], hash: createHash("sha256").update(payload).digest("hex") };
+		const previousProbe = Object.getOwnPropertyDescriptor(globalThis, "probe");
+		const previousNotebook = Object.getOwnPropertyDescriptor(globalThis, "__piNotebook");
+		try {
+			Object.defineProperty(globalThis, "__piNotebook", { value: { syncProjectBindings() {} }, configurable: true });
+			const restore = new Function("Deno", "crypto", `return (async () => ${projectStateRestoreSource({
+				deno: "2.9.5",
+				v8: "test",
+				entries: [entry as never],
+			}, join(root, "candidate.bin"))})()`);
+			await restore({ version: { deno: "2.9.5", v8: "test" }, async readFile() { return payload; } }, { randomUUID });
+			const restored = (globalThis as Record<string, unknown>)["probe"] as { usage?: string; description?: string };
+			assert.equal(restored.usage, 'await helper("check")');
+			assert.equal(restored.description, undefined);
+		} finally {
+			if (previousProbe) Object.defineProperty(globalThis, "probe", previousProbe);
+			else delete (globalThis as Record<string, unknown>)["probe"];
+			if (previousNotebook) Object.defineProperty(globalThis, "__piNotebook", previousNotebook);
+			else delete (globalThis as Record<string, unknown>)["__piNotebook"];
+		}
+
+		const details: NotebookStatusDetails = {
+			state: "idle",
+			userCells: 0,
+			checkpoint: {},
+			retainedBindings: 1,
+			retainedBytes: payload.length,
+			pinnedBindings: 1,
+			pinned: [{ name: "probe", kind: "function", bytes: payload.length, updatedAt: new Date().toISOString(), pinned: true, usage: 'await helper("check")' }],
+			omittedPinned: 0,
+			largestUnpinned: [],
+			omittedLargestUnpinned: 0,
+		};
+		assert.match(formatStatus(details), /probe: .*usage: await helper\("check"\)/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-codex-conversion/tests/notebook-project-state.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-project-state.test.ts
@@ -97,6 +97,21 @@ test("project notebook merge preserves a concurrent same-name edit", () => {
 	assert.equal(repeated.payload.toString(), "current");
 });
 
+test("project notebook merge treats metadata edits as concurrent changes", () => {
+	const payload = Buffer.from("same");
+	const merged = mergeProjectState({
+		baseline: { generation: "base-generation", entries: [{ name: "shared", hash: hash(payload), description: "base" }] },
+		current: projectManifest("current-generation", payload, false, { description: "current" }),
+		candidate: projectCandidate(payload, "function", { description: "candidate" }),
+		candidatePayload: payload,
+		currentPayload: payload,
+	});
+
+	assert.deepEqual(merged.conflicts, ["shared"]);
+	assert.equal(merged.payload.toString(), "same");
+	assert.equal(merged.entries[0]?.description, "current");
+});
+
 test("project notebook merge applies an uncontested plain global", () => {
 	const previous = Buffer.from("previous");
 	const payload = Buffer.from("value");
@@ -126,16 +141,16 @@ test("stale session recovery cannot overwrite a newer project generation", () =>
 	assert.deepEqual([...sessionCheckpointProjectExclusions({ projectGeneration: "new" }, project)], []);
 });
 
-function projectCandidate(payload: Buffer, kind: "value" | "function" = "function"): ProjectStateCandidate {
+function projectCandidate(payload: Buffer, kind: "value" | "function" = "function", metadata: { description?: string; usage?: string } = {}): ProjectStateCandidate {
 	return {
 		deno: "2.9.5",
 		v8: "test",
-		entries: [{ name: "shared", kind, offset: 0, length: payload.length }],
+		entries: [{ name: "shared", kind, offset: 0, length: payload.length, ...metadata }],
 		skipped: [],
 	};
 }
 
-function projectManifest(generation: string, payload: Buffer, pinned = false): ProjectStateManifest {
+function projectManifest(generation: string, payload: Buffer, pinned = false, metadata: { description?: string; usage?: string } = {}): ProjectStateManifest {
 	return {
 		schema: 1,
 		project: "/project",
@@ -151,6 +166,7 @@ function projectManifest(generation: string, payload: Buffer, pinned = false): P
 			offset: 0,
 			length: payload.length,
 			hash: hash(payload),
+			...metadata,
 			...(pinned ? { pinned: true } : {}),
 		}],
 		skipped: [],

--- a/packages/pi-codex-conversion/tests/notebook-recovery.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-recovery.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { NotebookExecutionRuntime } from "../src/tools/notebook-mode/execution-runtime.ts";
+import { NotebookLifecycleController } from "../src/tools/notebook-mode/lifecycle.ts";
+import { formatNotebookDiagnostics, type NotebookDiagnostic } from "../src/tools/notebook-mode/notebook-diagnostics.ts";
+import { NotebookRecoveryController } from "../src/tools/notebook-mode/recovery.ts";
+import { PROJECT_STATE_SCHEMA, projectStatePaths, readProjectStateManifest, type ProjectStateManifest } from "../src/tools/notebook-mode/project-state-format.ts";
+import { isNotebookBootstrapFailure } from "../src/tools/notebook-mode/runtime-health.ts";
+
+test("notebook diagnostics group historical duplicates and put runtime health first", () => {
+	const diagnostics: NotebookDiagnostic[] = [diagnostic("cell-1", 0), diagnostic("cell-2", 1), diagnostic("cell-3", 2, "other"), diagnostic("cell-4", 3, "r", "error", "ts")];
+	const result = formatNotebookDiagnostics("/project/notebook.ipynb", 4, diagnostics, "invalidated");
+	assert.match(result.message, /^Notebook runtime health: invalidated;/);
+	assert.match(result.message, /Historical static diagnostics/);
+	assert.match(result.message, /2 occurrences warning deno-2451 \[r\]/);
+	assert.match(result.message, /samples: cell-1 cell 1:1:1, cell-2 cell 2:2:1/);
+	assert.doesNotMatch(result.message, /repair these/);
+	assert.deepEqual((result.details as { diagnosticGroups: Array<{ count: number; name?: string; severity: string; source?: string }> }).diagnosticGroups.map(({ count, name, severity, source }) => ({ count, name, severity, source })), [
+		{ count: 2, name: "r", severity: "warning", source: "deno" },
+		{ count: 1, name: "other", severity: "warning", source: "deno" },
+		{ count: 1, name: "r", severity: "error", source: "ts" },
+	]);
+	const bounded = formatNotebookDiagnostics(
+		`/${"é".repeat(12_000)}`,
+		2_000,
+		Array.from({ length: 2_000 }, (_, index) => diagnostic(`cell-${index}`, index, `name-${index}`)),
+		"ready",
+	);
+	assert.ok(Buffer.byteLength(bounded.message, "utf8") <= 16 * 1024);
+	assert.ok(Buffer.byteLength(JSON.stringify(bounded.details), "utf8") <= 16 * 1024);
+});
+
+test("notebook reset preserves the durable project manifest and pins", async () => {
+	const root = join(tmpdir(), `pi-notebook-reset-${process.pid}-${Date.now()}`);
+	const project = join(root, "project");
+	const agentDir = join(root, "agent");
+	const payload = Buffer.from("durable");
+	const paths = projectStatePaths(project, agentDir);
+	const manifest: ProjectStateManifest = {
+		schema: PROJECT_STATE_SCHEMA,
+		project,
+		generation: "generation-1",
+		deno: "2.9.5",
+		v8: "test",
+		payload: "project-00000000-0000-0000-0000-000000000001.bin",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		sourceSession: "session",
+		entries: [{ name: "prReview", kind: "value", offset: 0, length: payload.length, hash: hash(payload), pinned: true }],
+		skipped: [],
+	};
+	mkdirSync(paths.directory, { recursive: true });
+	writeFileSync(join(paths.directory, manifest.payload), payload);
+	writeFileSync(paths.manifest, `${JSON.stringify(manifest)}\n`);
+	writeFileSync(join(paths.directory, "npm-imports.json"), `${JSON.stringify({ schema: 1, project, imports: ["npm:example@1.2.3"] })}\n`);
+	const extensionContext = { cwd: project, sessionManager: { getSessionId: () => "session-id", getBranch: () => [] } };
+	const events: string[] = [];
+	const controller = new NotebookRecoveryController({ agentDir, maxBytes: 8 * 1024 * 1024 }, {
+		stopWithoutCheckpoint: async () => { events.push("stop"); return undefined; },
+		startClean: async () => { events.push("start"); },
+		checkpointEmpty: async () => { events.push("checkpoint"); },
+		configuredProfileActive: () => false,
+		runtimeHealth: () => ({ state: "ready" }),
+	});
+	try {
+		const result = await controller.reset({ cwd: project, extensionContext } as never);
+		const restored = readProjectStateManifest(paths.manifest);
+		assert.equal(restored?.entries[0]?.name, "prReview");
+		assert.equal(restored?.entries[0]?.pinned, true);
+		assert.deepEqual(JSON.parse(readFileSync(join(paths.directory, "npm-imports.json"), "utf8")).imports, ["npm:example@1.2.3"]);
+		assert.deepEqual(events, ["stop", "start", "checkpoint"]);
+		assert.match(result.message, /preserved 1 project binding including 1 pinned/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("terminating a notebook cell invalidates its kernel before another cell can use it", async () => {
+	assert.equal(isNotebookBootstrapFailure({ errorText: "TypeError: Cannot read properties of undefined (reading 'begin')" }), false);
+	assert.equal(isNotebookBootstrapFailure({ errorText: "Notebook runtime bootstrap unavailable: __piNotebook.begin" }), true);
+	type FakeResult = { status: "ok" | "aborted"; items: [] };
+	let kernel: { execute(): Promise<FakeResult>; interrupt(): Promise<void> } | undefined;
+	let interrupts = 0;
+	let executeCalls = 0;
+	let finish!: (result: FakeResult) => void;
+	const pending = new Promise<FakeResult>((resolve) => { finish = resolve; });
+	kernel = {
+		execute: () => {
+			executeCalls += 1;
+			return executeCalls === 1
+				? new Promise((resolve) => setTimeout(() => resolve({ status: "ok", items: [] }), 50))
+				: pending;
+		},
+		interrupt: async () => { interrupts += 1; finish({ status: "aborted", items: [] }); },
+	};
+	const session = {
+		kernel: () => kernel,
+		checkpoints: { flush: async () => {}, schedule: () => {} },
+		journal: () => undefined,
+		recordMemory: () => {},
+		memory: () => undefined,
+		takeNotice: () => undefined,
+		invalidateKernel: async () => { kernel = undefined; },
+		recoverFromBootstrapFailure: async () => false,
+	};
+	const runtime = new NotebookExecutionRuntime(
+		() => session as never,
+		async () => {},
+	);
+	const context = { cwd: "/tmp" };
+	const yielded = await runtime.execute('// @exec: {"yield_time_ms": 1}\nawait new Promise(() => {})', context);
+	assert.equal(yielded.kind, "yielded");
+	await new Promise((resolve) => setTimeout(resolve, 60));
+	assert.equal(executeCalls, 2);
+	assert.equal(runtime.activeCellId(), yielded.cellId);
+	const terminated = await runtime.terminate(yielded.cellId, context);
+	assert.equal(terminated.kind, "terminated");
+	assert.equal(interrupts, 1);
+	assert.equal(kernel, undefined);
+	assert.equal(runtime.activeCellId(), undefined);
+
+	let quickKernel: { execute(): Promise<FakeResult>; interrupt(): Promise<void> } | undefined;
+	let quickExecuteCalls = 0;
+	let quickInterrupts = 0;
+	quickKernel = {
+		execute: () => {
+			quickExecuteCalls += 1;
+			const delay = quickExecuteCalls === 1 ? 50 : 20;
+			return new Promise((resolve) => setTimeout(() => resolve({ status: "ok", items: [] }), delay));
+		},
+		interrupt: async () => { quickInterrupts += 1; },
+	};
+	const quickSession = {
+		...session,
+		kernel: () => quickKernel,
+		invalidateKernel: async () => { quickKernel = undefined; },
+	};
+	const quickRuntime = new NotebookExecutionRuntime(() => quickSession as never, async () => {});
+	const quickYielded = await quickRuntime.execute('// @exec: {"yield_time_ms": 1}\nawait new Promise(() => {})', context);
+	assert.equal(quickYielded.kind, "yielded");
+	await new Promise((resolve) => setTimeout(resolve, 60));
+	await quickRuntime.terminate(quickYielded.cellId, context);
+	assert.equal(quickExecuteCalls, 2);
+	assert.equal(quickInterrupts, 0);
+	assert.equal(quickKernel, undefined);
+});
+
+test("notebook restart bypasses capture after the runtime is invalidated", async () => {
+	let checkpoints = 0;
+	let prepares = 0;
+	let restarts = 0;
+	const controller = new NotebookLifecycleController({
+		prepare: async () => { prepares += 1; },
+		diagnostics: async () => ({ message: "", details: {} }),
+		reset: async () => ({ message: "", details: {} }),
+		kernel: () => undefined,
+		activeCellId: () => undefined,
+		stopActive: async () => undefined,
+		checkpoint: async () => { checkpoints += 1; },
+		retainedBindings: () => [],
+		promoteBindings: async () => async () => {},
+		markChanged: () => {},
+		restart: async () => { restarts += 1; return undefined; },
+		rollback: async () => {},
+		baselineNames: () => new Set(),
+		profileStorage: () => ({ agentDir: "/tmp", maxBytes: 8 * 1024 * 1024 }),
+		runtimeHealth: () => ({ state: "invalidated" }),
+		metadata: () => ({ userCells: 0, checkpoint: {} }),
+	} as never);
+
+	const result = await controller.control({ action: "restart" }, { cwd: "/tmp", extensionContext: {} } as never);
+	assert.equal(checkpoints, 0);
+	assert.equal(prepares, 0);
+	assert.equal(restarts, 1);
+	assert.match(result.message, /restarted from the last completed checkpoint/);
+});
+
+function diagnostic(cellId: string, cellIndex: number, name = "r", severity: NotebookDiagnostic["severity"] = "warning", source = "deno"): NotebookDiagnostic {
+	return {
+		cellId, cellIndex, line: cellIndex + 1, column: 1, endLine: cellIndex + 1, endColumn: 8,
+		severity, code: 2451, source, name,
+		message: `Cannot redeclare block-scoped variable '${name}'.`,
+	};
+}
+
+function hash(value: Buffer): string {
+	return createHash("sha256").update(value).digest("hex");
+}

--- a/packages/pi-codex-conversion/tests/openai-codex-request.test.ts
+++ b/packages/pi-codex-conversion/tests/openai-codex-request.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { buildRequestBody } from "../src/providers/openai-codex-custom-provider.ts";
+import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import type { AdapterState } from "../src/adapter/activation/state.ts";
+import { rewriteCodexProviderRequest } from "../src/adapter/provider-request.ts";
+import { createCodexTurnState } from "../src/providers/openai-codex/turn-state.ts";
 import {
 	buildSSEHeaders,
 	buildWebSocketHeaders,
@@ -81,6 +85,41 @@ test("buildRequestBody keeps Codex request shape stable for common options", () 
 		(normalModeBody.tools as Array<{ type: string; name: string }>).map(({ type, name }) => [type, name]),
 		[["function", "exec"], ["function", "wait"]],
 	);
+});
+
+test("final provider hook captures configured Responses instructions for native replay", async () => {
+	const state: AdapterState = {
+		enabled: true,
+		cwd: "/repo",
+		promptSkills: [],
+		executionMode: "normal",
+		codexTurnState: createCodexTurnState(),
+		pendingActiveProviderPromptCapture: true,
+		activeProviderSystemPrompt: "stale prompt",
+		config: {
+			...DEFAULT_CODEX_CONVERSION_CONFIG,
+			scope: { allProviders: "off", additionalProviders: ["passthrough"] },
+		},
+	};
+	const ctx = {
+		cwd: "/repo",
+		model: {
+			provider: "passthrough",
+			api: "openai-responses",
+			id: "gpt-5.6",
+			baseUrl: "https://proxy.example/v1",
+		},
+	} as never;
+	const finalPayload = await rewriteCodexProviderRequest({
+		model: "gpt-5.6",
+		instructions: "final chained instructions",
+		input: [],
+		text: { verbosity: "low" },
+		parallel_tool_calls: true,
+	}, ctx, state) as { instructions?: string };
+
+	assert.equal(finalPayload.instructions, "final chained instructions");
+	assert.equal(state.activeProviderSystemPrompt, "final chained instructions");
 });
 
 test("strict tool constraints serialize closed schemas and honor fallback policy", () => {

--- a/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
+++ b/packages/pi-codex-conversion/tests/remote-v2-compaction.test.ts
@@ -24,3 +24,13 @@ test("Responses compaction v2 retains real turns and reconciles tool history", (
 	assert.match(JSON.stringify(window), /remember this exactly/);
 	assert.equal(window.at(-1)?.["encrypted_content"], "sealed");
 });
+
+test("Responses compaction v2 does not retain an oversized newest user turn", () => {
+	const compaction = { type: "compaction", encrypted_content: "sealed" };
+	const window = buildRemoteCompactionV2Window([
+		{ role: "user", content: [{ type: "input_text", text: "older turn" }] },
+		{ role: "user", content: [{ type: "input_text", text: "x".repeat(12) }] },
+	], compaction, 2);
+
+	assert.deepEqual(window, [compaction]);
+});

--- a/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
+++ b/packages/pi-codex-conversion/tests/tool-result-contracts.test.ts
@@ -1,8 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import {
-	registerApplyPatchResultEvent,
-} from "../src/tools/apply-patch/tool.ts";
+import { registerApplyPatchResultEvent } from "../src/index.ts";
 import { toCodeModeToolResult } from "../src/tools/code-mode/tool-result.ts";
 
 test("apply_patch partial mutations remain error results", () => {
@@ -12,12 +10,19 @@ test("apply_patch partial mutations remain error results", () => {
 			if (event === "tool_result") handler = registered as typeof handler;
 		},
 	} as never);
+	const result = {
+		changedFiles: [],
+		createdFiles: [],
+		deletedFiles: [],
+		movedFiles: [],
+		fuzz: 0,
+	};
 
 	assert.deepEqual(handler?.({
 		toolName: "apply_patch",
-		details: { status: "partial_failure", result: {} },
+		details: { status: "partial_failure", result },
 	}), { isError: true });
-	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result: {} } }), undefined);
+	assert.equal(handler?.({ toolName: "apply_patch", details: { status: "success", result } }), undefined);
 });
 
 test("Notebook memory pressure is model-visible", () => {

--- a/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import { canonicalCodexAliasModelKey } from "../src/adapter/prompt/codex-model.ts";
 import { createCodexExtensionRuntime } from "../src/extension/runtime.ts";
 import { prewarmOpenAICodexWebSocket } from "../src/providers/openai-codex-custom-provider.ts";
 import { isWebSocketSseFallbackActive, recordWebSocketSseFallback } from "../src/providers/openai-codex/websocket.ts";
@@ -72,8 +73,21 @@ test("stalled auth in an aborted prewarm cannot block a newer equivalent operati
 	await current;
 });
 
-test("post-compaction reset seeds one reusable request identity", async () => {
-	const restoreWebSocket = installScriptedWebSocket([websocketSuccess]);
+test("post-compaction reset prewarms canonical aliases with normalized cache usage", async () => {
+	const restoreWebSocket = installScriptedWebSocket([(socket) => {
+		socket.emitJson({ type: "response.created", response: { id: "resp_cached" } });
+		socket.emitJson({
+			type: "response.completed",
+			response: {
+				id: "resp_cached",
+				status: "completed",
+				usage: {
+					input_tokens: 100,
+					input_tokens_details: { cached_tokens: 75 },
+				},
+			},
+		});
+	}]);
 	const sessionId = "history-prewarm-identity";
 	try {
 		const runtime = createCodexExtensionRuntime({
@@ -90,10 +104,19 @@ test("post-compaction reset seeds one reusable request identity", async () => {
 			executionMode: "code",
 		};
 		runtime.state.activeProviderSystemPrompt = "Stable prompt";
+		const alias = {
+			...model,
+			provider: "openai-codex-personal",
+			baseUrl: "https://chatgpt.com/backend-api",
+		};
+		runtime.state.canonicalAliasEndpoint = {
+			modelKey: canonicalCodexAliasModelKey(alias),
+			trusted: true,
+		};
 		const extensionContext = {
 			cwd: "/repo",
 			getSystemPrompt: () => "Stable prompt",
-			model,
+			model: alias,
 			modelRegistry: {
 				getApiKeyAndHeaders: async () => ({ ok: true, apiKey }),
 			},
@@ -103,7 +126,15 @@ test("post-compaction reset seeds one reusable request identity", async () => {
 			},
 		} as never;
 
-		await runtime.startCompactionPrewarm(extensionContext);
+		assert.deepEqual(await runtime.startCompactionPrewarm(extensionContext), {
+			status: "ready",
+			usage: {
+				inputTokens: 25,
+				cachedInputTokens: 75,
+				cacheWriteInputTokens: 0,
+			},
+			socketReused: false,
+		});
 
 		assert.equal(runtime.waitForPrewarm(extensionContext, "Stable prompt"), undefined);
 		assert.equal(sentFrames().length, 1);

--- a/packages/pi-codex-conversion/types/index.d.ts
+++ b/packages/pi-codex-conversion/types/index.d.ts
@@ -16,3 +16,18 @@ export function stripAdapterTools(
 	toolNames: string[],
 	adapterOwnedTools?: string[],
 ): string[];
+
+export type {
+	ApplyPatchPartialFailureDetails,
+	ApplyPatchRenderCall,
+	ApplyPatchRenderResult,
+	ApplyPatchSuccessDetails,
+	ApplyPatchToolDetails,
+	ApplyPatchToolOptions,
+	ExecutePatchResult,
+} from "../dist/tools/apply-patch/tool.js";
+export {
+	createApplyPatchTool,
+	isApplyPatchToolDetails,
+	registerApplyPatchResultEvent,
+} from "../dist/tools/apply-patch/tool.js";


### PR DESCRIPTION
This PR ships pi-codex-conversion 3.0.16 as one cumulative release assembled from focused stack reviews.

## Focused stack

1. #316 — diagnose native compaction cache misses
2. #317 — bound Responses V2 retained history
3. #318 — recover interrupted notebooks without deleting durable state
4. #319 — make durable Notebook globals self-describing
5. #320 — expose the apply_patch display renderer seam
6. #321 — invalidate stale background-widget contexts
7. #322 — capture final provider instructions for replay
8. #323 — streamline stacked JJ and Herdr dispatch
9. #326 — call Notebook controls from exec
10. #327 — add experimental project cache keepalive

## Summary

- add actionable cache diagnostics and keep post-compaction retained history within budget
- make Notebook interruption recovery non-destructive and teach discoverable unpinned globals as reusable scratch
- expose replaceable apply_patch presentation without changing its execution or model contract
- prevent delayed background UI work from using stale session contexts
- preserve configured Responses instructions at the final provider boundary for native replay
- keep future JJ release batches dependency-prepared while avoiding concurrent writes to linear stacks
- let Notebook exec inspect lifecycle state while redirecting cell-terminating controls to exact top-level calls
- optionally refresh an idle project's Codex WebSocket context with measured cache feedback

Closes #300.
Closes #303.
Closes #305.
Closes #306.
Closes #308.
Closes #309.

## Validation

- cumulative pi-codex-conversion package check
- 113 pi-codex-conversion tests passed
- build and Knip passed
- focused extension artifact and Code Mode host-assets verification passed
- focused layer checks and review completed before stack publication

## Review

The focused PRs are the native GitHub stack. This PR is the cumulative `main..top` release view and is the only PR intended to merge into `main`.

## Release

- Changesets: yes for each shipping pi-codex-conversion layer
- Package: `@howaboua/pi-codex-conversion`
- Repository workflow layer: no package release
- Aggregates: generated by release automation




