### PR TITLE
Fix native Codex compaction and collapse AGENTS.md context

### DIFF
--- a/.changeset/patch-mto7e7q4-697b0f.md
+++ b/.changeset/patch-mto7e7q4-697b0f.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Fixed Responses compaction v2 falling back to Pi compaction after native Codex provider registration.

--- a/.changeset/subdir-context-collapse.md
+++ b/.changeset/subdir-context-collapse.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subdir-agents": patch
+---
+
+Fixed developer-role AGENTS.md context always displaying in full. Messages now show file paths and expand with Ctrl+O.

--- a/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
+++ b/packages/pi-codex-conversion/src/adapter/compaction/remote-v2-client.ts
@@ -49,7 +49,7 @@ function resolveStream(options: ExecuteRemoteCompactionV2Options): V2Stream | un
 		const registration = options.modelRegistry.getRegisteredProviderConfig("openai-codex");
 		return registration?.api === "openai-codex-responses" && registration.streamSimple
 			? registration.streamSimple as V2Stream
-			: undefined;
+			: options.modelRegistry.getRegisteredNativeProvider("openai-codex")?.streamSimple as V2Stream | undefined;
 	}
 	const configuredRegistration = options.modelRegistry.getRegisteredProviderConfig(options.runtime.provider);
 	return options.runtime.api === "openai-responses"

--- a/packages/pi-codex-conversion/tests/websocket-compaction-continuation.test.ts
+++ b/packages/pi-codex-conversion/tests/websocket-compaction-continuation.test.ts
@@ -86,7 +86,8 @@ test("V2 compaction exactly replays an image-bearing provider baseline after its
 				currentModel: imageModel,
 			},
 			modelRegistry: {
-				getRegisteredProviderConfig: () => ({ api: model.api, streamSimple: registered.provider.streamSimple }),
+				getRegisteredProviderConfig: () => undefined,
+				getRegisteredNativeProvider: () => registered.provider,
 			} as never,
 			context: context([], "Changed instructions", [] as never),
 			promptInput: canonicalInput as never,

--- a/packages/pi-subdir-agents/index.ts
+++ b/packages/pi-subdir-agents/index.ts
@@ -1,10 +1,32 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import registerPackageChangelog from "./changelog.js";
-
+import { parsePersistedContextDetails } from "./src/core/subdir/details.js";
 import { registerSubdirContextAutoload } from "./src/core/subdir.js";
 
 export default async function (pi: ExtensionAPI): Promise<void> {
 	registerPackageChangelog(pi);
+	pi.registerMessageRenderer(
+		"subdir-agents-context",
+		(message, { expanded, outputPad }, theme) => {
+			const files = parsePersistedContextDetails(message.details)?.files ?? [];
+			const summary = files.length
+				? files.map((file) => file.path).join(", ")
+				: "Subdirectory AGENTS.md context";
+			const content =
+				typeof message.content === "string"
+					? message.content
+					: message.content
+							.filter((item) => item.type === "text")
+							.map((item) => item.text)
+							.join("\n");
+			return new Text(
+				theme.fg("dim", summary) + (expanded ? `\n${content}` : ""),
+				outputPad,
+				0,
+			);
+		},
+	);
 	registerSubdirContextAutoload(pi, await loadDeveloperMessages());
 }
 

--- a/packages/pi-subdir-agents/tests/subdir-context.test.mjs
+++ b/packages/pi-subdir-agents/tests/subdir-context.test.mjs
@@ -30,6 +30,7 @@ function mockPi() {
 		},
 		registerTool() {},
 		registerCommand() {},
+		registerMessageRenderer() {},
 		sendUserMessage() {},
 		sendMessage(message) {
 			sentMessages.push(message);


### PR DESCRIPTION
Fixed native Responses compaction stream resolution after the Codex provider registration change. Closes #370.

Also collapses subdirectory AGENTS.md developer messages to file paths, with full content available through Ctrl+O. Developer-role delivery is unchanged.

Both fixes ship together with package patch changesets. `bun run check:changed` and `bun run changeset:check` pass. Interactive rendering has not been manually exercised.
