### PR TITLE
Fix Codex cache refresh for long idle sessions

### DIFF
--- a/.changeset/patch-mt2nxg09-c1a60c.md
+++ b/.changeset/patch-mt2nxg09-c1a60c.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Keep long Codex sessions cached through idle periods by generating and discarding an isolated completion over the complete settled context every 25 minutes. Resume transport from the complete current branch instead of a system-only baseline, and add named diagnostics with socket, continuation, and authoritative refresh usage.

--- a/packages/pi-codex-conversion/src/adapter/activation/cache-experiment.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/cache-experiment.ts
@@ -1,0 +1,88 @@
+export const CODEX_CACHE_KEEPALIVE_STRATEGIES = [
+	"generated-current",
+] as const;
+
+export type CodexCacheKeepaliveStrategy =
+	(typeof CODEX_CACHE_KEEPALIVE_STRATEGIES)[number];
+
+export const DEFAULT_CODEX_CACHE_KEEPALIVE_INTERVAL_MS = 25 * 60 * 1_000;
+const MIN_CODEX_CACHE_KEEPALIVE_INTERVAL_MS = 60 * 1_000;
+const MAX_CODEX_CACHE_KEEPALIVE_INTERVAL_MS = 30 * 60 * 1_000;
+
+export interface CodexCacheExperimentEnvironment {
+	keepalive?: CodexCacheKeepaliveStrategy | false | undefined;
+	keepaliveIntervalMs: number;
+	diagnostics?: "off" | "status" | "status-and-log" | undefined;
+	logName?: string | undefined;
+	warnings: string[];
+}
+
+function normalizeKeepalive(value: string): CodexCacheKeepaliveStrategy | false | undefined {
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "off" || normalized === "false" || normalized === "0") return false;
+	return (CODEX_CACHE_KEEPALIVE_STRATEGIES as readonly string[]).includes(normalized)
+		? normalized as CodexCacheKeepaliveStrategy
+		: undefined;
+}
+
+export function readCodexCacheExperimentEnvironment(
+	env: NodeJS.ProcessEnv = process.env,
+): CodexCacheExperimentEnvironment {
+	const warnings: string[] = [];
+	const rawKeepalive = env["PI_CODEX_CACHE_KEEPALIVE"];
+	const parsedKeepalive = rawKeepalive === undefined ? undefined : normalizeKeepalive(rawKeepalive);
+	const keepalive = rawKeepalive !== undefined && parsedKeepalive === undefined
+		? false
+		: parsedKeepalive;
+	if (rawKeepalive !== undefined && parsedKeepalive === undefined) {
+		warnings.push(
+			`PI_CODEX_CACHE_KEEPALIVE must be off, ${CODEX_CACHE_KEEPALIVE_STRATEGIES.join(", ")}`,
+		);
+	}
+
+	const rawInterval = env["PI_CODEX_CACHE_KEEPALIVE_INTERVAL_MS"];
+	let keepaliveIntervalMs = DEFAULT_CODEX_CACHE_KEEPALIVE_INTERVAL_MS;
+	if (rawInterval !== undefined) {
+		const value = Number(rawInterval);
+		if (
+			Number.isSafeInteger(value)
+			&& value >= MIN_CODEX_CACHE_KEEPALIVE_INTERVAL_MS
+			&& value <= MAX_CODEX_CACHE_KEEPALIVE_INTERVAL_MS
+		) {
+			keepaliveIntervalMs = value;
+		} else {
+			warnings.push(
+				`PI_CODEX_CACHE_KEEPALIVE_INTERVAL_MS must be an integer from ${MIN_CODEX_CACHE_KEEPALIVE_INTERVAL_MS} to ${MAX_CODEX_CACHE_KEEPALIVE_INTERVAL_MS}`,
+			);
+		}
+	}
+
+	const rawDiagnostics = env["PI_CODEX_CACHE_DIAGNOSTICS"]?.trim().toLowerCase();
+	const diagnostics = rawDiagnostics === "off" || rawDiagnostics === "status" || rawDiagnostics === "status-and-log"
+		? rawDiagnostics
+		: undefined;
+	if (rawDiagnostics !== undefined && diagnostics === undefined) {
+		warnings.push(
+			"PI_CODEX_CACHE_DIAGNOSTICS must be off, status, or status-and-log",
+		);
+	}
+
+	const rawLogName = env["PI_CODEX_CACHE_LOG_NAME"]?.trim();
+	const logName = rawLogName && Buffer.byteLength(rawLogName) <= 80 ? rawLogName : undefined;
+	if (rawLogName && !logName) warnings.push("PI_CODEX_CACHE_LOG_NAME must be at most 80 bytes");
+
+	return {
+		...(keepalive !== undefined ? { keepalive } : {}),
+		keepaliveIntervalMs,
+		...(diagnostics !== undefined ? { diagnostics } : {}),
+		...(logName ? { logName } : {}),
+		warnings,
+	};
+}
+
+export function resolveCodexCacheKeepaliveStrategy(
+	configured: boolean,
+	experiment: CodexCacheExperimentEnvironment,
+): CodexCacheKeepaliveStrategy | false {
+	return experiment.keepalive ?? (configured ? "generated-current" : false);
+}

--- a/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
+++ b/packages/pi-codex-conversion/src/adapter/activation/config-store.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { migrateCodexConversionConfigIfNeeded } from "./config-migration.ts";
 import { DEFAULT_CODEX_CONVERSION_CONFIG, normalizeCodexConversionConfig, type CodexConversionConfig } from "./config.ts";
+import { readCodexCacheExperimentEnvironment } from "./cache-experiment.ts";
 
 // Lite deliberately shares the original package's config so replacing either
 // package does not require a reset or a second settings file.
