### PR TITLE
Configure GPT shortcut session defaults

### DIFF
--- a/.changeset/patch-mt086j96-793dcd.md
+++ b/.changeset/patch-mt086j96-793dcd.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-gpt-switcher": patch
+---
+
+Add configurable session context windows and reasoning defaults for GPT shortcuts.

--- a/packages/pi-gpt-switcher/README.md
+++ b/packages/pi-gpt-switcher/README.md
@@ -8,8 +8,26 @@ Pi extension adding quick model commands:
 | `/terra [reasoning]` | `openai-codex/gpt-5.6-terra` |
 | `/luna [reasoning]` | `openai-codex/gpt-5.6-luna` |
 
-Reasoning defaults to `high`. Valid arguments are `off`, `minimal`, `low`,
-`medium`, `high`, `xhigh`, and `max`; for example, `/luna low`.
+An explicit reasoning argument overrides the configured default. Valid arguments
+are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; for example,
+`/luna low`.
+
+## Defaults
+
+On first load, the extension creates `pi-gpt-switcher.json` in Pi's global
+agent directory:
+
+```json
+{
+  "sol": { "contextWindow": 272000, "reasoning": "high" },
+  "terra": { "contextWindow": 872000, "reasoning": "high" },
+  "luna": { "contextWindow": 472000, "reasoning": "xhigh" }
+}
+```
+
+Edit the file to change a shortcut's session context window or default
+reasoning. Changes apply on the next shortcut invocation and do not alter the
+provider catalogue.
 
 ## Install
 
@@ -29,8 +47,8 @@ The commands use Pi's model registry and normal provider authentication. If a
 model is unavailable or the OpenAI Codex credentials are missing, the command
 reports that instead of changing the current model.
 
-Reasoning defaults to `high`. Pi clamps the requested level automatically if
-the selected model supports fewer levels.
+Pi clamps the requested reasoning level automatically if the selected model
+supports fewer levels.
 
 ## Local development
 

--- a/packages/pi-gpt-switcher/README.md
+++ b/packages/pi-gpt-switcher/README.md
@@ -27,7 +27,8 @@ agent directory:
 
 Edit the file to change a shortcut's session context window or default
 reasoning. Changes apply on the next shortcut invocation and do not alter the
-provider catalogue.
+provider catalogue. Context windows may be lowered to 128k but not raised
+above the shortcut's shipped limit.
 
 ## Install
 

