### PR TITLE
Fix automatic tags for Changesets 3 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          registry-url: https://registry.npmjs.org
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - name: Build pi-codex-conversion extension
@@ -27,15 +30,14 @@ jobs:
         run: bun run changeset:aggregates
       - name: Changesets release
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          publish: bun run release
-          version: bun run version-packages
-          createGithubReleases: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: bun run release
+          version-script: bun run version-packages
+          create-github-releases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Delete Changesets release branch after publish
         if: steps.changesets.outputs.published == 'true'
         run: git push origin --delete changeset-release/main || true


### PR DESCRIPTION
Changesets 3 writes publish results through CHANGESETS_OUTPUT, but main still runs the v1 action that parses the old stdout format. npm published 3.0.20 and 3.0.21 successfully, while the action silently missed both sets of tags and GitHub Releases.

Use the Changesets 3-compatible v2 action, its renamed inputs, and setup-node's npm authentication. The missing 3.0.21 tags and releases have been backfilled against Version Packages commit 52a2004c.

This branch contains no package versions or changesets. Merging it will scan npm, find every current version already published, and publish nothing.