@@ -126,11 +127,30 @@ export function hasFolderCodexConversionConfig(cwd: string, projectTrusted: bool
 }
 
 function applyProcessOverrides(config: CodexConversionConfig, env: NodeJS.ProcessEnv): CodexConversionConfig {
+	const cacheExperiment = readCodexCacheExperimentEnvironment(env);
 	const fast = env["PI_CODEX_FAST"]?.trim().toLowerCase();
-	if (fast !== "1" && fast !== "true" && fast !== "0" && fast !== "false") return config;
+	const fastOverride = fast === "1" || fast === "true"
+		? true
+		: fast === "0" || fast === "false"
+			? false
+			: undefined;
+	if (
+		fastOverride === undefined
+		&& cacheExperiment.keepalive === undefined
+		&& cacheExperiment.diagnostics === undefined
+	) return config;
 	return {
 		...config,
-		openai: { ...config.openai, fast: fast === "1" || fast === "true" },
+		openai: {
+			...config.openai,
+			...(fastOverride !== undefined ? { fast: fastOverride } : {}),
+			...(cacheExperiment.keepalive !== undefined
+				? { cacheKeepalive: cacheExperiment.keepalive !== false }
+				: {}),
+			...(cacheExperiment.diagnostics !== undefined
+				? { cacheDiagnostics: cacheExperiment.diagnostics }
+				: {}),
+		},
 	};
 }
 

--- a/packages/pi-codex-conversion/src/diagnostics/lazy.ts
+++ b/packages/pi-codex-conversion/src/diagnostics/lazy.ts
@@ -17,6 +17,7 @@ export interface LazyCodexDiagnostics {
 		active: boolean;
 		ctx: ExtensionContext;
 		agentDir: string;
+		logName?: string | undefined;
 		announceLog?: boolean | undefined;
 	}): Promise<void>;
 	sink(): CodexDiagnosticsSink | undefined;
@@ -66,6 +67,7 @@ export function createLazyCodexDiagnostics(): LazyCodexDiagnostics {
 				model?.id,
 				model?.api,
 				model?.baseUrl,
+				options.logName,
 			]);
 			if (active?.key === key && options.active) return;
 			const currentGeneration = ++generation;

--- a/packages/pi-codex-conversion/src/diagnostics/logger.ts
+++ b/packages/pi-codex-conversion/src/diagnostics/logger.ts
@@ -26,12 +26,15 @@ export function codexDiagnosticsLogPath(options: {
 	sessionId: string;
 	sessionFile?: string | undefined;
 	sessionName?: string | undefined;
+	logName?: string | undefined;
 }): string {
 	const sessionFileStem = options.sessionFile
 		? safeFilenamePart(basename(options.sessionFile, ".jsonl"))
 		: "";
 	const identity = sessionFileStem || safeFilenamePart(options.sessionId) || "session";
-	const name = options.sessionName ? safeFilenamePart(options.sessionName) : "";
+	const name = options.logName
+		? safeFilenamePart(options.logName)
+		: options.sessionName ? safeFilenamePart(options.sessionName) : "";
 	return join(options.agentDir, LOG_DIRECTORY_BASENAME, `${name ? `${name}--` : ""}${identity}.log`);
 }
 
