### PR TITLE
Fix Codex tool auth routing and repeated AGENTS context

### DIFF
--- a/.changeset/patch-mtobtypy-e88aa7.md
+++ b/.changeset/patch-mtobtypy-e88aa7.md
@@ -1,0 +1,6 @@
+---
+"@howaboua/pi-codex-imagegen": patch
+"@howaboua/pi-codex-web-run": patch
+---
+
+Fixed Codex web search and image generation to use local Codex authentication on unrelated chat providers while preserving explicit Codex routes and optional Pi Codex integration. Removed Pi Codex package dependencies.

--- a/.changeset/quiet-agents-context.md
+++ b/.changeset/quiet-agents-context.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-subdir-agents": patch
+---
+
+Fixed repeated AGENTS.md context injection during repository discovery. Unchanged guidance stays deduplicated; new and edited files still load.

--- a/bun.lock
+++ b/bun.lock
@@ -175,7 +175,6 @@
         "@biomejs/biome": "^2.5.10",
         "@earendil-works/pi-coding-agent": "0.85.0",
         "@earendil-works/pi-tui": "0.85.0",
-        "@howaboua/pi-codex-conversion": "3.0.28",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.12",
         "typebox": "1.3.18",
@@ -184,12 +183,8 @@
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.84.4",
         "@earendil-works/pi-tui": ">=0.84.4",
-        "@howaboua/pi-codex-conversion": ">=3.0.28",
         "typebox": "*",
       },
-      "optionalPeers": [
-        "@howaboua/pi-codex-conversion",
-      ],
     },
     "packages/pi-codex-web-run": {
       "name": "@howaboua/pi-codex-web-run",
@@ -202,7 +197,6 @@
         "@biomejs/biome": "^2.5.10",
         "@earendil-works/pi-coding-agent": "0.85.0",
         "@earendil-works/pi-tui": "0.85.0",
-        "@howaboua/pi-codex-conversion": "3.0.28",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.12",
         "typebox": "1.3.18",
@@ -211,12 +205,8 @@
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.84.4",
         "@earendil-works/pi-tui": ">=0.84.4",
-        "@howaboua/pi-codex-conversion": ">=3.0.28",
         "typebox": "*",
       },
