### PR TITLE
fix(pi-codex): raise native compaction budget

### DIFF
--- a/.changeset/patch-mt046e4n-190cf0.md
+++ b/.changeset/patch-mt046e4n-190cf0.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Allow native OpenAI Codex compaction requests up to the 872k subscription context budget without truncating tool outputs.

--- a/packages/pi-codex-conversion/src/adapter/compaction/request-shrink.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/request-shrink.ts
@@ -2,7 +2,7 @@ import type { NativeCompactionRequestBody, ResponsesInputItem } from "./serializ
 import { supportsResponsesLiteModel } from "../../providers/openai-codex/responses-lite-model.ts";
 
 export const COMPACTION_TRUNCATED_TOOL_OUTPUT_MESSAGE = "Output exceeded the available model context and was truncated";
-export const OPENAI_CODEX_COMPACTION_ENDPOINT_BUDGET_TOKENS = 372_000;
+export const OPENAI_CODEX_COMPACTION_ENDPOINT_BUDGET_TOKENS = 872_000;
 const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95;
 
 export type NativeCompactionShrinkResult = {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/oauth.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/oauth.ts
@@ -48,8 +48,6 @@ export function getOpenAICodexAccountId(accessToken: string): string | null {
 
 export function clampOpenAICodexModelWindows(models: Model<Api>[]): Model<Api>[] {
 	return models.map((model) =>
-		// Temporary: remove this clamp as soon as OpenAI confirms 372k production
-		// context caching is fixed. Overestimating currently delays Pi compaction.
 		/^gpt-5\.6-(?:luna|terra|sol)$/i.test(model.id) && model.contextWindow > GPT_56_PRODUCTION_CONTEXT_WINDOW
 			? { ...model, contextWindow: GPT_56_PRODUCTION_CONTEXT_WINDOW }
 			: model,


### PR DESCRIPTION
This PR lets native Codex compaction preserve full tool output through the 872k subscription compaction budget.

## Summary

- raise the native Responses compaction request budget from 372k to 872k tokens
- retain tool-output trimming only when a compaction request exceeds that budget

## Validation

- `bun run check:changed`
- `bun run changeset:check`

## Release

- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