@@ -56,8 +59,15 @@ function eventFields(event: CodexDiagnosticsEvent): Array<string | undefined> {
 		field("transport", event.transport),
 		field("attempt", event.attempt),
 		field("socket", event.socketReused === undefined ? undefined : event.socketReused ? "reused" : "new"),
+		field("socket_age_ms", event.socketAgeMs),
+		field("socket_lane", event.socketLane),
 		field("continuation", event.continuation),
+		field("continuation_input_items", event.continuationBaselineInputItems),
+		field("continuation_response_items", event.continuationBaselineResponseItems),
 		field("canonical_history", event.canonicalHistory),
+		field("prewarm_kind", event.prewarm?.kind),
+		field("keepalive_strategy", event.prewarm?.keepaliveStrategy),
+		field("request_source", event.prewarm?.requestSource),
 		field("previous_response_id", event.previousResponseId),
 		field("full_input_items", event.fullInputItems),
 		field("sent_input_items", event.sentInputItems),
@@ -93,7 +103,35 @@ function eventFields(event: CodexDiagnosticsEvent): Array<string | undefined> {
 		field("event", event.type), field("lane", event.lane), field("transport", event.transport),
 		field("failure", event.failure.category), field("code", event.failure.code), field("status", event.failure.status),
 	];
-	return [field("event", event.type), field("transport", event.transport), field("socket", event.socketReused ? "reused" : "new")];
+	if (event.type === "prewarm-ready") {
+		const generatedRefresh = event.prewarm.keepaliveStrategy === "generated-current";
+		const totalInput = event.usage
+			? event.usage.inputTokens + event.usage.cachedInputTokens + event.usage.cacheWriteInputTokens
+			: undefined;
+		return [
+			field("event", event.type),
+			field("transport", event.transport),
+			field("socket", event.socketReused ? "reused" : "new"),
+			field("socket_age_ms", event.socketAgeMs),
+			field("socket_lane", event.socketLane),
+			field("prewarm_kind", event.prewarm.kind),
+			field("keepalive_strategy", event.prewarm.keepaliveStrategy),
+			field("request_source", event.prewarm.requestSource),
+			field("input_tokens", totalInput),
+			field("cache_read", event.usage?.cachedInputTokens),
+			field("cache_write", event.usage?.cacheWriteInputTokens),
+			field("output_tokens", event.usage?.outputTokens),
+			field("cache_usage", event.usage ? generatedRefresh ? "authoritative" : "non_authoritative" : "unavailable"),
+		];
+	}
+	return [
+		field("event", event.type),
+		field("phase", event.phase),
+		field("keepalive_strategy", event.strategy),
+		field("interval_ms", event.intervalMs),
+		field("request_source", event.requestSource),
+		field("action", event.action),
+	];
 }
 
 function formatEvent(event: CodexDiagnosticsEvent): string {
@@ -104,6 +142,7 @@ export async function createCodexDiagnosticsLog(options: {
 	sessionId: string;
 	sessionFile?: string | undefined;
 	sessionName?: string | undefined;
+	logName?: string | undefined;
 	cwd: string;
 	modelProvider?: string | undefined;
 	modelId?: string | undefined;
@@ -116,6 +155,7 @@ export async function createCodexDiagnosticsLog(options: {
 		sessionId: options.sessionId,
 		sessionFile: options.sessionFile,
 		sessionName: options.sessionName,
+		logName: options.logName,
 	});
 	await mkdir(join(agentDir, LOG_DIRECTORY_BASENAME), { recursive: true, mode: 0o700 });
 	const header = [
@@ -124,6 +164,7 @@ export async function createCodexDiagnosticsLog(options: {
 		`# opened=${new Date().toISOString()}`,
 		`# session_id=${JSON.stringify(options.sessionId)}`,
 		`# session_name=${JSON.stringify(options.sessionName ?? "")}`,
+		`# log_name=${JSON.stringify(options.logName ?? "")}`,
 		`# session_file=${JSON.stringify(options.sessionFile ?? "")}`,
 		`# cwd=${JSON.stringify(options.cwd)}`,
 		`# model=${JSON.stringify([options.modelProvider, options.modelId].filter(Boolean).join("/") || "")}`,

--- a/packages/pi-codex-conversion/src/diagnostics/runtime.ts
+++ b/packages/pi-codex-conversion/src/diagnostics/runtime.ts
@@ -43,6 +43,7 @@ export async function createCodexDiagnosticsRuntime(options: {
 	mode: Exclude<CacheDiagnosticsMode, "off">;
 	ctx: ExtensionContext;
 	agentDir: string;
+	logName?: string | undefined;
 	announceLog?: boolean | undefined;
 	missHoldMs?: number | undefined;
 }): Promise<CodexDiagnosticsRuntime> {
@@ -97,6 +98,7 @@ export async function createCodexDiagnosticsRuntime(options: {
 				sessionId: ctx.sessionManager.getSessionId(),
 				sessionFile: ctx.sessionManager.getSessionFile(),
 				sessionName: ctx.sessionManager.getSessionName(),
+				logName: options.logName,
 				cwd: ctx.cwd,
 				modelProvider: ctx.model?.provider,
 				modelId: ctx.model?.id,
@@ -134,9 +136,18 @@ export async function createCodexDiagnosticsRuntime(options: {
 				return;
 			}
 			if (event.type === "prewarm-ready") {
-				showCurrent(`prewarm ready • WS ${event.socketReused ? "reused" : "new"}`);
+				const strategy = event.prewarm.keepaliveStrategy;
+				if (strategy === "generated-current" && event.usage) {
+					const totalInput = event.usage.inputTokens + event.usage.cachedInputTokens + event.usage.cacheWriteInputTokens;
+					const suffix = `${strategy} • ${event.usage.cachedInputTokens > 0 ? "HIT" : "MISS"} • WS ${event.socketReused ? "reused" : "new"}`;
+					if (event.usage.cachedInputTokens > 0 || totalInput === 0) showCurrent(suffix);
+					else holdMiss(suffix);
+					return;
+				}
+				showCurrent(`${strategy ?? event.prewarm.kind} ready • WS ${event.socketReused ? "reused" : "new"}`);
 				return;
 			}
+			if (event.type === "keepalive") return;
 			if (event.type === "retry") {
 				showCurrent(`${laneLabel(event.lane) ? `${laneLabel(event.lane)} • ` : ""}${event.transport === "websocket" ? "WS" : "SSE"} retry ${event.attempt}`);
 				return;

--- a/packages/pi-codex-conversion/src/extension/register.ts
+++ b/packages/pi-codex-conversion/src/extension/register.ts
@@ -26,7 +26,6 @@ export async function registerCodexConversion(pi: ExtensionAPI): Promise<void> {
 			turnState: runtime.state.codexTurnState,
 			getDiagnostics: () => runtime.diagnosticsSink(),
 			onPreparedPayload: (payload) => {
-				runtime.captureCacheKeepaliveRequest(payload);
 				if (!runtime.state.pendingActiveProviderPromptCapture) return;
 				captureActiveProviderSystemPrompt(payload, runtime.state);
 				runtime.state.pendingActiveProviderPromptCapture = false;

--- a/packages/pi-codex-conversion/src/extension/runtime.ts
+++ b/packages/pi-codex-conversion/src/extension/runtime.ts
@@ -2,6 +2,7 @@ import { buildSessionContext, convertToLlm, type ExtensionAPI, type ExtensionCon
 import type { Context } from "@earendil-works/pi-ai";
 import { dirname } from "node:path";
 import type { CodexConversionConfig } from "../adapter/activation/config.ts";
+import { readCodexCacheExperimentEnvironment, resolveCodexCacheKeepaliveStrategy, type CodexCacheKeepaliveStrategy } from "../adapter/activation/cache-experiment.ts";
 import { getCodexConversionConfigPath, readEffectiveCodexConversionConfig } from "../adapter/activation/config-store.ts";
 import { isAdapterRuntime, resolveCodexRuntimePlan, resolveCodexRuntimePlanForState } from "../adapter/activation/runtime-plan.ts";
 import type { AdapterState } from "../adapter/activation/state.ts";
@@ -12,7 +13,7 @@ import { buildCodexSystemPrompt, type PiSystemPromptOptions } from "../prompt/bu
 import { closeOpenAICodexWebSocketSessions, prewarmOpenAICodexWebSocket } from "../providers/openai-codex-custom-provider.ts";
 import { resetOpenAICodexWebSocketSessions } from "../providers/openai-codex/websocket.ts";
 import { createCodexTurnState } from "../providers/openai-codex/turn-state.ts";
-import type { CodexPrewarmUsage, OpenAICodexStreamOptions, ResponsesBody } from "../providers/openai-codex/types.ts";
+import type { CodexPrewarmUsage, OpenAICodexStreamOptions } from "../providers/openai-codex/types.ts";
 import { createExecCommandTracker } from "../tools/exec/command-state.ts";
 import { createExecSessionManager } from "../tools/exec/session-manager.ts";
 import { getBundledToolBinaryPath } from "../tools/native/binary.ts";
@@ -45,7 +46,6 @@ export interface CodexExtensionRuntime {
 	startKeepalivePrewarm(ctx: CodexContext): Promise<CodexPrewarmResult> | undefined;
 	armCacheKeepalive(ctx: CodexContext): void;
 	cancelCacheKeepalive(): void;
-	captureCacheKeepaliveRequest(payload: ResponsesBody): void;
 	resetTransport(sessionId?: string): void;
 	resetTransportAfterCompaction(sessionId: string): void;
 	shutdownTransport(sessionId: string): void;
@@ -55,8 +55,6 @@ export interface CodexExtensionRuntime {
 	diagnosticsSink(): CodexDiagnosticsSink | undefined;
 	shutdownDiagnostics(): Promise<void>;
 }
-
-const CACHE_KEEPALIVE_INTERVAL_MS = 25 * 60 * 1000;
 
 function activeToolContext(pi: ExtensionAPI): NonNullable<Context["tools"]> {
 	// Pi ToolInfo omits constrainedSampling; restore our owned exec contract so
@@ -69,6 +67,10 @@ function prewarmReasoningOption(level: ReturnType<ExtensionAPI["getThinkingLevel
 }
 
 export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRuntime {
+	const cacheExperiment = readCodexCacheExperimentEnvironment();
+	for (const warning of cacheExperiment.warnings) {
+		console.warn(`[pi-codex-conversion] ${warning}`);
+	}
 	const initialConfig = readEffectiveCodexConversionConfig({ cwd: process.cwd(), projectTrusted: false });
 	const state: AdapterState = {
 		enabled: false,
@@ -87,13 +89,13 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	let prewarmPromise: Promise<CodexPrewarmResult> | undefined;
 	let prewarmTransportSettlement: Promise<unknown> | undefined;
 	let pendingPrewarmKey: string | undefined;
-	let prewarmedIdentity: string | undefined;
-	let activePrewarmKind: "ordinary" | "keepalive" | undefined;
+	let prewarmedKey: string | undefined;
+	let activePrewarmKind: "ordinary" | "compaction" | "keepalive" | undefined;
 	let cacheKeepaliveTimer: ReturnType<typeof setTimeout> | undefined;
 	let cacheKeepaliveEpoch = 0;
-	let cacheKeepaliveRequest: ResponsesBody | undefined;
 	const voice = new CodexVoiceController(pi);
 	const diagnostics = createLazyCodexDiagnostics();
+	let cacheExperimentWarningsReported = false;
 	const buildPrewarmPlan = (
 		ctx: CodexContext,
 		systemPrompt: string,
@@ -143,16 +145,20 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		messages: Context["messages"] = [],
 		rewriteFinalRequest = false,
 		force = false,
-		kind: "ordinary" | "keepalive" = "ordinary",
-		preparedBody?: ResponsesBody,
+		kind: "ordinary" | "compaction" | "keepalive" = "ordinary",
+		preserveContinuation = false,
+		keepaliveStrategy?: CodexCacheKeepaliveStrategy,
+		requestSource?: "captured" | "reconstructed",
+		generate = false,
 	): Promise<CodexPrewarmResult> | undefined => {
 		const plan = buildPrewarmPlan(ctx, systemPrompt, prepared, messages, rewriteFinalRequest);
 		if (!plan) return undefined;
-		const { model, config, executionMode, preparedSystemPrompt, tools, reasoning, identity, key: prewarmKey } = plan;
+		const { model, config, executionMode, preparedSystemPrompt, tools, reasoning, key: requestKey } = plan;
+		const prewarmKey = JSON.stringify({ requestKey, preserveContinuation, generate });
 		if (pendingPrewarmKey === prewarmKey) return prewarmPromise;
-		if (!force && !pendingPrewarmKey && prewarmedIdentity === identity) return undefined;
+		if (!force && !pendingPrewarmKey && prewarmedKey === prewarmKey) return undefined;
 		const previousTransportSettlement = prewarmTransportSettlement;
-		prewarmedIdentity = undefined;
+		prewarmedKey = undefined;
 		prewarmController?.abort();
 		const controller = new AbortController();
 		prewarmController = controller;
@@ -191,7 +197,13 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 						useResponsesLite: (currentModel) => resolveCodexRuntimePlan({ model: currentModel }, config, executionMode).transport === "responses-lite",
 						turnState: state.codexTurnState,
 						getDiagnostics: () => diagnostics.sink(),
-						...(preparedBody ? { preparedBody, preserveContinuation: true } : {}),
+						...(preserveContinuation ? { preserveContinuation: true } : {}),
+						prewarmDiagnostics: {
+							kind,
+							...(keepaliveStrategy ? { keepaliveStrategy } : {}),
+							...(requestSource ? { requestSource } : {}),
+						},
+						...(generate ? { generate: true } : {}),
 					},
 				);
 				prewarmTransportSettlement = transportSettlement;
@@ -199,7 +211,7 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 					const result = await transportSettlement;
 					if (controller.signal.aborted) return { status: "aborted" } as const;
 					if (!result) return { status: "skipped" } as const;
-					prewarmedIdentity = identity;
+					if (kind !== "keepalive") prewarmedKey = prewarmKey;
 					return { status: "ready", ...(result.usage ? { usage: result.usage } : {}), socketReused: result.socketReused } as const;
 				} finally {
 					if (prewarmTransportSettlement === transportSettlement) prewarmTransportSettlement = undefined;
@@ -226,30 +238,30 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		return promise;
 	};
 
-	const currentContextPrewarm = (ctx: CodexContext, force: boolean) => {
-		if (force && cacheKeepaliveRequest) {
-			return startPrewarm(
-				ctx,
-				state.activeProviderSystemPrompt ?? ctx.getSystemPrompt(),
-				state.activeProviderSystemPrompt !== undefined,
-				[],
-				false,
-				true,
-				"keepalive",
-				cacheKeepaliveRequest,
-			);
-		}
-		const messages = buildSessionContext(ctx.sessionManager.getBranch()).messages
-			.filter((message) => !isProviderContextExcludedMessage(message));
+	const currentMessages = (ctx: CodexContext) => convertToLlm(
+		buildSessionContext(ctx.sessionManager.getBranch()).messages
+			.filter((message) => !isProviderContextExcludedMessage(message)),
+	);
+
+	const currentContextPrewarm = (ctx: CodexContext, kind: "compaction" | "keepalive") => {
+		const keepaliveStrategy = kind === "keepalive"
+			? resolveCodexCacheKeepaliveStrategy(state.config.openai.cacheKeepalive, cacheExperiment)
+			: false;
+		if (kind === "keepalive" && !keepaliveStrategy) return undefined;
+		const preserveContinuation = keepaliveStrategy !== false;
 		const activeSystemPrompt = state.activeProviderSystemPrompt;
 		return startPrewarm(
 			ctx,
 			activeSystemPrompt ?? ctx.getSystemPrompt(),
 			activeSystemPrompt !== undefined,
-			convertToLlm(messages),
+			currentMessages(ctx),
 			true,
-			force,
-			force ? "keepalive" : "ordinary",
+			kind === "keepalive",
+			kind,
+			preserveContinuation,
+			keepaliveStrategy || undefined,
+			kind === "keepalive" ? "reconstructed" : undefined,
+			keepaliveStrategy === "generated-current",
 		);
 	};
 
@@ -261,13 +273,25 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 	};
 
 	const scheduleCacheKeepalive = (ctx: CodexContext, epoch: number) => {
-		if (!state.config.openai.cacheKeepalive) return;
+		const strategy = resolveCodexCacheKeepaliveStrategy(state.config.openai.cacheKeepalive, cacheExperiment);
+		if (!strategy) return;
 		if (cacheKeepaliveTimer) clearTimeout(cacheKeepaliveTimer);
+		diagnostics.sink()?.({
+			type: "keepalive",
+			phase: "armed",
+			strategy,
+			intervalMs: cacheExperiment.keepaliveIntervalMs,
+		});
 		cacheKeepaliveTimer = setTimeout(() => {
 			cacheKeepaliveTimer = undefined;
 			if (epoch !== cacheKeepaliveEpoch || !ctx.isIdle()) return;
-			const keepalive = currentContextPrewarm(ctx, true);
-			if (!keepalive) return;
+			const requestSource = "reconstructed";
+			diagnostics.sink()?.({ type: "keepalive", phase: "started", strategy, requestSource });
+			const keepalive = currentContextPrewarm(ctx, "keepalive");
+			if (!keepalive) {
+				diagnostics.sink()?.({ type: "keepalive", phase: "skipped", strategy, requestSource });
+				return;
+			}
 			void keepalive.then((result) => {
 				if (epoch !== cacheKeepaliveEpoch || result.status === "aborted" || result.status === "skipped") return;
 				if (result.status === "failed") {
@@ -275,13 +299,11 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 					scheduleCacheKeepalive(ctx, epoch);
 					return;
 				}
-				ctx.ui.notify(
-					`Codex cache keepalive refreshed · WS ${result.socketReused ? "reused" : "new"}`,
-					"info",
-				);
+				const action = "generated-refresh";
+				diagnostics.sink()?.({ type: "keepalive", phase: "applied", strategy, requestSource, action });
 				scheduleCacheKeepalive(ctx, epoch);
 			});
-		}, CACHE_KEEPALIVE_INTERVAL_MS);
+		}, cacheExperiment.keepaliveIntervalMs);
 		cacheKeepaliveTimer.unref?.();
 	};
 
@@ -322,10 +344,10 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			return startPrewarm(ctx, systemPrompt, prepared);
 		},
 		startCompactionPrewarm(ctx) {
-			return currentContextPrewarm(ctx, false);
+			return currentContextPrewarm(ctx, "compaction");
 		},
 		startKeepalivePrewarm(ctx) {
-			return currentContextPrewarm(ctx, true);
+			return currentContextPrewarm(ctx, "keepalive");
 		},
 		armCacheKeepalive(ctx) {
 			armCacheKeepalive(ctx);
@@ -333,16 +355,12 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 		cancelCacheKeepalive() {
 			cancelCacheKeepalive();
 		},
-		captureCacheKeepaliveRequest(payload) {
-			if (state.config.openai.cacheKeepalive) cacheKeepaliveRequest = structuredClone(payload);
-		},
 		resetTransport(sessionId) {
 			cancelCacheKeepalive();
 			prewarmController?.abort();
 			prewarmController = undefined;
 			pendingPrewarmKey = undefined;
-			prewarmedIdentity = undefined;
-			cacheKeepaliveRequest = undefined;
+			prewarmedKey = undefined;
 			state.codexTurnState.reset();
 			if (sessionId) resetOpenAICodexWebSocketSessions(sessionId);
 			else closeOpenAICodexWebSocketSessions();
@@ -357,18 +375,23 @@ export function createCodexExtensionRuntime(pi: ExtensionAPI): CodexExtensionRun
 			closeOpenAICodexWebSocketSessions(sessionId);
 		},
 		waitForPrewarm(ctx, systemPrompt) {
-			return runtime.startPrewarm(ctx, systemPrompt, true);
+			return startPrewarm(ctx, systemPrompt, true, currentMessages(ctx), true);
 		},
 		prewarmIdentity(ctx, systemPrompt) {
 			return buildPrewarmPlan(ctx, systemPrompt, true, [], false)?.identity;
 		},
 		configureDiagnostics(ctx, announceLog = false) {
+			if (!cacheExperimentWarningsReported && cacheExperiment.warnings.length > 0) {
+				cacheExperimentWarningsReported = true;
+				ctx.ui.notify(`Codex cache experiment: ${cacheExperiment.warnings.join("; ")}`, "warning");
+			}
 			return diagnostics.configure({
 				mode: state.config.openai.cacheDiagnostics,
 				active: ctx.model?.provider === "openai-codex",
 				ctx,
 				agentDir: dirname(getCodexConversionConfigPath()),
-				announceLog,
+				logName: cacheExperiment.logName,
+				announceLog: announceLog || cacheExperiment.logName !== undefined,
 			});
 		},
 		diagnosticsSink() {

--- a/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex-custom-provider.ts
@@ -8,7 +8,7 @@ import { buildRequestBody } from "./openai-codex/request-body.ts";
 import { openAICodexModelsWithDaybreak } from "./openai-codex/model-catalog.ts";
 import { supportsResponsesLiteModel } from "./openai-codex/responses-lite-model.ts";
 import { applyResponsesLiteRequest, applyResponsesLiteWebSocketMetadata, isResponsesLiteRequest, namespaceExistingResponsesLiteRequest, prepareResponsesLiteRequestImages } from "./openai-codex/responses-lite.ts";
-import type { CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
+import type { CodexDiagnosticsSink, CodexPrewarmDiagnostics, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./openai-codex/types.ts";
 import { recordWebSocketSseFallback } from "./openai-codex/websocket.ts";
 import { isWebSocketMessageTooBigError, isWebSocketUpgradeRequiredError } from "./openai-codex/websocket-connection.ts";
 import { prewarmWebSocket } from "./openai-codex/websocket-stream.ts";
@@ -59,8 +59,9 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 		useResponsesLite?: (model: Model<Api>) => boolean;
 		turnState?: CodexTurnState | undefined;
 		getDiagnostics?: (() => CodexDiagnosticsSink | undefined) | undefined;
-		preparedBody?: ResponsesBody | undefined;
 		preserveContinuation?: boolean | undefined;
+		generate?: boolean | undefined;
+		prewarmDiagnostics?: CodexPrewarmDiagnostics | undefined;
 	},
 ): Promise<CodexPrewarmResult | undefined> {
 	const runtimeConfig = deps.getConfig?.();
@@ -73,7 +74,7 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	const effectiveOptions = runtimeConfig?.compaction?.responsesCompaction
 		? { ...options, grammarToolInputProperties, headers: withRemoteCompactionV2Feature(options.headers) }
 		: { ...options, grammarToolInputProperties };
-	const body = deps.preparedBody ? structuredClone(deps.preparedBody) : await prepareCodexRequestBody(model, context, effectiveOptions, responsesLite);
+	const body = await prepareCodexRequestBody(model, context, effectiveOptions, responsesLite);
 	const accountId = extractAccountId(options.apiKey);
 	const routing = resolveCodexRequestRouting({
 		model: body.model,
@@ -86,7 +87,18 @@ export async function prewarmOpenAICodexWebSocket<TApi extends Api>(
 	const websocketBody = withCodexTurnState(responsesLite ? applyResponsesLiteWebSocketMetadata(body) : body, turnState);
 	const diagnostics = noThrowCodexDiagnosticsSink(deps.getDiagnostics?.());
 	try {
-		return await prewarmWebSocket(resolveCodexWebSocketUrl(model.baseUrl), websocketBody, headers, accountId, effectiveOptions, turnState, diagnostics, deps.preserveContinuation);
+		return await prewarmWebSocket(
+			resolveCodexWebSocketUrl(model.baseUrl),
+			websocketBody,
+			headers,
+			accountId,
+			effectiveOptions,
+			turnState,
+			diagnostics,
+			deps.preserveContinuation,
+			deps.prewarmDiagnostics,
+			deps.generate,
+		);
 	} catch (error) {
 		if (!options.signal?.aborted && (isWebSocketUpgradeRequiredError(error) || isWebSocketMessageTooBigError(error))) {
 			recordWebSocketSseFallback(options.sessionId);

--- a/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/types.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import type { CodexCompactionDiagnostic } from "../../adapter/compaction/diagnostics.ts";
+import type { CodexCacheKeepaliveStrategy } from "../../adapter/activation/cache-experiment.ts";
 
 export interface WebSocketLike {
 	readyState?: number | undefined;
@@ -17,6 +18,7 @@ export interface WebSocketConstructorLike {
 export interface SessionWebSocketCacheEntry {
 	socket: WebSocketLike;
 	busy: boolean;
+	createdAtMs: number;
 	continuation?: CachedWebSocketContinuationState | undefined;
 }
 
@@ -24,6 +26,7 @@ export interface AcquiredWebSocket {
 	socket: WebSocketLike;
 	entry?: SessionWebSocketCacheEntry | undefined;
 	reused: boolean;
+	socketAgeMs: number;
 	release: (options?: { keep?: boolean | undefined }) => void;
 }
 
@@ -52,6 +55,12 @@ export type CanonicalHistoryDecision =
 	| "validated";
 
 export type CodexDiagnosticsLane = "response" | "compaction" | "prewarm";
+export type CodexPrewarmKind = "ordinary" | "compaction" | "keepalive";
+export interface CodexPrewarmDiagnostics {
+	kind: CodexPrewarmKind;
+	keepaliveStrategy?: CodexCacheKeepaliveStrategy | undefined;
+	requestSource?: "captured" | "reconstructed" | undefined;
+}
 export type CodexDiagnosticsTransport = "websocket" | "sse";
 export type CodexDiagnosticsFailureCategory =
 	| "aborted"
@@ -81,8 +90,13 @@ export type CodexDiagnosticsEvent =
 			sentInputItems: number;
 			model?: string | undefined;
 			socketReused?: boolean | undefined;
+			socketAgeMs?: number | undefined;
+			socketLane?: "main" | "keepalive" | undefined;
 			continuation?: WebSocketContinuationDecision | undefined;
+			continuationBaselineInputItems?: number | undefined;
+			continuationBaselineResponseItems?: number | undefined;
 			canonicalHistory?: CanonicalHistoryDecision | undefined;
+			prewarm?: CodexPrewarmDiagnostics | undefined;
 			compaction?: CodexCompactionDiagnostic | undefined;
 			previousResponseId?: boolean | undefined;
 	  }
@@ -120,6 +134,18 @@ export type CodexDiagnosticsEvent =
 			type: "prewarm-ready";
 			transport: "websocket";
 			socketReused: boolean;
+			socketAgeMs: number;
+			socketLane: "main" | "keepalive";
+			prewarm: CodexPrewarmDiagnostics;
+			usage?: CodexPrewarmUsage | undefined;
+	  }
+	| {
+			type: "keepalive";
+			phase: "armed" | "started" | "applied" | "skipped";
+			strategy: CodexCacheKeepaliveStrategy;
+			intervalMs?: number | undefined;
+			requestSource?: "captured" | "reconstructed" | undefined;
+			action?: "generated-refresh" | undefined;
 	  };
 
 export type CodexDiagnosticsSink = (event: CodexDiagnosticsEvent) => void;
@@ -177,6 +203,7 @@ export interface CodexPrewarmUsage {
 	inputTokens: number;
 	cachedInputTokens: number;
 	cacheWriteInputTokens: number;
+	outputTokens?: number | undefined;
 }
 
 export interface CodexPrewarmResult {

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-session-cache.ts
@@ -84,6 +84,7 @@ export async function acquireWebSocket(
 		return {
 			socket,
 			reused: false,
+			socketAgeMs: 0,
 			release: ({ keep } = {}) => {
 				if (keep === false) {
 					closeWebSocketSilently(socket);
@@ -104,6 +105,7 @@ export async function acquireWebSocket(
 				socket: cached.socket,
 				entry: cached,
 				reused: true,
+				socketAgeMs: Math.max(0, Date.now() - cached.createdAtMs),
 				release: ({ keep } = {}) => {
 					if (!keep || !isWebSocketReusable(cached.socket)) {
 						closeWebSocketSilently(cached.socket);
@@ -122,6 +124,7 @@ export async function acquireWebSocket(
 			return {
 				socket,
 				reused: false,
+				socketAgeMs: 0,
 				release: () => {
 					closeWebSocketSilently(socket);
 				},
@@ -136,7 +139,7 @@ export async function acquireWebSocket(
 	}
 
 	const socket = await connectWebSocket(url, headers, signal, connectTimeoutMs, env);
-	const entry: SessionWebSocketCacheEntry = { socket, busy: true };
+	const entry: SessionWebSocketCacheEntry = { socket, busy: true, createdAtMs: Date.now() };
 	routeEntries = websocketSessionCache.get(sessionId);
 	if (!routeEntries) {
 		routeEntries = new Map();
@@ -147,6 +150,7 @@ export async function acquireWebSocket(
 		socket,
 		entry,
 		reused: false,
+		socketAgeMs: 0,
 		release: ({ keep } = {}) => {
 			if (!keep || !isWebSocketReusable(entry.socket)) {
 				closeWebSocketSilently(entry.socket);

--- a/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
+++ b/packages/pi-codex-conversion/src/providers/openai-codex/websocket-stream.ts
@@ -3,7 +3,7 @@ import { normalizeTimeoutMs } from "./sse.ts";
 import { buildCachedWebSocketRequestBody } from "./websocket-continuation.ts";
 import { acquireWebSocket, parseWebSocket, startWebSocketOutputOnFirstEvent } from "./websocket.ts";
 import { assertSuccessfulCodexOutput, assertSuccessfulCodexStatus, mapCodexEvents, processMappedCodexResponsesStream } from "./stream-events.ts";
-import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
+import type { CachedWebSocketRequestBodyResult, CanonicalHistoryDecision, CodexDiagnosticsLane, CodexDiagnosticsSink, CodexPrewarmDiagnostics, CodexPrewarmResult, OpenAICodexStreamOptions, ResponsesBody } from "./types.ts";
 import type { CodexTurnState } from "./turn-state.ts";
 import { DEFAULT_STREAM_IDLE_TIMEOUT_MS, DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS } from "./constants.ts";
 import { codexDiagnosticsFailure, noThrowCodexDiagnosticsSink } from "./diagnostic-failure.ts";
@@ -31,7 +31,7 @@ export async function processWebSocketStream<TApi extends Api>(
 	const idleTimeoutMs = normalizeTimeoutMs(options?.timeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS, "timeoutMs");
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options?.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
 
-	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, options?.sessionId, accountId, options?.signal, websocketConnectTimeoutMs, options?.env);
+	const { socket, entry, release, reused, socketAgeMs } = await acquireWebSocket(url, headers, options?.sessionId, accountId, options?.signal, websocketConnectTimeoutMs, options?.env);
 	let keepConnection = true;
 	let released = false;
 	const responseItems: unknown[] = [];
@@ -72,7 +72,13 @@ export async function processWebSocketStream<TApi extends Api>(
 				sentInputItems: requestBody.input.length,
 				model: fullBody.model,
 				socketReused: reused,
+				socketAgeMs,
+				socketLane: "main",
 				continuation: cachedRequest.decision,
+				...(entry?.continuation ? {
+					continuationBaselineInputItems: entry.continuation.lastRequestBody.input.length,
+					continuationBaselineResponseItems: entry.continuation.lastResponseItems.length,
+				} : {}),
 				...(canonical?.decision ? { canonicalHistory: canonical.decision } : {}),
 				...(options?.compactionDiagnostics ? { compaction: structuredClone(options.compactionDiagnostics) } : {}),
 				previousResponseId: Boolean(requestBody.previous_response_id),
@@ -144,11 +150,14 @@ export async function prewarmWebSocket(
 	turnState?: CodexTurnState,
 	diagnostics?: CodexDiagnosticsSink | undefined,
 	preserveContinuation = false,
+	prewarm: CodexPrewarmDiagnostics = { kind: "ordinary" },
+	generate = false,
 ): Promise<CodexPrewarmResult> {
 	const recordDiagnostics = noThrowCodexDiagnosticsSink(diagnostics);
 	const websocketConnectTimeoutMs = normalizeTimeoutMs(options.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
 	const socketSessionId = preserveContinuation ? `${options.sessionId}:cache-keepalive` : options.sessionId;
-	const { socket, entry, release, reused } = await acquireWebSocket(url, headers, socketSessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
+	const socketLane = preserveContinuation ? "keepalive" : "main";
+	const { socket, entry, release, reused, socketAgeMs } = await acquireWebSocket(url, headers, socketSessionId, accountId, options.signal, websocketConnectTimeoutMs, options.env);
 	let keepConnection = true;
 	const responseItems: unknown[] = [];
 	let responseId: string | undefined;
@@ -163,10 +172,14 @@ export async function prewarmWebSocket(
 			attempt: 1,
 			fullInputItems: body.input.length,
 			sentInputItems: body.input.length,
+			model: body.model,
 			socketReused: reused,
+			socketAgeMs,
+			socketLane,
+			prewarm,
 			previousResponseId: Boolean(body.previous_response_id),
 		});
-		socket.send(JSON.stringify({ type: "response.create", ...body, generate: false }));
+		socket.send(JSON.stringify({ type: "response.create", ...body, ...(generate ? {} : { generate: false }) }));
 		for await (const event of mapCodexEvents(parseWebSocket(socket, options.signal, idleTimeoutMs, (value) => {
 			if (!preserveContinuation) turnState?.capturePrewarm(value);
 		}))) {
@@ -183,6 +196,7 @@ export async function prewarmWebSocket(
 						inputTokens: Math.max(0, (responseUsage.input_tokens ?? 0) - cacheRead - cacheWrite),
 						cachedInputTokens: cacheRead,
 						cacheWriteInputTokens: cacheWrite,
+						...(generate ? { outputTokens: responseUsage.output_tokens ?? 0 } : {}),
 					};
 				}
 			}
@@ -191,7 +205,15 @@ export async function prewarmWebSocket(
 		if (!preserveContinuation && entry && responseId) {
 			entry.continuation = { lastRequestBody: body, lastResponseId: responseId, lastResponseItems: responseItems };
 		}
-		recordDiagnostics?.({ type: "prewarm-ready", transport: "websocket", socketReused: reused });
+		recordDiagnostics?.({
+			type: "prewarm-ready",
+			transport: "websocket",
+			socketReused: reused,
+			socketAgeMs,
+			socketLane,
+			prewarm,
+			...(usage ? { usage } : {}),
+		});
 		return { socketReused: reused, ...(usage ? { usage } : {}) };
 	} catch (error) {
 		keepConnection = false;

--- a/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
+++ b/packages/pi-codex-conversion/tests/cache-diagnostics.test.ts
@@ -27,9 +27,10 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 			sessionId,
 			sessionFile,
 			sessionName: "../../ Cache Test",
+			logName: "generated refresh",
 		});
 		assert.equal(dirname(path), join(agentDir, "pi-codex-logs"));
-		assert.match(basename(path), /^Cache-Test--2026-08-06T15-56-33-850Z_/);
+		assert.match(basename(path), /^generated-refresh--2026-08-06T15-56-33-850Z_/);
 
 		const errors: unknown[] = [];
 		const log = await createCodexDiagnosticsLog({
@@ -37,6 +38,7 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 			sessionId,
 			sessionFile,
 			sessionName: "../../ Cache Test",
+			logName: "generated refresh",
 			cwd: "/work/project",
 			onError: (error) => errors.push(error),
 		});
@@ -73,6 +75,22 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 			previousResponseId: false,
 		});
 		log.record({
+			type: "prewarm-ready",
+			transport: "websocket",
+			socketReused: true,
+			socketAgeMs: 1_500_000,
+			socketLane: "keepalive",
+			prewarm: { kind: "keepalive", keepaliveStrategy: "generated-current", requestSource: "reconstructed" },
+			usage: { inputTokens: 408, cachedInputTokens: 14_080, cacheWriteInputTokens: 0, outputTokens: 4 },
+		});
+		log.record({
+			type: "keepalive",
+			phase: "applied",
+			strategy: "generated-current",
+			requestSource: "reconstructed",
+			action: "generated-refresh",
+		});
+		log.record({
 			type: "failure",
 			lane: "compaction",
 			transport: "websocket",
@@ -82,12 +100,15 @@ test("cache diagnostics log is session-derived, readable, and omits raw provider
 
 		const contents = await readFile(log.path, "utf8");
 		assert.match(contents, /Metadata only/);
+		assert.match(contents, /# log_name="generated refresh"/);
 		assert.match(contents, /event="request" lane="compaction" transport="websocket"/);
 		assert.match(contents, /canonical_history="validated"/);
 		assert.match(contents, /full_input_items=43 sent_input_items=43/);
 		assert.match(contents, /model="gpt-5.6-sol"/);
 		assert.match(contents, /compaction_source="reconstructed" compaction_replay="response_prefix_mismatch" checkpoint_reused=true checkpoint_model="gpt-5.6-luna" rewritten_tool_outputs=2/);
 		assert.match(contents, /failure="authentication" code="invalid_token" status=401/);
+		assert.match(contents, /event="prewarm-ready".*socket_age_ms=1500000.*keepalive_strategy="generated-current".*input_tokens=14488 cache_read=14080 cache_write=0 output_tokens=4 cache_usage="authoritative"/);
+		assert.match(contents, /event="keepalive" phase="applied" keepalive_strategy="generated-current".*action="generated-refresh"/);
 		assert.doesNotMatch(contents, /error=|resp_secret|echoed_prompt|Bearer/);
 		assert.deepEqual(errors, []);
 	} finally {
@@ -147,6 +168,8 @@ test("provider diagnostics are authoritative and cannot alter or leak the stream
 			sentInputItems: 1,
 			model: "gpt-5.6-luna",
 			socketReused: false,
+			socketAgeMs: 0,
+			socketLane: "main",
 			continuation: "no_continuation",
 			previousResponseId: false,
 		});

--- a/packages/pi-codex-conversion/tests/config-store.test.ts
+++ b/packages/pi-codex-conversion/tests/config-store.test.ts
@@ -66,6 +66,17 @@ test("trusted folder config overrides globals without crossing folder or process
 			globalConfigPath: globalPath,
 			env: { PI_CODEX_FAST: "0" },
 		}).openai.fast, false);
+		const experiment = readEffectiveCodexConversionConfig({
+			cwd: project,
+			projectTrusted: true,
+			globalConfigPath: globalPath,
+			env: {
+				PI_CODEX_CACHE_KEEPALIVE: "generated-current",
+				PI_CODEX_CACHE_DIAGNOSTICS: "status-and-log",
+			},
+		});
+		assert.equal(experiment.openai.cacheKeepalive, true);
+		assert.equal(experiment.openai.cacheDiagnostics, "status-and-log");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
This PR makes opt-in Codex cache keepalive perform a real, silent cache refresh instead of a `generate:false` transport warmup that expires on long sessions.

## Summary

- rebuild the complete settled provider context every 25 minutes, run an isolated generated refresh, discard its output, and leave the main continuation and Pi session history untouched
- prewarm resumed turns from their complete current branch rather than chaining a large request from a system-only baseline
- add process-scoped keepalive interval, diagnostics mode, and log-name overrides for controlled live investigations
- log socket age/lane, continuation baselines, refresh lifecycle, and authoritative generated-refresh usage without prompts, credentials, response IDs, or generated text
- keep successful refreshes silent; only failures notify the user

## Backend evidence

Verified against `openai-codex/gpt-5.6-sol` on an 85k-token fork of a long-lived session:

- repeated `generate:false` replays at +25m and +50m still produced a cold +51m full request
- generated refreshes at +25m, +50m, and +75m each read 85,248 cached tokens
- the +51m real turn read 85,248 / 85,891 tokens (99.3%)
- after physical main-WebSocket expiry, a new full request read 85,248 / 85,921 tokens (99.2%)
- a generated refresh emitted 4 discarded output tokens; no provider output entered Pi history or rendering

At this prompt size, each refresh processes about 85k cached input tokens plus a small uncached tail and output. This is a real provider call and cost, deliberately scoped to project-enabled keepalive sessions.

## Validation

- `bun run check:changed`
- `bun run changeset:check`
- 109 package tests
- extension artifact verification
- Knip
- live 25/50/75-minute refresh and post-WebSocket-expiry probes

## Review focus

- generated output is parsed and discarded on the isolated `:cache-keepalive` lane; it is never appended, rendered, or executed
- ordinary and compaction transport prewarm still use `generate:false`; only cache keepalive stops using that primitive
- refresh/ordinary/compaction prewarm keys separate request-affecting lane and generation policy while deduplicating equivalent requests

## Release

- Changeset: yes
- Packages: `@howaboua/pi-codex-conversion`
- Aggregates: generated by release automation
