### PR TITLE
Fix Codex cache keepalive request replay

### DIFF
--- a/.changeset/patch-msztyf72-2dece0.md
+++ b/.changeset/patch-msztyf72-2dece0.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep idle Codex cache refreshes on the exact provider request that produced the active cache, every 25 minutes, without disturbing the live WebSocket continuation or presenting `generate:false` usage as cache telemetry.

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -26,6 +26,7 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 			turnState: runtime.state.codexTurnState,
 			getDiagnostics: () => runtime.diagnosticsSink(),
 			onPreparedPayload: (payload) => {
+				runtime.captureCacheKeepaliveRequest(payload);
 				if (!runtime.state.pendingActiveProviderPromptCapture) return;
 				captureActiveProviderSystemPrompt(payload, runtime.state);
 				runtime.state.pendingActiveProviderPromptCapture = false;

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -12,7 +12,7 @@ import { buildCodexSystemPrompt, type PiSystemPromptOptions } from "../prompt/bu
 import { closeOpenAICodexWebSocketSessions, prewarmOpenAICodexWebSocket } from "../providers/openai-codex-custom-provider.ts";
 import { resetOpenAICodexWebSocketSessions } from "../providers/openai-codex/websocket.ts";
 import { createCodexTurnState } from "../providers/openai-codex/turn-state.ts";
-import type { CodexPrewarmUsage, OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
+import type { CodexPrewarmUsage, OpenAICodexStreamOptions, ResponsesBody } from "../providers/openai-codex/types.ts";
 import { createExecCommandTracker } from "../tools/exec/command-state.ts";
 import { createExecSessionManager } from "../tools/exec/session-manager.ts";
 import { getBundledToolBinaryPath } from "../tools/native/binary.ts";
@@ -45,6 +45,7 @@ export interface CodexExtensionRuntime {
 	startKeepalivePrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
 	armCacheKeepalive(ctx: CodexContext): void;
 	cancelCacheKeepalive(): void;
+	captureCacheKeepaliveRequest(payload: ResponsesBody): void;
 	resetTransport(sessionId?: string): void;
 	resetTransportAfterCompaction(sessionId: string): void;
 	shutdownTransport(sessionId: string): void;
@@ -90,8 +91,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	let activePrewarmKind: "ordinary" | "keepalive" | undefined;
 	let cacheKeepaliveTimer: ReturnType<typeof setTimeout> | undefined;
 	let cacheKeepaliveEpoch = 0;
-	let consecutiveRedKeepalives = 0;
-	let cacheKeepalivePaused = false;
+	let cacheKeepaliveRequest: ResponsesBody | undefined;
 	const voice = new CodexVoiceController(pi);
 	const diagnostics = createLazyCodexDiagnostics();
 	const buildPrewarmPlan = (
@@ -144,6 +144,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		rewriteFinalRequest = false,
 		force = false,
 		kind: "ordinary" | "keepalive" = "ordinary",
+		preparedBody?: ResponsesBody,
 	): Promise<CodexPrewarmResult> | undefined => {
 		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteFinalRequest);
 		if (!plan) return undefined;
@@ -190,6 +191,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 						useResponsesLite: (currentModel) => resolveCodexRuntimePlan({ model: currentModel }, config, executionMode).transport === "responses-lite",
 						turnState: state.codexTurnState,
 						getDiagnostics: () => diagnostics.sink(),
+						...(preparedBody ? { preparedBody, preserveContinuation: true } : {}),
 					},
 				);
 				prewarmTransportSettlement = transportSettlement;
@@ -225,6 +227,18 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	};
 
 	const currentContextPrewarm = (ctx: CodexContext, force: boolean) => {
+		if (force && cacheKeepaliveRequest) {
+			return startPrewarm(
+				ctx,
+				state.activeProviderSystemPrompt ?? ctx.getSystemPrompt(),
+				state.activeProviderSystemPrompt !== undefined,
+				[],
+				false,
+				true,
+				"keepalive",
+				cacheKeepaliveRequest,
+			);
+		}
 		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
 			.filter((message) => !isProviderContextExcludedMessage(message));
 		const activeSystemPrompt = state.activeProviderSystemPrompt;
@@ -246,17 +260,8 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		if (activePrewarmKind === "keepalive") prewarmController?.abort();
 	};
 