-      "optionalPeers": [
-        "@howaboua/pi-codex-conversion",
-      ],
     },
     "packages/pi-dynamic-tools": {
       "name": "@howaboua/pi-dynamic-tools",

--- a/packages/pi-codex-imagegen/README.md
+++ b/packages/pi-codex-imagegen/README.md
@@ -8,7 +8,7 @@ Codex image generation and editing for ordinary Pi, Code Mode, and Notebook Mode
 
 Requires Pi 0.84.4 or newer and Node.js 22.19 or newer.
 
-Run `/login openai-codex` for the normal Codex route. When the active model uses a compatible Codex transport, the tool can use it directly. Pi Codex can instead route an explicitly configured Responses provider with that provider's own credentials.
+Run `/login openai-codex` for the normal Codex route, including when chatting with another provider. Compatible active Codex transports keep their own credentials. Pi Codex's resolver is preferred when present, but its conversation-provider scope does not select tool endpoints. Neither Pi Codex nor an install script is required.
 
 Pi Codex 3.0.25 or newer is optional. With it installed, the normal imagegen tool becomes tools.image_gen__imagegen inside Code and Notebook Mode.
 

--- a/packages/pi-codex-imagegen/index.ts
+++ b/packages/pi-codex-imagegen/index.ts
@@ -1,10 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import registerPackageChangelog from "./changelog.js";
 import { imagegenCodeModeResult } from "./src/code-mode.js";
-import {
-	isConfiguredCodexToolProvider,
-	resolveHostedCodexToolProvider,
-} from "./src/codex-runtime/policy.js";
+import { resolveHostedCodexToolProvider } from "./src/codex-runtime/policy.js";
 import { createImageGenerationTool } from "./src/tool.js";
 
 const CODE_MODE_PACKAGE = "@howaboua/pi-codex-conversion";
@@ -21,8 +18,6 @@ export default async function imagegenExtension(
 	registerPackageChangelog(pi);
 	const tool = createImageGenerationTool({
 		allowCodexProviderFallback: true,
-		allowConfiguredProvider: (model) =>
-			isConfiguredCodexToolProvider(pi, model),
 		resolveProvider: (ctx) => resolveHostedCodexToolProvider(pi, ctx),
 		promptSnippet: false,
 	});
@@ -37,7 +32,7 @@ async function registerImagegenInCodeMode(
 ) {
 	try {
 		const { adaptToolForCodeMode, registerCodeModeExtensionTools } =
-			await import("@howaboua/pi-codex-conversion/code-mode");
+			await import(CODE_MODE_MODULE);
 		return registerCodeModeExtensionTools(pi, () => [
 			adaptToolForCodeMode(tool, {
 				usage:

--- a/packages/pi-codex-imagegen/package.json
+++ b/packages/pi-codex-imagegen/package.json
@@ -47,18 +47,11 @@
 		"undici": "8.10.0"
 	},
 	"peerDependencies": {
-		"@howaboua/pi-codex-conversion": ">=3.0.28",
 		"@earendil-works/pi-coding-agent": ">=0.84.4",
 		"@earendil-works/pi-tui": ">=0.84.4",
 		"typebox": "*"
 	},
-	"peerDependenciesMeta": {
-		"@howaboua/pi-codex-conversion": {
-			"optional": true
-		}
-	},
 	"devDependencies": {
-		"@howaboua/pi-codex-conversion": "3.0.28",
 		"@biomejs/biome": "^2.5.10",
 		"@earendil-works/pi-coding-agent": "0.85.0",
 		"@earendil-works/pi-tui": "0.85.0",

--- a/packages/pi-codex-imagegen/src/codex-runtime/policy.ts
+++ b/packages/pi-codex-imagegen/src/codex-runtime/policy.ts
@@ -3,34 +3,14 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import type { CodexToolProviderResolver } from "../contract.js";
+import { resolveAuthModel } from "./resolve.js";
 import type { CodexToolProvider } from "./types.js";
 
-const CONFIGURED_PROVIDER_CHANNEL =
-	"@howaboua/pi-codex-conversion.configured-provider/v1";
 const PROVIDER_RESOLVER_CHANNEL =
 	"@howaboua/pi-codex-conversion.provider-resolver/v1";
 
-interface ConfiguredProviderRequest {
-	model: ExtensionContext["model"];
-	allow(): void;
-}
-
 interface ProviderResolverRequest {
 	use(resolver: CodexToolProviderResolver): void;
-}
-
-export function isConfiguredCodexToolProvider(
-	pi: ExtensionAPI,
-	model: ExtensionContext["model"],
-): boolean {
-	let allowed = false;
-	pi.events.emit(CONFIGURED_PROVIDER_CHANNEL, {
-		model,
-		allow() {
-			allowed = true;
-		},
-	} satisfies ConfiguredProviderRequest);
-	return allowed;
 }
 
 export async function resolveHostedCodexToolProvider(
@@ -43,5 +23,6 @@ export async function resolveHostedCodexToolProvider(
 			resolver ??= candidate;
 		},
 	} satisfies ProviderResolverRequest);
-	return resolver?.(ctx);
+	// Conversation-provider opt-ins do not advertise Codex tool endpoints.
+	return resolver?.({ ...ctx, model: resolveAuthModel(ctx) });
 }

--- a/packages/pi-codex-imagegen/src/codex-runtime/resolve.ts
+++ b/packages/pi-codex-imagegen/src/codex-runtime/resolve.ts
@@ -101,7 +101,7 @@ function resolveOpenAICodexAuthModel(
 	);
 }
 
-function resolveAuthModel(
+export function resolveAuthModel(
 	ctx: ExtensionContext,
 	allowConfiguredProvider?: AllowConfiguredCodexToolProvider,
 	isConfiguredCodexTransport?: AllowConfiguredCodexToolProvider,

--- a/packages/pi-codex-web-run/README.md
+++ b/packages/pi-codex-web-run/README.md
@@ -8,7 +8,7 @@ Codex web search, page opening, link traversal, and in-page finding for ordinary
 
 Requires Pi 0.84.4 or newer and Node.js 22.19 or newer.
 
-Run `/login openai-codex` for the normal Codex route. When the active model uses a compatible Codex transport, the tool can use it directly. Pi Codex can instead route an explicitly configured Responses provider with that provider's own credentials.
+Run `/login openai-codex` for the normal Codex route, including when chatting with another provider. Compatible active Codex transports keep their own credentials. Pi Codex's resolver is preferred when present, but its conversation-provider scope does not select tool endpoints. Neither Pi Codex nor an install script is required.
 
 Pi Codex 3.0.25 or newer is optional. With it installed, the normal web_run tool becomes tools.web__run inside Code and Notebook Mode.
 

--- a/packages/pi-codex-web-run/index.ts
+++ b/packages/pi-codex-web-run/index.ts
@@ -1,10 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import registerPackageChangelog from "./changelog.js";
 import { webRunCodeModeResult } from "./src/code-mode.js";
-import {
-	isConfiguredCodexToolProvider,
-	resolveHostedCodexToolProvider,
-} from "./src/codex-runtime/policy.js";
+import { resolveHostedCodexToolProvider } from "./src/codex-runtime/policy.js";
 import { createWebSearchTool } from "./src/tool.js";
 
 const CODE_MODE_PACKAGE = "@howaboua/pi-codex-conversion";
@@ -18,8 +15,6 @@ export default async function webRunExtension(pi: ExtensionAPI): Promise<void> {
 	registerPackageChangelog(pi);
 	const tool = createWebSearchTool("web_run", {
 		allowCodexProviderFallback: true,
-		allowConfiguredProvider: (model) =>
-			isConfiguredCodexToolProvider(pi, model),
 		resolveProvider: (ctx) => resolveHostedCodexToolProvider(pi, ctx),
 		promptSnippet: false,
 	});
@@ -34,7 +29,7 @@ async function registerWebRunInCodeMode(
 ) {
 	try {
 		const { adaptToolForCodeMode, registerCodeModeExtensionTools } =
-			await import("@howaboua/pi-codex-conversion/code-mode");
+			await import(CODE_MODE_MODULE);
 		return registerCodeModeExtensionTools(pi, () => [
 			adaptToolForCodeMode(tool, {
 				usage:

--- a/packages/pi-codex-web-run/package.json
+++ b/packages/pi-codex-web-run/package.json
@@ -47,18 +47,11 @@
 		"undici": "8.10.0"
 	},
 	"peerDependencies": {
-		"@howaboua/pi-codex-conversion": ">=3.0.28",
 		"@earendil-works/pi-coding-agent": ">=0.84.4",
 		"@earendil-works/pi-tui": ">=0.84.4",
 		"typebox": "*"
 	},
-	"peerDependenciesMeta": {
-		"@howaboua/pi-codex-conversion": {
-			"optional": true
-		}
-	},
 	"devDependencies": {
-		"@howaboua/pi-codex-conversion": "3.0.28",
 		"@biomejs/biome": "^2.5.10",
 		"@earendil-works/pi-coding-agent": "0.85.0",
 		"@earendil-works/pi-tui": "0.85.0",

--- a/packages/pi-codex-web-run/src/codex-runtime/policy.ts
+++ b/packages/pi-codex-web-run/src/codex-runtime/policy.ts
@@ -3,34 +3,14 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import type { CodexToolProviderResolver } from "../contract.js";
+import { resolveAuthModel } from "./resolve.js";
 import type { CodexToolProvider } from "./types.js";
 
-const CONFIGURED_PROVIDER_CHANNEL =
-	"@howaboua/pi-codex-conversion.configured-provider/v1";
 const PROVIDER_RESOLVER_CHANNEL =
 	"@howaboua/pi-codex-conversion.provider-resolver/v1";
 
-interface ConfiguredProviderRequest {
-	model: ExtensionContext["model"];
-	allow(): void;
-}
-
 interface ProviderResolverRequest {
 	use(resolver: CodexToolProviderResolver): void;
-}
-
-export function isConfiguredCodexToolProvider(
-	pi: ExtensionAPI,
-	model: ExtensionContext["model"],
-): boolean {
-	let allowed = false;
-	pi.events.emit(CONFIGURED_PROVIDER_CHANNEL, {
-		model,
-		allow() {
-			allowed = true;
-		},
-	} satisfies ConfiguredProviderRequest);
-	return allowed;
 }
 
 export async function resolveHostedCodexToolProvider(
@@ -43,5 +23,6 @@ export async function resolveHostedCodexToolProvider(
 			resolver ??= candidate;
 		},
 	} satisfies ProviderResolverRequest);
-	return resolver?.(ctx);
+	// Conversation-provider opt-ins do not advertise Codex tool endpoints.
+	return resolver?.({ ...ctx, model: resolveAuthModel(ctx) });
 }

--- a/packages/pi-codex-web-run/src/codex-runtime/resolve.ts
+++ b/packages/pi-codex-web-run/src/codex-runtime/resolve.ts
@@ -101,7 +101,7 @@ function resolveOpenAICodexAuthModel(
 	);
 }
 
-function resolveAuthModel(
+export function resolveAuthModel(
 	ctx: ExtensionContext,
 	allowConfiguredProvider?: AllowConfiguredCodexToolProvider,
 	isConfiguredCodexTransport?: AllowConfiguredCodexToolProvider,

--- a/packages/pi-codex-web-run/tests/runtime.test.ts
+++ b/packages/pi-codex-web-run/tests/runtime.test.ts
@@ -7,10 +7,7 @@ import {
 	resolveCodexToolModel,
 } from "../src/codex-runtime/config.js";
 import { fetchCodexTool } from "../src/codex-runtime/http.js";
-import {
-	isConfiguredCodexToolProvider,
-	resolveHostedCodexToolProvider,
-} from "../src/codex-runtime/policy.js";
+import { resolveHostedCodexToolProvider } from "../src/codex-runtime/policy.js";
 import { resolveCodexToolProvider } from "../src/codex-runtime/resolve.js";
 import { resolveCodexSearchUrl } from "../src/codex-runtime/urls.js";
 
@@ -89,36 +86,6 @@ test("Codex requests keep provider policy and bounded HTTP state", async () => {
 			},
 		},
 	};
-	const unregister = pi.events.on(
-		"@howaboua/pi-codex-conversion.configured-provider/v1",
-		(value) => {
-			if (
-				!value ||
-				typeof value !== "object" ||
-				!("model" in value) ||
-				!("allow" in value) ||
-				typeof value.allow !== "function"
-			)
-				return;
-			const model = value.model as { provider?: string } | undefined;
-			if (model?.provider === "configured") value.allow();
-		},
-	);
-	assert.equal(
-		isConfiguredCodexToolProvider(
-			pi as never,
-			{ provider: "configured" } as never,
-		),
-		true,
-	);
-	unregister();
-	assert.equal(
-		isConfiguredCodexToolProvider(
-			pi as never,
-			{ provider: "configured" } as never,
-		),
-		false,
-	);
 	const provider = {
 		route: "openai-codex" as const,
 		baseUrl: "https://chatgpt.com/backend-api/codex",
@@ -137,11 +104,26 @@ test("Codex requests keep provider policy and bounded HTTP state", async () => {
 				"use" in value &&
 				typeof value.use === "function"
 			)
-				value.use(async () => provider);
+				value.use(async (ctx: { model: { provider: string } }) => {
+					assert.equal(ctx.model.provider, "openai-codex");
+					return provider;
+				});
 		},
 	);
 	assert.deepEqual(
-		await resolveHostedCodexToolProvider(pi as never, {} as never),
+		await resolveHostedCodexToolProvider(
+			pi as never,
+			{
+				model: { provider: "meta", api: "openai-responses", id: "muse" },
+				modelRegistry: {
+					find: () => ({
+						provider: "openai-codex",
+						api: "openai-codex-responses",
+						id: "gpt-5.6-luna",
+					}),
+				},
+			} as never,
+		),
 		provider,
 	);
 	assert.equal(

--- a/packages/pi-subdir-agents/README.md
+++ b/packages/pi-subdir-agents/README.md
@@ -16,7 +16,7 @@ When a read or discovery command reaches a file or directory, the extension find
 
 The loader recognizes direct file reads, directory tools, common read-oriented shell commands, their reported paths, and completed Code Mode traces. It follows the discovered command working directory, including `cd` and `git -C`.
 
-Loaded files are persisted in developer custom-message or tool-result details. A resumed or revisited branch does not receive unchanged guidance again. The extension periodically refreshes the guidance without rewriting persisted history. Pi Codex is optional; unavailable developer-message support keeps the tool-result route.
+Loaded files are persisted in developer custom-message or tool-result details. A resumed or revisited branch does not receive unchanged guidance again. Discovery reloads guidance only when its content changes. Pi Codex is optional; unavailable developer-message support keeps the tool-result route.
 
 ## Why append guidance instead of changing the system prompt
 

--- a/packages/pi-subdir-agents/src/core/subdir.ts
+++ b/packages/pi-subdir-agents/src/core/subdir.ts
@@ -36,7 +36,6 @@ export function registerSubdirContextAutoload(
 	const loadedAgentsContent = new Map<string, string>();
 	let currentCwd = "";
 	let cwdAgentsPath = "";
-	let readCount = 0;
 
 	function relativePath(absolutePath: string): string {
 		const relative = currentCwd
@@ -48,7 +47,6 @@ export function registerSubdirContextAutoload(
 	function resetSession(cwd: string): void {
 		currentCwd = resolvePath(cwd, process.cwd());
 		cwdAgentsPath = path.join(currentCwd, "AGENTS.md");
-		readCount = 0;
 		loadedAgents.clear();
 		loadedAgentsContent.clear();
 		loadedAgents.add(cwdAgentsPath);
@@ -162,7 +160,6 @@ export function registerSubdirContextAutoload(
 	async function readAppendixFiles(
 		agentFiles: string[],
 		branchContext: Map<string, string>,
-		refreshAppendix: boolean,
 	) {
 		const loadedNow: string[] = [];
 		const persistedFiles: PersistedContextFile[] = [];
@@ -178,8 +175,7 @@ export function registerSubdirContextAutoload(
 				const changed = previousContent !== content;
 				const rel = relativePath(agentsPath);
 				if (changed) persistedFiles.push({ path: rel, content });
-				if (!wasLoaded || changed || refreshAppendix)
-					appendixFiles.push({ path: rel, content });
+				if (!wasLoaded || changed) appendixFiles.push({ path: rel, content });
 				if (!wasLoaded) loadedNow.push(rel);
 			} catch (error) {
 				if (error instanceof Error) failedFiles.push({ agentsPath, error });
@@ -218,16 +214,11 @@ export function registerSubdirContextAutoload(
 
 		const branchContext = collectBranchContext(ctx, currentCwd, cwdAgentsPath);
 		mergeRuntimeFromBranch(branchContext);
-		readCount += 1;
 
 		const agentFiles = agentsForTargets(targets);
 		if (!agentFiles.length) return undefined;
 
-		const result = await readAppendixFiles(
-			agentFiles,
-			branchContext,
-			readCount % 10 === 0,
-		);
+		const result = await readAppendixFiles(agentFiles, branchContext);
 		if (ctx.hasUI) {
 			for (const failed of result.failedFiles) {
 				ctx.ui.notify(

--- a/packages/pi-subdir-agents/tests/subdir-context.test.mjs
+++ b/packages/pi-subdir-agents/tests/subdir-context.test.mjs
@@ -169,18 +169,10 @@ async function run() {
 		ctx,
 	);
 
-	assert.ok(
-		tenthQualifyingAction,
-		"cadence refresh should re-append unchanged AGENTS context on the tenth qualifying operation",
-	);
 	assert.equal(
-		persistedFiles(tenthQualifyingAction.details).length,
-		0,
-		"cadence refresh should not persist duplicate unchanged AGENTS context",
-	);
-	assert.match(
-		textContent(tenthQualifyingAction),
-		/<agents_file path="a\/AGENTS\.md">/,
+		tenthQualifyingAction,
+		undefined,
+		"unchanged AGENTS context must stay deduplicated across discovery operations",
 	);
 
 	await fs.writeFile(path.join(cwd, "a", "b", "c", "AGENTS.md"), "C");


### PR DESCRIPTION
Codex web search was sending requests to Meta's nonexistent `/alpha/search` endpoint because Pi Codex's conversation-provider scope was treated as tool backend capability.

- Select local `openai-codex` auth for unrelated chat providers before using the optional Pi Codex resolver. Preserve active Codex transports and explicit proxy routes.
- Remove Pi Codex dependency declarations from web-run and imagegen. Both remain standalone, with no postinstall scripts or shared internal runtime package.
- Stop reinjecting unchanged nested AGENTS.md guidance every tenth discovery. New and edited guidance still loads.

These session fixes ship together, with patch changesets for all three packages.

Validation: `bun run check:changed` and `bun run changeset:check` passed, including package lint, types, tests, and repository Knip. The two vendored runtime trees remain identical. Isolated tarball registration and Codex auth fallback passed without Pi Codex installed. That probe required supplying upstream Pi 0.85.0's undeclared `pi-server` dependency in the temporary environment only. No live search or image-generation request was made.