--- a/packages/pi-gpt-switcher/biome.json
+++ b/packages/pi-gpt-switcher/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/packages/pi-gpt-switcher/codex-model-shortcuts.ts
+++ b/packages/pi-gpt-switcher/codex-model-shortcuts.ts
@@ -5,6 +5,14 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	ensureGptSwitcherConfig,
+	type GptSwitcherConfig,
+	readGptSwitcherConfig,
+	type ShortcutAlias,
+	THINKING_LEVELS,
+	type ThinkingLevel,
+} from "./config.js";
 
 const MODELS = {
 	sol: "gpt-5.6-sol",
@@ -12,41 +20,32 @@ const MODELS = {
 	luna: "gpt-5.6-luna",
 } as const;
 
-type Alias = keyof typeof MODELS;
-type ThinkingLevel =
-	| "off"
-	| "minimal"
-	| "low"
-	| "medium"
-	| "high"
-	| "xhigh"
-	| "max";
+type Alias = keyof typeof MODELS & ShortcutAlias;
 
-const DEFAULT_THINKING_LEVEL: ThinkingLevel = "high";
-const THINKING_LEVELS = new Set<ThinkingLevel>([
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-	"max",
-]);
-
-function parseThinkingLevel(args: string): ThinkingLevel | undefined {
+function parseThinkingLevel(
+	args: string,
+	defaultThinkingLevel: ThinkingLevel,
+): ThinkingLevel | undefined {
 	const requested = args.trim().toLowerCase();
-	if (requested === "") return DEFAULT_THINKING_LEVEL;
+	if (requested === "") return defaultThinkingLevel;
 	return THINKING_LEVELS.has(requested as ThinkingLevel)
 		? (requested as ThinkingLevel)
 		: undefined;
 }
 
-export default function (pi: ExtensionAPI) {
+export default function (
+	pi: ExtensionAPI,
+	options: { getConfig?: () => GptSwitcherConfig } = {},
+) {
+	const getConfig = options.getConfig ?? readGptSwitcherConfig;
+	if (!options.getConfig) ensureGptSwitcherConfig();
+
 	for (const alias of Object.keys(MODELS) as Alias[]) {
 		pi.registerCommand(alias, {
 			description: `Switch to GPT-5.6 ${alias.charAt(0).toUpperCase()}${alias.slice(1)}`,
 			handler: async (args, ctx) => {
-				const thinkingLevel = parseThinkingLevel(args);
+				const defaults = getConfig()[alias];
+				const thinkingLevel = parseThinkingLevel(args, defaults.reasoning);
 				if (!thinkingLevel) {
 					ctx.ui.notify(
 						`Usage: /${alias} [off|minimal|low|medium|high|xhigh|max]`,
@@ -63,12 +62,18 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 
+				const selectedModel = {
+					...model,
+					contextWindow: defaults.contextWindow,
+				};
 				const alreadySelected =
-					ctx.model?.provider === "openai-codex" && ctx.model.id === modelId;
+					ctx.model?.provider === "openai-codex" &&
+					ctx.model.id === modelId &&
+					ctx.model.contextWindow === defaults.contextWindow;
 				if (!alreadySelected) {
 					let switched: boolean;
 					try {
-						switched = await pi.setModel(model);
+						switched = await pi.setModel(selectedModel);
 					} catch (error) {
 						ctx.ui.notify(
 							`Could not switch to ${model.name}: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/pi-gpt-switcher/config.ts
+++ b/packages/pi-gpt-switcher/config.ts
@@ -1,0 +1,158 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const SHORTCUT_ALIASES = ["sol", "terra", "luna"] as const;
+export type ShortcutAlias = (typeof SHORTCUT_ALIASES)[number];
+export type ThinkingLevel =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+export const THINKING_LEVELS = new Set<ThinkingLevel>([
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+]);
+
+export type ShortcutDefaults = {
+	contextWindow: number;
+	reasoning: ThinkingLevel;
+};
+
+export type GptSwitcherConfig = Record<ShortcutAlias, ShortcutDefaults>;
+
+export const DEFAULT_GPT_SWITCHER_CONFIG: GptSwitcherConfig = {
+	sol: { contextWindow: 272_000, reasoning: "high" },
+	terra: { contextWindow: 872_000, reasoning: "high" },
+	luna: { contextWindow: 472_000, reasoning: "xhigh" },
+};
+
+const CONFIG_BASENAME = "pi-gpt-switcher.json";
+const MAX_CONTEXT_WINDOW = 872_000;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function configurationError(message: string): void {
+	console.warn(`[pi-gpt-switcher] ${message}`);
+}
+
+function normalizeContextWindow(
+	value: unknown,
+	fallback: number,
+	alias: ShortcutAlias,
+): number {
+	if (value === undefined) return fallback;
+	if (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value > 0 &&
+		value <= MAX_CONTEXT_WINDOW
+	)
+		return value;
+	configurationError(
+		`${alias}.contextWindow must be a positive integer up to ${MAX_CONTEXT_WINDOW}; using the default`,
+	);
+	return fallback;
+}
+
+function normalizeReasoning(
+	value: unknown,
+	fallback: ThinkingLevel,
+	alias: ShortcutAlias,
+): ThinkingLevel {
+	if (value === undefined) return fallback;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (THINKING_LEVELS.has(normalized as ThinkingLevel))
+			return normalized as ThinkingLevel;
+	}
+	configurationError(
+		`${alias}.reasoning must be a supported Pi thinking level; using the default`,
+	);
+	return fallback;
+}
+
+export function normalizeGptSwitcherConfig(value: unknown): GptSwitcherConfig {
+	if (!isObject(value)) {
+		configurationError("configuration must be a JSON object; using defaults");
+		return structuredClone(DEFAULT_GPT_SWITCHER_CONFIG);
+	}
+
+	return Object.fromEntries(
+		SHORTCUT_ALIASES.map((alias) => {
+			const defaults = DEFAULT_GPT_SWITCHER_CONFIG[alias];
+			const configured = value[alias];
+			if (configured === undefined) return [alias, { ...defaults }];
+			if (!isObject(configured)) {
+				configurationError(`${alias} must be an object; using defaults`);
+				return [alias, { ...defaults }];
+			}
+			return [
+				alias,
+				{
+					contextWindow: normalizeContextWindow(
+						configured["contextWindow"],
+						defaults.contextWindow,
+						alias,
+					),
+					reasoning: normalizeReasoning(
+						configured["reasoning"],
+						defaults.reasoning,
+						alias,
+					),
+				},
+			];
+		}),
+	) as GptSwitcherConfig;
+}
+
+export function getGptSwitcherConfigPath(
+	agentDir: string = getAgentDir(),
+): string {
+	return join(agentDir, CONFIG_BASENAME);
+}
+
+export function ensureGptSwitcherConfig(
+	configPath: string = getGptSwitcherConfigPath(),
+): void {
+	if (existsSync(configPath)) return;
+	try {
+		mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });
+		writeFileSync(
+			configPath,
+			`${JSON.stringify(DEFAULT_GPT_SWITCHER_CONFIG, null, 2)}\n`,
+			{ encoding: "utf8", mode: 0o600, flag: "wx" },
+		);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+		configurationError(
+			`could not create ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+export function readGptSwitcherConfig(
+	configPath: string = getGptSwitcherConfigPath(),
+): GptSwitcherConfig {
+	try {
+		return normalizeGptSwitcherConfig(
+			JSON.parse(readFileSync(configPath, "utf8")) as unknown,
+		);
+	} catch (error) {
+		configurationError(
+			`could not read ${configPath}: ${error instanceof Error ? error.message : String(error)}; using defaults`,
+		);
+		return structuredClone(DEFAULT_GPT_SWITCHER_CONFIG);
+	}
+}

--- a/packages/pi-gpt-switcher/config.ts
+++ b/packages/pi-gpt-switcher/config.ts
@@ -37,7 +37,7 @@ export const DEFAULT_GPT_SWITCHER_CONFIG: GptSwitcherConfig = {
 };
 
 const CONFIG_BASENAME = "pi-gpt-switcher.json";
-const MAX_CONTEXT_WINDOW = 872_000;
+const MIN_CONTEXT_WINDOW = 128_000;
 
 function isObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -56,12 +56,12 @@ function normalizeContextWindow(
 	if (
 		typeof value === "number" &&
 		Number.isSafeInteger(value) &&
-		value > 0 &&
-		value <= MAX_CONTEXT_WINDOW
+		value >= MIN_CONTEXT_WINDOW &&
+		value <= fallback
 	)
 		return value;
 	configurationError(
-		`${alias}.contextWindow must be a positive integer up to ${MAX_CONTEXT_WINDOW}; using the default`,
+		`${alias}.contextWindow must be an integer from ${MIN_CONTEXT_WINDOW} to ${fallback}; using the default`,
 	);
 	return fallback;
 }

--- a/packages/pi-gpt-switcher/package.json
+++ b/packages/pi-gpt-switcher/package.json
@@ -31,6 +31,7 @@
 	"files": [
 		"index.ts",
 		"codex-model-shortcuts.ts",
+		"config.ts",
 		"README.md",
 		"LICENSE",
 		"tsconfig.json",

--- a/packages/pi-gpt-switcher/tests/extension.test.ts
+++ b/packages/pi-gpt-switcher/tests/extension.test.ts
@@ -8,58 +8,6 @@ import gptSwitcher from "../index.js";
 
 type CommandHandler = (args: string, ctx: ExtensionContext) => unknown;
 
-test("registers model commands and switches model plus reasoning level", async () => {
-	const commands = new Map<string, { handler: CommandHandler }>();
-	const notifications: string[] = [];
-	const model = { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" };
-	let selectedModel: unknown;
-	let selectedThinkingLevel: unknown;
-	let currentThinkingLevel = "high";
-
-	gptSwitcher(
-		{
-			registerCommand(name, options) {
-				commands.set(name, options as { handler: CommandHandler });
-			},
-			setModel: async (next) => {
-				selectedModel = next;
-				return true;
-			},
-			setThinkingLevel: (level) => {
-				selectedThinkingLevel = level;
-				currentThinkingLevel = level;
-			},
-			getThinkingLevel: () => currentThinkingLevel,
-		} as unknown as ExtensionAPI,
-		{
-			getConfig: () => structuredClone(DEFAULT_GPT_SWITCHER_CONFIG),
-		},
-	);
-
-	const ctx = {
-		model: undefined,
-		modelRegistry: {
-			find(provider: string, id: string) {
-				expect(provider).toBe("openai-codex");
-				expect(id).toBe("gpt-5.6-luna");
-				return model;
-			},
-		},
-		ui: {
-			notify(message: string) {
-				notifications.push(message);
-			},
-		},
-	} as unknown as ExtensionContext;
-
-	expect([...commands.keys()]).toEqual(["sol", "terra", "luna"]);
-	await commands.get("luna")?.handler("", ctx);
-
-	expect(selectedModel).toEqual({ ...model, contextWindow: 472_000 });
-	expect(selectedThinkingLevel).toBe("xhigh");
-	expect(notifications).toEqual(["Switched to GPT-5.6 Luna (xhigh)"]);
-});
-
 test("reports model authentication failures without changing reasoning", async () => {
 	const notifications: string[] = [];
 	const pi = {

--- a/packages/pi-gpt-switcher/tests/extension.test.ts
+++ b/packages/pi-gpt-switcher/tests/extension.test.ts
@@ -3,6 +3,7 @@ import type {
 	ExtensionAPI,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_GPT_SWITCHER_CONFIG } from "../config.js";
 import gptSwitcher from "../index.js";
 
 type CommandHandler = (args: string, ctx: ExtensionContext) => unknown;
@@ -15,20 +16,25 @@ test("registers model commands and switches model plus reasoning level", async (
 	let selectedThinkingLevel: unknown;
 	let currentThinkingLevel = "high";
 
-	gptSwitcher({
-		registerCommand(name, options) {
-			commands.set(name, options as { handler: CommandHandler });
+	gptSwitcher(
+		{
+			registerCommand(name, options) {
+				commands.set(name, options as { handler: CommandHandler });
+			},
+			setModel: async (next) => {
+				selectedModel = next;
+				return true;
+			},
+			setThinkingLevel: (level) => {
+				selectedThinkingLevel = level;
+				currentThinkingLevel = level;
+			},
+			getThinkingLevel: () => currentThinkingLevel,
+		} as unknown as ExtensionAPI,
+		{
+			getConfig: () => structuredClone(DEFAULT_GPT_SWITCHER_CONFIG),
 		},
-		setModel: async (next) => {
-			selectedModel = next;
-			return true;
-		},
-		setThinkingLevel: (level) => {
-			selectedThinkingLevel = level;
-			currentThinkingLevel = level;
-		},
-		getThinkingLevel: () => currentThinkingLevel,
-	} as unknown as ExtensionAPI);
+	);
 
 	const ctx = {
 		model: undefined,
@@ -47,11 +53,11 @@ test("registers model commands and switches model plus reasoning level", async (
 	} as unknown as ExtensionContext;
 
 	expect([...commands.keys()]).toEqual(["sol", "terra", "luna"]);
-	await commands.get("luna")?.handler("low", ctx);
+	await commands.get("luna")?.handler("", ctx);
 
-	expect(selectedModel).toBe(model);
-	expect(selectedThinkingLevel).toBe("low");
-	expect(notifications).toEqual(["Switched to GPT-5.6 Luna (low)"]);
+	expect(selectedModel).toEqual({ ...model, contextWindow: 472_000 });
+	expect(selectedThinkingLevel).toBe("xhigh");
+	expect(notifications).toEqual(["Switched to GPT-5.6 Luna (xhigh)"]);
 });
 
 test("reports model authentication failures without changing reasoning", async () => {
@@ -80,7 +86,9 @@ test("reports model authentication failures without changing reasoning", async (
 		commands.set(name, options);
 	}) as typeof pi.registerCommand;
 
-	gptSwitcher(pi);
+	gptSwitcher(pi, {
+		getConfig: () => structuredClone(DEFAULT_GPT_SWITCHER_CONFIG),
+	});
 	await commands.get("sol")?.handler("", ctx);
 
 	expect(notifications).toEqual([


### PR DESCRIPTION
This PR makes GPT shortcut context and reasoning defaults configurable per active Pi session.

## Summary

- Create Pi's global `pi-gpt-switcher.json` with Luna 472k/xhigh, Sol 272k/high, and Terra 872k/high defaults
- Apply configured context metadata only to the selected session model
- Bound overrides to each model's supported window

## Validation

- `bun run check:changed`
- `bun run changeset:check origin/main`
- `bun run --cwd packages/pi-gpt-switcher pack:dry`

## Release

- Changeset: yes
- Packages: `@howaboua/pi-gpt-switcher`
- Aggregates: generated by release automation