-	const formatKeepaliveMetrics = (usage: CodexPrewarmUsage, socketReused: boolean | undefined) => {
-		const total = usage.inputTokens + usage.cachedInputTokens;
-		const ratio = total > 0 ? usage.cachedInputTokens / total : undefined;
-		return {
-			ratio,
-			message: `Codex cache keepalive · input ${usage.inputTokens.toLocaleString("en-US")} · read ${usage.cachedInputTokens.toLocaleString("en-US")} · write ${usage.cacheWriteInputTokens.toLocaleString("en-US")} · ${ratio === undefined ? "cache unavailable" : `${(ratio * 100).toFixed(1)}%`} · WS ${socketReused ? "reused" : "new"}`,
-		};
-	};
-
 	const scheduleCacheKeepalive = (ctx: CodexContext, epoch: number) => {
-		if (cacheKeepalivePaused || !state.config.openai.cacheKeepalive) return;
+		if (!state.config.openai.cacheKeepalive) return;
 		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
 		cacheKeepaliveTimer = setTimeout(() => {
 			cacheKeepaliveTimer = undefined;
@@ -270,25 +275,10 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 					scheduleCacheKeepalive(ctx, epoch);
 					return;
 				}
-				if (!result.usage) {
-					consecutiveRedKeepalives = 0;
-					ctx.ui.notify("Codex cache keepalive completed without usage metrics", "warning");
-					scheduleCacheKeepalive(ctx, epoch);
-					return;
-				}
-				const metrics = formatKeepaliveMetrics(result.usage, result.socketReused);
-				if (metrics.ratio !== undefined && metrics.ratio <= 0.1) {
-					consecutiveRedKeepalives++;
-					ctx.ui.notify(metrics.message, "error");
-					if (consecutiveRedKeepalives >= 2) {
-						cacheKeepalivePaused = true;
-						ctx.ui.notify("Codex cache keepalive paused after two consecutive ≤10% reads", "error");
-						return;
-					}
-				} else {
-					consecutiveRedKeepalives = 0;
-					ctx.ui.notify(metrics.message, metrics.ratio !== undefined && metrics.ratio < 0.5 ? "warning" : "info");
-				}
+				ctx.ui.notify(
+					`Codex cache keepalive refreshed · WS ${result.socketReused ? "reused" : "new"}`,
+					"info",
+				);
 				scheduleCacheKeepalive(ctx, epoch);
 			});
 		}, CACHE_KEEPALIVE_INTERVAL_MS);
@@ -297,8 +287,6 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 
 	const armCacheKeepalive = (ctx: CodexContext) => {
 		cancelCacheKeepalive();
-		consecutiveRedKeepalives = 0;
-		cacheKeepalivePaused = false;
 		scheduleCacheKeepalive(ctx, cacheKeepaliveEpoch);
 	};
 
@@ -345,12 +333,16 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		cancelCacheKeepalive() {
 			cancelCacheKeepalive();
 		},
