### PR TITLE
ci: stop Bun node-gyp install corruption

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@howaboua/pi-stuff-monorepo",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/pi-pet/package.json
+++ b/packages/pi-pet/package.json
@@ -71,7 +71,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "peerDependencies": {
     "@howaboua/pi-gippity-control": ">=0.0.13",
     "@earendil-works/pi-coding-agent": ">=0.84.3",


### PR DESCRIPTION
The release job failed twice during `bun install` because Bun 1.3.14 created an incomplete temporary `node-gyp` installation while compiling `better-sqlite3`. The failures reported different missing files beneath `/tmp/bunx-1001-node-gyp@latest`, matching [oven-sh/bun#10608](https://github.com/oven-sh/bun/issues/10608).

Use Bun 1.4.0, which contains the upstream fix, for the monorepo and Pi Pet package metadata.

Validated with a fresh repository archive, isolated empty Bun cache and isolated temporary directory. Bun 1.4.0 installed all 310 packages, including `better-sqlite3`, successfully.
