### PR TITLE
Add experimental project cache keepalive

### DIFF
--- a/.changeset/keep-codex-project-cache-warm.md
+++ b/.changeset/keep-codex-project-cache-warm.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Add a project-only experimental Codex cache keepalive that refreshes idle WebSocket context and reports cache-read results.

--- a/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-migration.ts
@@ -76,6 +76,7 @@ export function migrateCodexConversionConfigIfNeeded(value: unknown): { migrated
 		openai: {
 			fast: typeof value["fast"] === "boolean" ? value["fast"] : DEFAULT_CODEX_CONVERSION_CONFIG.openai["fast"],
 			verbosity: normalizeCodexVerbosity(value["verbosity"]) ?? DEFAULT_CODEX_CONVERSION_CONFIG.openai["verbosity"],
+			cacheKeepalive: DEFAULT_CODEX_CONVERSION_CONFIG.openai.cacheKeepalive,
 			proxyResponsesLite: DEFAULT_CODEX_CONVERSION_CONFIG.openai.proxyResponsesLite,
 			forceCachedWebSockets: typeof value["forceCachedWebSockets"] === "boolean" ? value["forceCachedWebSockets"] : DEFAULT_CODEX_CONVERSION_CONFIG.openai["forceCachedWebSockets"],
 			cacheDiagnostics: DEFAULT_CODEX_CONVERSION_CONFIG.openai.cacheDiagnostics,

--- a/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
@@ -57,6 +57,23 @@ function writeConfigDocumentAtomic(configPath: string, document: Record<string, 
 	}
 }
 
+function withoutProjectOnlyConfig(config: CodexConversionConfig): CodexConversionConfig {
+	return {
+		...config,
+		openai: { ...config.openai, cacheKeepalive: false },
+	};
+}
+
+function withoutProjectOnlyDocument(document: Record<string, unknown>): Record<string, unknown> {
+	const openai = isRecord(document["openai"]) ? { ...document["openai"] } : undefined;
+	if (!openai) return document;
+	delete openai["cacheKeepalive"];
+	const next = { ...document };
+	if (Object.keys(openai).length > 0) next["openai"] = openai;
+	else delete next["openai"];
+	return next;
+}
+
 export function getCodexConversionConfigPath(agentDir: string = getAgentDir()): string {
 	return join(agentDir, CODEX_CONVERSION_CONFIG_BASENAME);
 }
@@ -80,7 +97,7 @@ export function readCodexConversionConfig(configPath: string = getCodexConversio
 	const parsed = readConfigDocument(configPath, "global");
 	if (parsed === undefined) return structuredClone(DEFAULT_CODEX_CONVERSION_CONFIG);
 	const migration = migrateCodexConversionConfigIfNeeded(parsed);
-	const config = normalizeCodexConversionConfig(migration.config);
+	const config = withoutProjectOnlyConfig(normalizeCodexConversionConfig(migration.config));
 	const voice = isRecord(parsed) && isRecord(parsed["voice"])
 		? parsed["voice"]
 		: undefined;
@@ -100,7 +117,12 @@ export function readProjectCodexConversionDocument(cwd: string, projectTrusted: 
 
 export function hasFolderCodexConversionConfig(cwd: string, projectTrusted: boolean): boolean {
 	const project = readProjectCodexConversionDocument(cwd, projectTrusted);
-	return !!project && [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS].some((key) => key in project);
+	if (!project) return false;
+	return [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS].some((key) => {
+		if (key !== "openai") return key in project;
+		const openai = isRecord(project["openai"]) ? project["openai"] : undefined;
+		return !!openai && Object.keys(openai).some((option) => option !== "cacheKeepalive");
+	});
 }
 
 function applyProcessOverrides(config: CodexConversionConfig, env: NodeJS.ProcessEnv): CodexConversionConfig {
@@ -127,6 +149,32 @@ export function readLayeredCodexConversionConfig(
 		: global;
 }
 
+export function setProjectCodexCacheKeepalive(
+	cwd: string,
+	projectTrusted: boolean,
+	enabled: boolean,
+): { ok: true } | { ok: false; error: string } {
+	if (!projectTrusted) return { ok: false, error: "Trust this folder before changing project cache keepalive" };
+	const path = getProjectCodexConversionConfigPath(cwd);
+	try {
+		const existing = readConfigDocument(path, "trusted project");
+		if (existsSync(path) && !isRecord(existing)) return { ok: false, error: "Project config is not a JSON object" };
+		const document = isRecord(existing) ? existing : {};
+		const openai = isRecord(document["openai"]) ? { ...document["openai"] } : {};
+		if (enabled) openai["cacheKeepalive"] = true;
+		else delete openai["cacheKeepalive"];
+		if (Object.keys(openai).length > 0) document["openai"] = openai;
+		else delete document["openai"];
+		if (Object.keys(document).length === 0) rmSync(path, { force: true });
+		else writeConfigDocumentAtomic(path, document);
+		return { ok: true };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-codex-conversion] Failed to write project cache keepalive ${path}: ${message}`);
+		return { ok: false, error: message };
+	}
+}
+
 export function materializeFolderCodexConversionConfig(
 	cwd: string,
 	projectTrusted: boolean,
@@ -134,7 +182,7 @@ export function materializeFolderCodexConversionConfig(
 ): { ok: true; config: CodexConversionConfig } | { ok: false; error: string } {
 	if (!projectTrusted) return { ok: false, error: "Trust this folder before enabling folder settings" };
 	const config = readLayeredCodexConversionConfig({ cwd, projectTrusted, globalConfigPath });
-	const result = writeCodexConversionConfig(config, getProjectCodexConversionConfigPath(cwd));
+	const result = writeCodexConversionConfig(config, getProjectCodexConversionConfigPath(cwd), true);
 	return result.ok ? { ok: true, config } : result;
 }
 
@@ -146,7 +194,16 @@ export function clearFolderCodexConversionConfig(
 	const path = getProjectCodexConversionConfigPath(cwd);
 	const project = readProjectCodexConversionDocument(cwd, true);
 	if (!project) return { ok: true };
-	for (const key of [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS]) delete project[key];
+	for (const key of [...OWNED_CONFIG_KEYS, ...LEGACY_OWNED_CONFIG_KEYS]) {
+		if (key === "openai" && isRecord(project[key])) {
+			const keepalive = project[key]["cacheKeepalive"];
+			const nextOpenAI = typeof keepalive === "boolean" ? { cacheKeepalive: keepalive } : {};
+			if (Object.keys(nextOpenAI).length === 0) delete project[key];
+			else project[key] = nextOpenAI;
+			continue;
+		}
+		delete project[key];
+	}
 	try {
 		if (Object.keys(project).length === 0) rmSync(path, { force: true });
 		else writeConfigDocumentAtomic(path, project);
@@ -161,9 +218,10 @@ export function clearFolderCodexConversionConfig(
 export function writeCodexConversionConfig(
 	config: CodexConversionConfig,
 	configPath: string = getCodexConversionConfigPath(),
+	preserveProjectCacheKeepalive = false,
 ): { ok: true } | { ok: false; error: string } {
 	try {
-		const normalized = normalizeCodexConversionConfig(config) as unknown as Record<string, unknown>;
+		const normalized = withoutProjectOnlyDocument(normalizeCodexConversionConfig(config) as unknown as Record<string, unknown>);
 		let document = normalized;
 		if (existsSync(configPath)) {
 			try {
@@ -173,6 +231,7 @@ export function writeCodexConversionConfig(
 				// A valid explicit settings write replaces an unreadable document.
 			}
 		}
+		if (!preserveProjectCacheKeepalive) document = withoutProjectOnlyDocument(document);
 		clearAbsentOwnedOptionals(document, normalized);
 		for (const key of LEGACY_OWNED_CONFIG_KEYS) delete document[key];
 		writeConfigDocumentAtomic(configPath, document);

--- a/packages/pi-codex-conversion/src/adapter/activation/config.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config.ts
@@ -103,6 +103,7 @@ export interface CodexConversionConfig {
 	openai: {
 		fast: boolean;
 		verbosity: CodexVerbosity;
+		cacheKeepalive: boolean;
 		proxyResponsesLite: boolean;
 		forceCachedWebSockets: boolean;
 		cacheDiagnostics: CacheDiagnosticsMode;
@@ -155,6 +156,7 @@ export const DEFAULT_CODEX_CONVERSION_CONFIG: CodexConversionConfig = {
 	openai: {
 		fast: false,
 		verbosity: "low",
+		cacheKeepalive: false,
 		proxyResponsesLite: false,
 		forceCachedWebSockets: true,
 		cacheDiagnostics: "off",
@@ -464,6 +466,10 @@ export function normalizeCodexConversionConfig(
 			verbosity:
 				normalizeCodexVerbosity(openai["verbosity"]) ??
 				DEFAULT_CODEX_CONVERSION_CONFIG.openai["verbosity"],
+			cacheKeepalive: bool(
+				openai["cacheKeepalive"],
+				DEFAULT_CODEX_CONVERSION_CONFIG.openai["cacheKeepalive"],
+			),
 			proxyResponsesLite: bool(
 				openai["proxyResponsesLite"],
 				DEFAULT_CODEX_CONVERSION_CONFIG.openai.proxyResponsesLite,

--- a/packages/pi-codex-conversion/src/extension/events.ts
+++ b/packages/pi-codex-conversion/src/extension/events.ts
@@ -227,7 +227,11 @@ export function registerCodexEvents(
 		const update = event.assistantMessageEvent;
 		if (update.type === "text_delta" && typeof update.delta === "string") runtime.voice.streamDelta(update.delta);
 	});
-	pi.on("agent_start", async () => { runtime.voice.agentStarted(); runtime.lanVoice.agentStarted(); });
+	pi.on("agent_start", async () => {
+		runtime.cancelCacheKeepalive();
+		runtime.voice.agentStarted();
+		runtime.lanVoice.agentStarted();
+	});
 	pi.on("agent_settled", async (_event, ctx) => {
 		state.pendingActiveProviderPromptCapture = false;
 		state.voiceSystemPromptOverride = undefined;
@@ -235,6 +239,7 @@ export function registerCodexEvents(
 		runtime.voice.settleTurn();
 		runtime.lanVoice.agentSettled();
 		if (!state.config.voiceFeaturesOnly) void ui.refreshUsageStatus(ctx);
+		runtime.armCacheKeepalive(ctx);
 	});
 	pi.on("before_provider_request", async (event, ctx) => {
 		state.cwd = ctx.cwd;

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -47,6 +47,9 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 						&& config.openai.cacheDiagnostics === "status-and-log",
 				);
 			}
+			if (config.openai.cacheKeepalive !== previousConfig.openai.cacheKeepalive) {
+				runtime.cancelCacheKeepalive();
+			}
 			if (
 				config.voiceFeaturesOnly !== previousConfig.voiceFeaturesOnly
 				|| executionModeChanged

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -12,7 +12,7 @@ import { buildCodexSystemPrompt, type PiSystemPromptOptions } from "../prompt/bu
 import { closeOpenAICodexWebSocketSessions, prewarmOpenAICodexWebSocket } from "../providers/openai-codex-custom-provider.ts";
 import { resetOpenAICodexWebSocketSessions } from "../providers/openai-codex/websocket.ts";
 import { createCodexTurnState } from "../providers/openai-codex/turn-state.ts";
-import type { OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
+import type { CodexPrewarmUsage, OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
 import { createExecCommandTracker } from "../tools/exec/command-state.ts";
 import { createExecSessionManager } from "../tools/exec/session-manager.ts";
 import { getBundledToolBinaryPath } from "../tools/native/binary.ts";
@@ -26,7 +26,8 @@ import type { CodexDiagnosticsSink } from "../providers/openai-codex/types.ts";
 export type CodexContext = ExtensionContext;
 
 export type CodexPrewarmResult =
-	| { status: "ready" }
+	| { status: "ready"; usage?: CodexPrewarmUsage | undefined; socketReused?: boolean | undefined }
+	| { status: "skipped" }
 	| { status: "aborted" }
 	| { status: "failed"; error: Error };
 
@@ -41,6 +42,9 @@ export interface CodexExtensionRuntime {
 	codexSystemPrompt(basePrompt: string, ctx: CodexContext, skills?: AdapterState["promptSkills"], systemPromptOptions?: PiSystemPromptOptions): string;
 	startPrewarm(ctx: CodexContext, systemPrompt?: string, prepared?: boolean): Promise<CodexPrewarmResult> | undefined;
 	startCompactionPrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
+	startKeepalivePrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
+	armCacheKeepalive(ctx: CodexContext): void;
+	cancelCacheKeepalive(): void;
 	resetTransport(sessionId?: string): void;
 	resetTransportAfterCompaction(sessionId: string): void;
 	shutdownTransport(sessionId: string): void;
@@ -50,6 +54,8 @@ export interface CodexExtensionRuntime {
 	diagnosticsSink(): CodexDiagnosticsSink | undefined;
 	shutdownDiagnostics(): Promise<void>;
 }
+
+const CACHE_KEEPALIVE_INTERVAL_MS = 25 * 60 * 1000;
 
 function activeToolContext(pi: ExtensionAPI): NonNullable<Context["tools"]> {
 	// Pi ToolInfo omits constrainedSampling; restore our owned exec contract so
@@ -78,9 +84,14 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	});
 	let prewarmController: AbortController | undefined;
 	let prewarmPromise: Promise<CodexPrewarmResult> | undefined;
-	let prewarmTransportSettlement: Promise<void> | undefined;
+	let prewarmTransportSettlement: Promise<unknown> | undefined;
 	let pendingPrewarmKey: string | undefined;
 	let prewarmedIdentity: string | undefined;
+	let activePrewarmKind: "ordinary" | "keepalive" | undefined;
+	let cacheKeepaliveTimer: ReturnType<typeof setTimeout> | undefined;
+	let cacheKeepaliveEpoch = 0;
+	let consecutiveRedKeepalives = 0;
+	let cacheKeepalivePaused = false;
 	const voice = new CodexVoiceController(pi);
 	const diagnostics = createLazyCodexDiagnostics();
 	const buildPrewarmPlan = (
@@ -88,12 +99,13 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		systemPrompt: string,
 		prepared: boolean,
 		messages: Context["messages"],
-		rewriteCompactedReplay: boolean,
+		rewriteFinalRequest: boolean,
 	) => {
 		const model = ctx.model;
 		const config = structuredClone(state.config);
 		const executionMode = state.executionMode;
-		if (!model || model.provider !== "openai-codex" || !isAdapterRuntime(resolveCodexRuntimePlan(ctx, config, executionMode)) || !config.openai.forceCachedWebSockets) return undefined;
+		const runtimePlan = resolveCodexRuntimePlan(ctx, config, executionMode);
+		if (!model || !runtimePlan.codexTransport || !isAdapterRuntime(runtimePlan) || !config.openai.forceCachedWebSockets) return undefined;
 		const preparedSystemPrompt = prepared
 			? systemPrompt
 			: runtime.codexSystemPrompt(systemPrompt, ctx);
@@ -111,7 +123,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		const key = JSON.stringify({
 			identity,
 			messages,
-			rewriteCompactedReplay,
+			rewriteFinalRequest,
 		});
 		return {
 			model,
@@ -129,18 +141,21 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		systemPrompt = ctx.getSystemPrompt(),
 		prepared = false,
 		messages: Context["messages"] = [],
-		rewriteCompactedReplay = false,
+		rewriteFinalRequest = false,
+		force = false,
+		kind: "ordinary" | "keepalive" = "ordinary",
 	): Promise<CodexPrewarmResult> | undefined => {
-		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteCompactedReplay);
+		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteFinalRequest);
 		if (!plan) return undefined;
 		const { model, config, executionMode, preparedSystemPrompt, tools, reasoning, identity, key: prewarmKey } = plan;
 		if (pendingPrewarmKey === prewarmKey) return prewarmPromise;
-		if (!pendingPrewarmKey && prewarmedIdentity === identity) return undefined;
+		if (!force && !pendingPrewarmKey && prewarmedIdentity === identity) return undefined;
 		const previousTransportSettlement = prewarmTransportSettlement;
 		prewarmedIdentity = undefined;
 		prewarmController?.abort();
 		const controller = new AbortController();
 		prewarmController = controller;
+		activePrewarmKind = kind;
 		pendingPrewarmKey = prewarmKey;
 		const promise = (async () => {
 			if (previousTransportSettlement) await previousTransportSettlement.catch(() => undefined);
@@ -166,7 +181,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 						...reasoning,
 						textVerbosity: config.openai.verbosity,
 						...(config.openai.fast ? { serviceTier: "priority" as const } : {}),
-						onPayload: (body) => rewriteCompactedReplay
+						onPayload: (body) => rewriteFinalRequest
 							? rewriteCodexProviderRequest(body, ctx, { ...state, config, executionMode })
 							: rewriteCodexPrewarmProviderRequest(body, ctx, { ...state, config, executionMode }),
 					},
@@ -179,7 +194,11 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 				);
 				prewarmTransportSettlement = transportSettlement;
 				try {
-					await transportSettlement;
+					const result = await transportSettlement;
+					if (controller.signal.aborted) return { status: "aborted" } as const;
+					if (!result) return { status: "skipped" } as const;
+					prewarmedIdentity = identity;
+					return { status: "ready", ...(result.usage ? { usage: result.usage } : {}), socketReused: result.socketReused } as const;
 				} finally {
 					if (prewarmTransportSettlement === transportSettlement) prewarmTransportSettlement = undefined;
 				}
@@ -191,18 +210,96 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 				}
 				return { status: "failed", error: failure } as const;
 			}
-			if (controller.signal.aborted) return { status: "aborted" } as const;
-			prewarmedIdentity = identity;
-			return { status: "ready" } as const;
 		})().finally(() => {
 			if (prewarmPromise === promise) {
 				prewarmPromise = undefined;
 				if (pendingPrewarmKey === prewarmKey) pendingPrewarmKey = undefined;
 			}
-			if (prewarmController === controller) prewarmController = undefined;
+			if (prewarmController === controller) {
+				prewarmController = undefined;
+				activePrewarmKind = undefined;
+			}
 		});
 		prewarmPromise = promise;
 		return promise;
+	};
+
+	const currentContextPrewarm = (ctx: CodexContext, force: boolean) => {
+		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
+			.filter((message) => !isProviderContextExcludedMessage(message));
+		const activeSystemPrompt = state.activeProviderSystemPrompt;
+		return startPrewarm(
+			ctx,
+			activeSystemPrompt ?? ctx.getSystemPrompt(),
+			activeSystemPrompt !== undefined,
+			convertToLlm(messages),
+			true,
+			force,
+			force ? "keepalive" : "ordinary",
+		);
+	};
+
+	const cancelCacheKeepalive = () => {
+		cacheKeepaliveEpoch++;
+		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
+		cacheKeepaliveTimer = undefined;
+		if (activePrewarmKind === "keepalive") prewarmController?.abort();
+	};
+
+	const formatKeepaliveMetrics = (usage: CodexPrewarmUsage, socketReused: boolean | undefined) => {
+		const total = usage.inputTokens + usage.cachedInputTokens;
+		const ratio = total > 0 ? usage.cachedInputTokens / total : undefined;
+		return {
+			ratio,
+			message: `Codex cache keepalive · input ${usage.inputTokens.toLocaleString("en-US")} · read ${usage.cachedInputTokens.toLocaleString("en-US")} · write ${usage.cacheWriteInputTokens.toLocaleString("en-US")} · ${ratio === undefined ? "cache unavailable" : `${(ratio * 100).toFixed(1)}%`} · WS ${socketReused ? "reused" : "new"}`,
+		};
+	};
+
+	const scheduleCacheKeepalive = (ctx: CodexContext, epoch: number) => {
+		if (cacheKeepalivePaused || !state.config.openai.cacheKeepalive) return;
+		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
+		cacheKeepaliveTimer = setTimeout(() => {
+			cacheKeepaliveTimer = undefined;
+			if (epoch !== cacheKeepaliveEpoch || !ctx.isIdle()) return;
+			const keepalive = currentContextPrewarm(ctx, true);
+			if (!keepalive) return;
+			void keepalive.then((result) => {
+				if (epoch !== cacheKeepaliveEpoch || result.status === "aborted" || result.status === "skipped") return;
+				if (result.status === "failed") {
+					ctx.ui.notify(`Codex cache keepalive failed: ${result.error.message}`, "warning");
+					scheduleCacheKeepalive(ctx, epoch);
+					return;
+				}
+				if (!result.usage) {
+					consecutiveRedKeepalives = 0;
+					ctx.ui.notify("Codex cache keepalive completed without usage metrics", "warning");
+					scheduleCacheKeepalive(ctx, epoch);
+					return;
+				}
+				const metrics = formatKeepaliveMetrics(result.usage, result.socketReused);
+				if (metrics.ratio !== undefined && metrics.ratio <= 0.1) {
+					consecutiveRedKeepalives++;
+					ctx.ui.notify(metrics.message, "error");
+					if (consecutiveRedKeepalives >= 2) {
+						cacheKeepalivePaused = true;
+						ctx.ui.notify("Codex cache keepalive paused after two consecutive ≤10% reads", "error");
+						return;
+					}
+				} else {
+					consecutiveRedKeepalives = 0;
+					ctx.ui.notify(metrics.message, metrics.ratio !== undefined && metrics.ratio < 0.5 ? "warning" : "info");
+				}
+				scheduleCacheKeepalive(ctx, epoch);
+			});
+		}, CACHE_KEEPALIVE_INTERVAL_MS);
+		cacheKeepaliveTimer.unref?.();
+	};
+
+	const armCacheKeepalive = (ctx: CodexContext) => {
+		cancelCacheKeepalive();
+		consecutiveRedKeepalives = 0;
+		cacheKeepalivePaused = false;
+		scheduleCacheKeepalive(ctx, cacheKeepaliveEpoch);
 	};
 
 	const runtime: CodexExtensionRuntime = {
@@ -237,18 +334,19 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			return startPrewarm(ctx, systemPrompt, prepared);
 		},
 		startCompactionPrewarm(ctx) {
-			const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
-				.filter((message) => !isProviderContextExcludedMessage(message));
-			const activeSystemPrompt = state.activeProviderSystemPrompt;
-			return startPrewarm(
-				ctx,
-				activeSystemPrompt ?? ctx.getSystemPrompt(),
-				activeSystemPrompt !== undefined,
-				convertToLlm(messages),
-				true,
-			);
+			return currentContextPrewarm(ctx, false);
+		},
+		startKeepalivePrewarm(ctx) {
+			return currentContextPrewarm(ctx, true);
+		},
+		armCacheKeepalive(ctx) {
+			armCacheKeepalive(ctx);
+		},
+		cancelCacheKeepalive() {
+			cancelCacheKeepalive();
 		},
 		resetTransport(sessionId) {
+			cancelCacheKeepalive();
 			prewarmController?.abort();
 			prewarmController = undefined;
 			pendingPrewarmKey = undefined;
@@ -262,6 +360,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			closeOpenAICodexWebSocketSessions(sessionId);
 		},
 		shutdownTransport(sessionId) {
+			cancelCacheKeepalive();
 			runtime.resetTransport(sessionId);
 			closeOpenAICodexWebSocketSessions(sessionId);
 		},

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -8,7 +8,7 @@ import { buildRequestBody } from "./openai-codex/request-body.ts";
 import { openAICodexModelsWithDaybreak } from "./openai-codex/model-catalog.ts";
 import { supportsResponsesLiteModel } from "./openai-codex/responses-lite-model.ts";
 import { applyResponsesLiteRequest, applyResponsesLiteWebSocketMetadata, isResponsesLiteRequest, namespaceExistingResponsesLiteRequest, prepareResponsesLiteRequestImages } from "./openai-codex/responses-lite.ts";
-import type { CodexDiagnosticsSink, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
+import type { CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { recordWebSocketSseFallback } from "./openai-codex/websocket.ts";
 import { isWebSocketMessageTooBigError, isWebSocketUpgradeRequiredError } from "./openai-codex/websocket-connection.ts";
 import { prewarmWebSocket } from "./openai-codex/websocket-stream.ts";
@@ -60,7 +60,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 		turnState?: CodexTurnState | undefined;
 		getDiagnostics?: (() => CodexDiagnosticsSink | undefined) | undefined;
 	},
-): Promise<void> {
+): Promise<CodexPrewarmResult | undefined> {
 	const runtimeConfig = deps.getConfig?.();
 	if (getEffectiveCodexTransport(options.transport, runtimeConfig?.openai, options.sessionId) === "sse") return;
 	if (!options.apiKey || !options.sessionId) return;
@@ -83,7 +83,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	const websocketBody = withCodexTurnState(responsesLite ? applyResponsesLiteWebSocketMetadata(body) : body, deps.turnState);
 	const diagnostics = noThrowCodexDiagnosticsSink(deps.getDiagnostics?.());
 	try {
-		await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, deps.turnState, diagnostics);
+		return await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, deps.turnState, diagnostics);
 	} catch (error) {
 		if (!options.signal?.aborted && (isWebSocketUpgradeRequiredError(error) || isWebSocketMessageTooBigError(error))) {
 			recordWebSocketSseFallback(options.sessionId);

--- a/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
@@ -173,6 +173,17 @@ export interface ResponsesBody {
 	[key: string]: unknown;
 }
 
+export interface CodexPrewarmUsage {
+	inputTokens: number;
+	cachedInputTokens: number;
+	cacheWriteInputTokens: number;
+}
+
+export interface CodexPrewarmResult {
+	socketReused: boolean;
+	usage?: CodexPrewarmUsage | undefined;
+}
+
 export interface ResponseEnvelope {
 	id?: string | undefined;
 	status?: string | undefined;

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -3,7 +3,7 @@ import { normalizeTimeoutMs } from "./sse.ts";
 import { buildCachedWebSocketRequestBody } from "./websocket-continuation.ts";
 import { acquireWebSocket, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket.ts";
 import { assertSuccessfulCodexOutput, assertSuccessfulCodexStatus, mapCodexEvents, processMappedCodexResponsesStream } from "./stream-events.ts";
-import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
+import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
 import type { CodexTurnState } from "./turn-state.ts";
 import { DEFAULT_STREAM_IDLE_TIMEOUT_MS, DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS } from "./constants.ts";
 import { codexDiagnosticsFailure, noThrowCodexDiagnosticsSink } from "./diagnostic-failure.ts";
@@ -143,7 +143,7 @@ export async function prewarmWebSocket(
 	options: OpenAICodexStreamOptions,
 	turnState?: CodexTurnState,
 	diagnostics?: CodexDiagnosticsSink | undefined,
-): Promise<void> {
+): Promise<CodexPrewarmResult> {
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics);
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
 	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, options.sessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
@@ -151,6 +151,7 @@ export async function prewarmWebSocket(
 	const responseItems: unknown[] = [];
 	let responseId: string | undefined;
 	let responseStatus: string | undefined;
+	let usage: CodexPrewarmResult["usage"];
 	const idleTimeoutMs = normalizeTimeoutMs(options.timeoutMs ?? options.websocketConnectTimeoutMs ?? DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS, "timeoutMs");
 	try {
 		recordDiagnostics?.({
@@ -170,6 +171,16 @@ export async function prewarmWebSocket(
 			if (event.type === "response.completed") {
 				if (event.response?.id) responseId = event.response.id;
 				responseStatus = event.response?.status;
+				const responseUsage = event.response?.usage;
+				if (responseUsage) {
+					const cacheRead = responseUsage.input_tokens_details?.cached_tokens ?? 0;
+					const cacheWrite = responseUsage.input_tokens_details?.cache_write_tokens ?? 0;
+					usage = {
+						inputTokens: Math.max(0, (responseUsage.input_tokens ?? 0) - cacheRead - cacheWrite),
+						cachedInputTokens: cacheRead,
+						cacheWriteInputTokens: cacheWrite,
+					};
+				}
 			}
 		}
 		assertSuccessfulCodexStatus(responseStatus);
@@ -177,6 +188,7 @@ export async function prewarmWebSocket(
 			entry.continuation = { lastRequestBody: body, lastResponseId: responseId, lastResponseItems: responseItems };
 		}
 		recordDiagnostics?.({ type: "prewarm-ready", transport: "websocket", socketReused: reused });
+		return { socketReused: reused, ...(usage ? { usage } : {}) };
 	} catch (error) {
 		keepConnection = false;
 		recordDiagnostics?.({

--- a/packages/pi-codex-conversion/src/ui/settings/command.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/command.ts
@@ -9,6 +9,7 @@ import {
 	readCodexConversionConfig,
 	readEffectiveCodexConversionConfig,
 	readLayeredCodexConversionConfig,
+	setProjectCodexCacheKeepalive,
 	type CodexConversionConfigScope,
 	writeCodexConversionConfig,
 } from "../../adapter/activation/config-store.ts";
@@ -54,7 +55,7 @@ export function registerCodexCommand(
 		const path = scope === "folder"
 			? getProjectCodexConversionConfigPath(ctx.cwd)
 			: getCodexConversionConfigPath();
-		const writeResult = writeCodexConversionConfig(nextConfig, path);
+		const writeResult = writeCodexConversionConfig(nextConfig, path, scope === "folder");
 		if (!writeResult.ok) {
 			ctx.ui.notify(`Failed to save Codex settings: ${writeResult.error}`, "error");
 			return false;
@@ -94,13 +95,32 @@ export function registerCodexCommand(
 				return;
 			}
 		}
-		const readSelectedConfig = () => configScope === "folder"
-			? readLayeredCodexConversionConfig({ cwd: ctx.cwd, projectTrusted: true })
-			: readCodexConversionConfig();
+		const readSelectedConfig = () => {
+			const selected = configScope === "folder"
+				? readLayeredCodexConversionConfig({ cwd: ctx.cwd, projectTrusted: true })
+				: readCodexConversionConfig();
+			return {
+				...selected,
+				openai: {
+					...selected.openai,
+					cacheKeepalive: effectiveConfig(ctx).openai.cacheKeepalive,
+				},
+			};
+		};
 		await openCodexSettingsScreen(ctx, {
 			initialConfig: readSelectedConfig(),
 			initialTab: tab,
 			onChange: (config) => saveAndApply(ctx, configScope, config),
+			onProjectCacheKeepalive: (enabled) => {
+				const result = setProjectCodexCacheKeepalive(ctx.cwd, ctx.isProjectTrusted(), enabled);
+				if (!result.ok) {
+					ctx.ui.notify(`Failed to save project cache keepalive: ${result.error}`, "error");
+					return undefined;
+				}
+				const previousConfig = state.config;
+				applyEffectiveConfig(ctx, previousConfig);
+				return readSelectedConfig();
+			},
 			configScope: {
 				current: () => configScope,
 				canUseFolder: ctx.isProjectTrusted(),

--- a/packages/pi-codex-conversion/src/ui/settings/config-editor.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-editor.ts
@@ -46,13 +46,14 @@ export function splitEditorCommand(command: string, platform: NodeJS.Platform = 
 
 export async function openCodexConfigInExternalEditor(
 	file: string,
+	preserveProjectCacheKeepalive: boolean,
 	stopTui: () => void,
 	startTui: () => void,
 	requestRender: (full?: boolean) => void,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
 	const editorCmd = editorCommand();
 	if (!editorCmd) return { ok: false, error: "Set $VISUAL or $EDITOR to edit the config file." };
-	writeCodexConversionConfig(readCodexConversionConfig(file), file);
+	writeCodexConversionConfig(readCodexConversionConfig(file), file, preserveProjectCacheKeepalive);
 	try {
 		stopTui();
 		const status = await new Promise<number | null>((resolve) => {

--- a/packages/pi-codex-conversion/src/ui/settings/config-items-openai.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-items-openai.ts
@@ -6,7 +6,7 @@ import {
 	normalizeV2UserMessageRetention,
 	V2_USER_MESSAGE_RETENTION_OPTIONS,
 } from "../../adapter/activation/config.ts";
-import { type ConfigSetting, setting, toggle } from "./config-items-shared.ts";
+import { type ConfigSetting, projectToggle, setting, toggle } from "./config-items-shared.ts";
 
 export function buildOpenAISettings(
 	config: CodexConversionConfig,
@@ -17,6 +17,11 @@ export function buildOpenAISettings(
 			...current,
 			openai: { ...current.openai, fast: enabled },
 		})),
+		projectToggle(
+			"cacheKeepalive",
+			"Experimental cache keepalive",
+			config.openai.cacheKeepalive,
+		),
 		setting(
 			{
 				id: "verbosity",

--- a/packages/pi-codex-conversion/src/ui/settings/config-items-shared.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/config-items-shared.ts
@@ -14,7 +14,7 @@ export interface ConfigSetting {
 	update?:
 		| ((value: string, config: CodexConversionConfig) => CodexConversionConfig)
 		| undefined;
-	action?: "edit-config" | undefined;
+	action?: "edit-config" | "project-cache-keepalive" | undefined;
 }
 
 export class TextSettingSubmenu extends Container implements Focusable {
@@ -75,4 +75,11 @@ export function toggle(
 		{ id, label, currentValue: current ? "on" : "off", values: ["off", "on"] },
 		(value, config) => update(value === "on", config),
 	);
+}
+
+export function projectToggle(id: string, label: string, current: boolean): ConfigSetting {
+	return {
+		item: { id, label, currentValue: current ? "on" : "off", values: ["off", "on"] },
+		action: "project-cache-keepalive",
+	};
 }

--- a/packages/pi-codex-conversion/src/ui/settings/screen.ts
+++ b/packages/pi-codex-conversion/src/ui/settings/screen.ts
@@ -24,6 +24,7 @@ import { createUsageTab, type UsageTabOptions } from "./usage-tab.ts";
 export interface CodexSettingsScreenOptions extends UsageTabOptions {
 	initialConfig: CodexConversionConfig;
 	onChange: (nextConfig: CodexConversionConfig) => boolean;
+	onProjectCacheKeepalive: (enabled: boolean) => CodexConversionConfig | undefined;
 	initialTab?: SettingsTab | undefined;
 	configScope: {
 		current: () => CodexConversionConfigScope;
@@ -65,6 +66,7 @@ export async function openCodexSettingsScreen(
 			}
 			const result = await openCodexConfigInExternalEditor(
 				options.configScope.path(),
+				options.configScope.current() === "folder",
 				() => tui.stop(),
 				() => tui.start(),
 				(full) => tui.requestRender(full),
@@ -136,6 +138,17 @@ export async function openCodexSettingsScreen(
 					const definition = buildSettings().find(({ item }) => item.id === id);
 					if (definition?.action === "edit-config") {
 						void runEditConfig();
+						return;
+					}
+					if (definition?.action === "project-cache-keepalive") {
+						const nextDraft = options.onProjectCacheKeepalive(value === "on");
+						if (nextDraft) {
+							draft = nextDraft;
+							for (const { item } of buildSettings()) list.updateValue(item.id, item.currentValue);
+						} else {
+							list.updateValue(id, definition.item.currentValue);
+						}
+						tui.requestRender();
 						return;
 					}
 					if (id === "configScope") {

--- a/packages/pi-codex-conversion/tests/config-store.test.ts
+++ b/packages/pi-codex-conversion/tests/config-store.test.ts
@@ -6,8 +6,10 @@ import test from "node:test";
 import {
 	clearFolderCodexConversionConfig,
 	getProjectCodexConversionConfigPath,
+	hasFolderCodexConversionConfig,
 	materializeFolderCodexConversionConfig,
 	readEffectiveCodexConversionConfig,
+	setProjectCodexCacheKeepalive,
 	writeCodexConversionConfig,
 } from "../src/adapter/activation/config-store.ts";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
@@ -17,7 +19,19 @@ test("trusted folder config overrides globals without crossing folder or process
 	try {
 		const globalPath = join(root, "agent", "pi-codex-conversion.json");
 		const project = join(root, "project");
+		const projectPath = getProjectCodexConversionConfigPath(project);
+		mkdirSync(join(root, "agent"), { recursive: true });
 		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(globalPath, JSON.stringify({ openai: { cacheKeepalive: true } }), { encoding: "utf8" });
+
+		assert.equal(readEffectiveCodexConversionConfig({ cwd: project, projectTrusted: true, globalConfigPath: globalPath, env: {} }).openai.cacheKeepalive, false);
+		assert.equal(setProjectCodexCacheKeepalive(project, true, true).ok, true);
+		assert.deepEqual(JSON.parse(readFileSync(projectPath, "utf8")), { openai: { cacheKeepalive: true } });
+		assert.equal(hasFolderCodexConversionConfig(project, true), false);
+		assert.equal(readEffectiveCodexConversionConfig({ cwd: project, projectTrusted: true, globalConfigPath: globalPath, env: {} }).openai.cacheKeepalive, true);
+		assert.equal(setProjectCodexCacheKeepalive(project, true, false).ok, true);
+		assert.equal(existsSync(projectPath), false);
+
 		writeCodexConversionConfig({
 			...structuredClone(DEFAULT_CODEX_CONVERSION_CONFIG),
 			openai: {

--- a/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-prewarm.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_CODEX_CONVERSION_CONFIG } from "../src/adapter/activation/config.ts";
+import { canonicalCodexAliasModelKey } from "../src/adapter/prompt/codex-model.ts";
 import { createCodexExtensionRuntime } from "../src/extension/runtime.ts";
 import { prewarmOpenAICodexWebSocket } from "../src/providers/openai-codex-custom-provider.ts";
 import { isWebSocketSseFallbackActive, recordWebSocketSseFallback } from "../src/providers/openai-codex/websocket.ts";
@@ -72,8 +73,21 @@ test("stalled auth in an aborted prewarm cannot block a newer equivalent operati
 	await current;
 });
 
-test("post-compaction reset seeds one reusable request identity", async () => {
-	const restoreWebSocket = installScriptedWebSocket([websocketSuccess]);
+test("post-compaction reset prewarms canonical aliases with normalized cache usage", async () => {
+	const restoreWebSocket = installScriptedWebSocket([(socket) => {
+		socket.emitJson({ type: "response.created", response: { id: "resp_cached" } });
+		socket.emitJson({
+			type: "response.completed",
+			response: {
+				id: "resp_cached",
+				status: "completed",
+				usage: {
+					input_tokens: 100,
+					input_tokens_details: { cached_tokens: 75 },
+				},
+			},
+		});
+	}]);
 	const sessionId = "history-prewarm-identity";
 	try {
 		const runtime = createCodexExtensionRuntime({
@@ -90,10 +104,19 @@ test("post-compaction reset seeds one reusable request identity", async () => {
 			executionMode: "code",
 		};
 		runtime.state.activeProviderSystemPrompt = "Stable prompt";
+		const alias = {
+			...model,
+			provider: "openai-codex-personal",
+			baseUrl: "https://chatgpt.com/backend-api",
+		};
+		runtime.state.canonicalAliasEndpoint = {
+			modelKey: canonicalCodexAliasModelKey(alias),
+			trusted: true,
+		};
 		const extensionContext = {
 			cwd: "/repo",
 			getSystemPrompt: () => "Stable prompt",
-			model,
+			model: alias,
 			modelRegistry: {
 				getApiKeyAndHeaders: async () => ({ ok: true, apiKey }),
 			},
@@ -103,7 +126,15 @@ test("post-compaction reset seeds one reusable request identity", async () => {
 			},
 		} as never;
 
-		await runtime.startCompactionPrewarm(extensionContext);
+		assert.deepEqual(await runtime.startCompactionPrewarm(extensionContext), {
+			status: "ready",
+			usage: {
+				inputTokens: 25,
+				cachedInputTokens: 75,
+				cacheWriteInputTokens: 0,
+			},
+			socketReused: false,
+		});
 
 		assert.equal(runtime.waitForPrewarm(extensionContext, "Stable prompt"), undefined);
 		assert.equal(sentFrames().length, 1);


### PR DESCRIPTION
Projects can opt into periodically refreshing an idle Codex WebSocket context without adding a user message or model output.

Part of #325.

## Summary

- add an experimental OAI toggle that always writes only the minimal project overlay
- arm a 25-minute full-context `generate:false` prewarm after `agent_settled`, never while Pi is working
- reuse the existing Codex WebSocket prewarm path and reset across transport, session, model, and compaction changes
- report cache metrics, warn below 50%, and pause after two consecutive reads at or below 10%

The transport behavior is supported; provider prompt-cache refresh remains experimental and is reported from observed usage rather than promised.

## Validation

- focused package check: 112 tests
- typecheck and Knip
- no paid provider calls
- cumulative stack check: 113 tests, build, and Knip

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