+		captureCacheKeepaliveRequest(payload) {
+			if (state.config.openai.cacheKeepalive) cacheKeepaliveRequest = structuredClone(payload);
+		},
 		resetTransport(sessionId) {
 			cancelCacheKeepalive();
 			prewarmController?.abort();
 			prewarmController = undefined;
 			pendingPrewarmKey = undefined;
 			prewarmedIdentity = undefined;
+			cacheKeepaliveRequest = undefined;
 			state.codexTurnState.reset();
 			if (sessionId) resetOpenAICodexWebSocketSessions(sessionId);
 			else closeOpenAICodexWebSocketSessions();

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -59,6 +59,8 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 		useResponsesLite?: (model: Model<Api>) => boolean;
 		turnState?: CodexTurnState | undefined;
 		getDiagnostics?: (() => CodexDiagnosticsSink | undefined) | undefined;
+		preparedBody?: ResponsesBody | undefined;
+		preserveContinuation?: boolean | undefined;
 	},
 ): Promise<CodexPrewarmResult | undefined> {
 	const runtimeConfig = deps.getConfig?.();
@@ -71,7 +73,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	const effectiveOptions = runtimeConfig?.compaction?.responsesCompaction
 		? { ...options, grammarToolInputProperties, headers: withRemoteCompactionV2Feature(options.headers) }
 		: { ...options, grammarToolInputProperties };
-	const body = await prepareCodexRequestBody(model, context, effectiveOptions, responsesLite);
+	const body = deps.preparedBody ? structuredClone(deps.preparedBody) : await prepareCodexRequestBody(model, context, effectiveOptions, responsesLite);
 	const accountId = extractAccountId(options.apiKey);
 	const routing = resolveCodexRequestRouting({
 		model: body.model,
@@ -80,10 +82,11 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 		normalOriginator: runtimeConfig?.openai.harnessIdentifierHeader ? PI_CODEX_CONVERSION_ORIGINATOR : "pi",
 	});
 	const headers = buildWebSocketHeaders(model.headers, effectiveOptions.headers, accountId, options.apiKey, options.sessionId, routing.originator, routing.routingHint);
-	const websocketBody = withCodexTurnState(responsesLite ? applyResponsesLiteWebSocketMetadata(body) : body, deps.turnState);
+	const turnState = deps.preserveContinuation ? undefined : deps.turnState;
+	const websocketBody = withCodexTurnState(responsesLite ? applyResponsesLiteWebSocketMetadata(body) : body, turnState);
 	const diagnostics = noThrowCodexDiagnosticsSink(deps.getDiagnostics?.());
 	try {
-		return await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, deps.turnState, diagnostics);
+		return await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, turnState, diagnostics, deps.preserveContinuation);
 	} catch (error) {
 		if (!options.signal?.aborted && (isWebSocketUpgradeRequiredError(error) || isWebSocketMessageTooBigError(error))) {
 			recordWebSocketSseFallback(options.sessionId);

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -143,10 +143,12 @@ export async function prewarmWebSocket(
 	options: OpenAICodexStreamOptions,
 	turnState?: CodexTurnState,
 	diagnostics?: CodexDiagnosticsSink | undefined,
+	preserveContinuation = false,
 ): Promise<CodexPrewarmResult> {
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics);
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
-	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, options.sessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
+	const socketSessionId = preserveContinuation ? `${options.sessionId}:cache-keepalive` : options.sessionId;
+	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, socketSessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
 	let keepConnection = true;
 	const responseItems: unknown[] = [];
 	let responseId: string | undefined;
@@ -165,7 +167,9 @@ export async function prewarmWebSocket(
 			previousResponseId: Boolean(body.previous_response_id),
 		});
 		socket.send(JSON.stringify({ type: "response.create", ...body, generate: false }));
-		for await (const event of mapCodexEvents(parseWebSocket(socket, options.signal, idleTimeoutMs, (value) => turnState?.capturePrewarm(value)))) {
+		for await (const event of mapCodexEvents(parseWebSocket(socket, options.signal, idleTimeoutMs, (value) => {
+			if (!preserveContinuation) turnState?.capturePrewarm(value);
+		}))) {
 			if (event.type === "response.created" && event.response?.id) responseId = event.response.id;
 			if (event.type === "response.output_item.done" && event.item) responseItems.push(event.item);
 			if (event.type === "response.completed") {
@@ -184,7 +188,7 @@ export async function prewarmWebSocket(
 			}
 		}
 		assertSuccessfulCodexStatus(responseStatus);
-		if (entry && responseId) {
+		if (!preserveContinuation && entry && responseId) {
 			entry.continuation = { lastRequestBody: body, lastResponseId: responseId, lastResponseItems: responseItems };
 		}
 		recordDiagnostics?.({ type: "prewarm-ready", transport: "websocket", socketReused: reused });


### PR DESCRIPTION
This PR makes idle Codex cache keepalives replay the provider request that established the active cache without disrupting the live response continuation.

## Summary

- capture the final prepared Responses body after Pi and provider request transforms instead of reconstructing idle context
- run `generate:false` refreshes on an isolated cached WebSocket lane so the live `previous_response_id` and turn state remain intact
- report refresh completion without presenting unreliable `generate:false` usage as cache telemetry
- retain the production 25-minute idle interval

## Validation

- `bun run check:changed` — 109 tests, typecheck, extension artifact, and Knip passed
- `bun run changeset:check`
- live Codex retention: 44,800 cached tokens before; six refreshes over 32m39s; 44,800 cached tokens afterward
- post-refresh live request stayed on WebSocket delta continuation, attempt 1

## Release

- Changeset: yes
- Package: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
