### PR TITLE
Call Notebook controls from exec

### DIFF
--- a/.changeset/notebook-exec-bridge.md
+++ b/.changeset/notebook-exec-bridge.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Make safe Notebook lifecycle controls callable from inside Notebook exec cells.

--- a/packages/pi-codex-conversion/src/tools/code-mode/notebook-tool.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/notebook-tool.ts
@@ -2,31 +2,45 @@ import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-age
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { getExperimentalToolSampling } from "../tool-sampling.ts";
+import { canExecuteNotebookControlInsideExec } from "../notebook-mode/control-contract.ts";
 import type { SharedCodeModeRuntime } from "./shared-runtime.ts";
-import type { NotebookControlRequest, ToolExecutionContext } from "./types.ts";
+import type {
+	NotebookControlRequest,
+	NotebookControlResult,
+	ProgrammaticCodeModeToolDefinition,
+	ToolExecutionContext,
+} from "./types.ts";
 
-const NOTEBOOK_PARAMETERS = Type.Object({
+export const NOTEBOOK_PARAMETERS = Type.Object({
 	action: StringEnum(["status", "list", "checkpoint", "save", "load", "pin", "unpin", "release", "prune", "restart", "diagnostics", "reset"]),
 	query: Type.Optional(Type.String()),
 	name: Type.Optional(Type.String()),
 	names: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
 });
 
+const NOTEBOOK_DESCRIPTION = "Control persistent notebook state: status inspects memory/bindings by query glob; checkpoint; pin/unpin/release names; prune unpinned matches; list/save/load profiles; restart; diagnostics; reset";
+
+type NotebookToolParameters = {
+	action: string;
+	query?: string | undefined;
+	name?: string | undefined;
+	names?: string[] | undefined;
+};
+
 export function registerNotebookTool(pi: ExtensionAPI, runtime: SharedCodeModeRuntime): void {
 	const constrainedSampling = getExperimentalToolSampling("notebook");
 	pi.registerTool({
 		name: "notebook",
 		label: "Notebook",
-		description: "Control persistent notebook state: status inspects memory/bindings by query glob; checkpoint; pin/unpin/release names; prune unpinned matches; list/save/load profiles; restart; diagnostics; reset",
+		description: NOTEBOOK_DESCRIPTION,
 		promptSnippet: "Inspect, recover, or control notebook state",
 		parameters: NOTEBOOK_PARAMETERS,
 		...(constrainedSampling ? { constrainedSampling } : {}),
 		async execute(_id, params, signal, _onUpdate, ctx) {
-			const result = await runtime.controlNotebook(
-				normalizeNotebookRequest(params),
-				{ cwd: ctx.cwd, extensionContext: ctx } as ToolExecutionContext,
-				signal,
-			);
+			const result = await executeNotebookControl(runtime, params, {
+				cwd: ctx.cwd,
+				extensionContext: ctx,
+			}, signal);
 			return {
 				content: [{ type: "text", text: result.message }],
 				details: result.details,
@@ -35,12 +49,55 @@ export function registerNotebookTool(pi: ExtensionAPI, runtime: SharedCodeModeRu
 	} satisfies ToolDefinition<typeof NOTEBOOK_PARAMETERS>);
 }
 
-export function normalizeNotebookRequest(params: {
-	action: string;
-	query?: string | undefined;
-	name?: string | undefined;
-	names?: string[] | undefined;
-}): NotebookControlRequest {
+export function createNotebookControlProxy(
+	runtime: SharedCodeModeRuntime,
+): ProgrammaticCodeModeToolDefinition {
+	return {
+		name: "notebook",
+		usage: "await tools.notebook({ action, query?, name?, names? })",
+		description: NOTEBOOK_DESCRIPTION,
+		deferLoading: true,
+		kind: "function",
+		inputSchema: NOTEBOOK_PARAMETERS,
+		invoke: (input, context, signal) =>
+			executeNotebookExecControl(runtime, input as NotebookToolParameters, context, signal),
+	};
+}
+
+export async function executeNotebookControl(
+	runtime: SharedCodeModeRuntime,
+	params: NotebookToolParameters,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	return executeNormalizedNotebookControl(runtime, normalizeNotebookRequest(params), context, signal);
+}
+
+export async function executeNotebookExecControl(
+	runtime: SharedCodeModeRuntime,
+	params: NotebookToolParameters,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	const request = normalizeNotebookRequest(params);
+	if (!canExecuteNotebookControlInsideExec(request))
+		return {
+			message: `Notebook ${request.action} was not run because it needs the active exec cell to finish. After exec returns, call notebook with ${JSON.stringify(request)}.`,
+			details: { notRun: true, action: request.action, retry: request },
+		};
+	return executeNormalizedNotebookControl(runtime, request, context, signal);
+}
+
+function executeNormalizedNotebookControl(
+	runtime: SharedCodeModeRuntime,
+	request: NotebookControlRequest,
+	context: ToolExecutionContext,
+	signal?: AbortSignal,
+): Promise<NotebookControlResult> {
+	return runtime.controlNotebook(request, context, signal);
+}
+
+export function normalizeNotebookRequest(params: NotebookToolParameters): NotebookControlRequest {
 	params = {
 		action: params.action,
 		...(params.query == null ? {} : { query: params.query }),

--- a/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
+++ b/packages/pi-codex-conversion/src/tools/code-mode/shared-runtime.ts
@@ -1,5 +1,6 @@
 import { ensureCodeModeHostBinary } from "./binary.js";
 import { CodeModeHostClient } from "./host-client.js";
+import { createNotebookControlProxy } from "./notebook-tool.ts";
 import type {
 	CodeModeToolDefinition,
 	NotebookControlRequest,
@@ -62,14 +63,14 @@ export class SharedCodeModeRuntime {
 	}
 
 	collectTools(ctx?: unknown): CodeModeToolDefinition[] {
-		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		const tools = this.collectProviderTools(ctx);
 		return this.customPromptToolsSnapshot
 			? applyCustomPromptState(tools, this.customPromptToolsSnapshot)
 			: tools;
 	}
 
 	refreshPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
-		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		const tools = this.collectProviderTools(ctx);
 		this.customPromptToolsSnapshot = tools.filter(isCustomTool);
 		return tools;
 	}
@@ -81,10 +82,8 @@ export class SharedCodeModeRuntime {
 
 	collectPromptTools(ctx?: unknown): CodeModeToolDefinition[] {
 		if (!this.customPromptToolsSnapshot) return this.refreshPromptTools(ctx);
-		const liveProgrammaticTools = collectUniqueTools(
-			this.activeProviders(ctx),
-			ctx,
-		).filter((tool) => !isCustomTool(tool));
+		const liveProgrammaticTools = this.collectProviderTools(ctx)
+			.filter((tool) => !isCustomTool(tool));
 		return [...liveProgrammaticTools, ...this.customPromptToolsSnapshot];
 	}
 
@@ -218,6 +217,14 @@ export class SharedCodeModeRuntime {
 				// Startup failure already reached the caller.
 			}
 		}
+	}
+
+	private collectProviderTools(ctx?: unknown): CodeModeToolDefinition[] {
+		const tools = collectUniqueTools(this.activeProviders(ctx), ctx);
+		if (this.executionKind(ctx) !== "notebook") return tools;
+		if (tools.some((tool) => tool.name === "notebook"))
+			throw new Error("Duplicate code-mode tool: notebook");
+		return [...tools, createNotebookControlProxy(this)];
 	}
 }
 

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/control-contract.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/control-contract.ts
@@ -1,0 +1,10 @@
+export const NOTEBOOK_EXEC_ACTIONS = ["status", "list", "diagnostics"] as const;
+
+export function canExecuteNotebookControlInsideExec(request: { action: string; query?: string | undefined }): boolean {
+	return NOTEBOOK_EXEC_ACTIONS.includes(request.action as typeof NOTEBOOK_EXEC_ACTIONS[number])
+		&& (request.action !== "status" || request.query === undefined);
+}
+
+export function notebookExecStartupNotice(): string {
+	return `Inside exec tools.notebook supports ${NOTEBOOK_EXEC_ACTIONS.join(", ")}; all others use the top-level notebook tool after exec returns`;
+}

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/session-startup.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { NotebookRuntimeOptions } from "../code-mode/shared-runtime.ts";
+import { notebookExecStartupNotice } from "./control-contract.ts";
 import type { NotebookBridgeServer } from "./bridge-server.ts";
 import {
 	garbageCollectSupersededNotebookCheckpoints,
@@ -106,7 +107,7 @@ export async function startNotebookSession(options: {
 		const exampleNotice = exampleNames.length === 2
 			? "Notebook example foo/bar available; inspect foo.description, foo.usage, bar.description, and bar.usage before constructing a reusable global"
 			: undefined;
-		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice].filter(Boolean).join(". ") || undefined;
+		const restoreNotice = [exampleNotice, npmNotice, formatProjectStateNotice(projectState), restored.message, profileNotice, notebookExecStartupNotice()].filter(Boolean).join(". ") || undefined;
 		return {
 			kernel,
 			journal,

--- a/packages/pi-codex-conversion/tests/notebook-exec-bridge.test.ts
+++ b/packages/pi-codex-conversion/tests/notebook-exec-bridge.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCodeModeToolsPrompt } from "../src/tools/code-mode/custom-tool-prompt.ts";
+import { createNotebookControlProxy } from "../src/tools/code-mode/notebook-tool.ts";
+import { SharedCodeModeRuntime } from "../src/tools/code-mode/shared-runtime.ts";
+import type { NotebookControlRequest, ToolExecutionContext } from "../src/tools/code-mode/types.ts";
+
+test("Notebook exec proxy shares control normalization without changing the prompt", async () => {
+	const calls: Array<{
+		request: NotebookControlRequest;
+		context: ToolExecutionContext;
+		signal: AbortSignal | undefined;
+	}> = [];
+	const runtime = {
+		async controlNotebook(request, context, signal) {
+			calls.push({ request, context, signal });
+			return { message: `Ran ${request.action}`, details: { action: request.action } };
+		},
+	} as Pick<SharedCodeModeRuntime, "controlNotebook"> as SharedCodeModeRuntime;
+	const proxy = createNotebookControlProxy(runtime);
+	const context: ToolExecutionContext = { cwd: "/project", toolCallId: "nested-notebook" };
+	const controller = new AbortController();
+	const modes = new SharedCodeModeRuntime();
+	modes.addProvider({
+		getTools: () => [],
+		executionKind: (mode) => mode as "code" | "notebook",
+	});
+
+	assert.equal(proxy.deferLoading, true);
+	assert.equal(buildCodeModeToolsPrompt([proxy]), "");
+	assert.deepEqual(modes.collectTools("code"), []);
+	assert.equal(modes.collectTools("notebook").at(-1)?.name, "notebook");
+	for (const request of [
+		{ action: "status" },
+		{ action: "list", query: "saved*" },
+		{ action: "diagnostics" },
+	] as const) {
+		assert.deepEqual(
+			await proxy.invoke(request, context, controller.signal),
+			{ message: `Ran ${request.action}`, details: { action: request.action } },
+		);
+	}
+	assert.deepEqual(calls.map(({ request }) => request), [
+		{ action: "status" },
+		{ action: "list", query: "saved*" },
+		{ action: "diagnostics" },
+	]);
+	for (const request of [
+		{ action: "status", query: "bindings*" },
+		{ action: "checkpoint" },
+		{ action: "save", name: "profile" },
+		{ action: "load", name: "profile" },
+		{ action: "pin", names: ["alpha", "alpha"] },
+		{ action: "unpin", names: ["alpha"] },
+		{ action: "release", names: ["alpha"] },
+		{ action: "prune", query: "alpha*" },
+		{ action: "restart" },
+		{ action: "reset" },
+	] as const) {
+		const normalized = request.action === "pin"
+			? { action: "pin" as const, names: ["alpha"] }
+			: request;
+		assert.deepEqual(
+			await proxy.invoke(request, context, controller.signal),
+			{
+				message: `Notebook ${request.action} was not run because it needs the active exec cell to finish. After exec returns, call notebook with ${JSON.stringify(normalized)}.`,
+				details: { notRun: true, action: request.action, retry: normalized },
+			},
+		);
+	}
+	assert.equal(calls.length, 3);
+	assert.equal(calls.every((call) => call.context === context && call.signal === controller.signal), true);
+	await assert.rejects(
+		proxy.invoke({ action: "save", query: "wrong" }, context, controller.signal),
+		/notebook save accepts name only/,
+	);
+	assert.equal(calls.length, 3);
+});


### PR DESCRIPTION
Notebook Mode exec code can now call the same Notebook lifecycle controls exposed by the top-level tool.

Part of #325.

## Summary

- expose a Notebook-only `tools.notebook(...)` exec proxy
- allow `status`, `list`, and `diagnostics` through the shared lifecycle executor
- return an exact top-level `notebook` retry payload for actions that require the active exec cell to finish
- advertise that allowlist once in the existing Notebook startup notice
- keep ordinary Code Mode and the static model-visible tool contract unchanged

## Validation

- focused package check: 111 tests
- cumulative stack check: 113 tests
- typecheck, build, Knip, extension artifact, and Code Mode host assets
- serialized top-level declaration unchanged

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`

