### PR TITLE
Add machine identity extension

### DIFF
--- a/.changeset/patch-mt4n1hvv-65b635.md
+++ b/.changeset/patch-mt4n1hvv-65b635.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-machine-identity": patch
+---
+
+Add the machine identity extension with context-independent prompt wording.

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,19 @@
         "@earendil-works/pi-tui": "*",
       },
     },
+    "packages/pi-machine-identity": {
+      "name": "@howaboua/pi-machine-identity",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
+        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@types/node": "^24.10.0",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.82.0",
+      },
+    },
     "packages/pi-markdown-workflows": {
       "name": "@howaboua/pi-markdown-workflows",
       "version": "0.2.20",

--- a/packages/pi-machine-identity/LICENSE
+++ b/packages/pi-machine-identity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 howaboua
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-machine-identity/README.md
+++ b/packages/pi-machine-identity/README.md
@@ -1,0 +1,3 @@
+# @howaboua/pi-machine-identity
+
+Adds the current machine identity and Howaclawa profile to Pi from `machine-identity.json` in the Pi agent directory.

--- a/packages/pi-machine-identity/biome.json
+++ b/packages/pi-machine-identity/biome.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": false
+	},
+	"files": {
+		"includes": [
+			"**",
+			"!node_modules",
+			"!dist",
+			"!coverage",
+			"!package-lock.json"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all"
+		}
+	}
+}

--- a/packages/pi-machine-identity/index.ts
+++ b/packages/pi-machine-identity/index.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type ExtensionAPI,
+	getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+
+type MachineConfig = {
+	machine: string;
+	description: string;
+	profile: string;
+};
+
+function loadConfig(): MachineConfig {
+	const path = join(getAgentDir(), "machine-identity.json");
+	const value = JSON.parse(
+		readFileSync(path, "utf8"),
+	) as Partial<MachineConfig>;
+	if (
+		!value.machine?.trim() ||
+		!value.description?.trim() ||
+		!value.profile?.trim()
+	) {
+		throw new Error(
+			`${path} requires non-empty machine, description, and profile strings`,
+		);
+	}
+	return {
+		machine: value.machine.trim(),
+		description: value.description.trim(),
+		profile: value.profile.trim(),
+	};
+}
+
+export default function machineIdentity(pi: ExtensionAPI) {
+	const config = loadConfig();
+	const identity = `Current machine: ${config.machine} - ${config.description}`;
+	const profile = `Howaclawa profile: ${config.profile}`;
+
+	pi.on("before_agent_start", (event) => ({
+		systemPrompt: `${event.systemPrompt}\n\n${identity}\n${profile}`,
+	}));
+}

--- a/packages/pi-machine-identity/package.json
+++ b/packages/pi-machine-identity/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@howaboua/pi-machine-identity",
+	"version": "0.0.1",
+	"description": "Current machine identity and Howaclawa profile for Pi",
+	"type": "module",
+	"main": "index.ts",
+	"exports": "./index.ts",
+	"files": [
+		"index.ts",
+		"README.md",
+		"LICENSE",
+		"tsconfig.json",
+		"biome.json"
+	],
+	"scripts": {
+		"check": "bun run lint && bun run typecheck",
+		"prepack": "bun run check",
+		"typecheck": "tsgo --noEmit",
+		"lint": "biome check .",
+		"format": "biome check --write .",
+		"pack:dry": "npm pack --dry-run"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	},
+	"keywords": [
+		"pi",
+		"pi-package",
+		"pi-extension"
+	],
+	"license": "MIT",
+	"author": "Igor Warzocha",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/IgorWarzocha/howaboua-pi-stuff.git",
+		"directory": "packages/pi-machine-identity"
+	},
+	"homepage": "https://github.com/IgorWarzocha/howaboua-pi-stuff/tree/main/packages/pi-machine-identity#readme",
+	"bugs": {
+		"url": "https://github.com/IgorWarzocha/howaboua-pi-stuff/issues"
+	},
+	"engines": {
+		"node": ">=20.6.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": ">=0.82.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"@earendil-works/pi-coding-agent": "0.84.1",
+		"@types/node": "^24.10.0",
+		"typescript": "^6.0.3"
+	}
+}

--- a/packages/pi-machine-identity/tsconfig.json
+++ b/packages/pi-machine-identity/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["index.ts"]
+}


### PR DESCRIPTION
Adds the machine identity extension to the canonical Pi package monorepo.

- Reads machine-specific identity and profile values from `machine-identity.json` in the Pi agent directory.
- Injects context-independent `Current machine` and `Howaclawa profile` lines before each agent starts.
- Replaces the old LAN Hivemind package vocabulary.
- Includes package lint, type checking, metadata, lockfile registration, and a patch changeset.

Validation:
- `bun run --cwd packages/pi-machine-identity check`
- `bun run check:changed`
- Installed extension smoke test against the server identity configuration
