### PR TITLE
fix(pi-codex-conversion): load Notebook archive extractor statically

### DIFF
--- a/.changeset/bright-notebooks-unzip.md
+++ b/.changeset/bright-notebooks-unzip.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-conversion": patch
+---
+
+Fix Notebook's first-run Deno installation in standalone Pi by loading the archive extractor through the extension's static module graph.

--- a/packages/pi-codex-conversion/src/tools/notebook-mode/deno-binary.ts
+++ b/packages/pi-codex-conversion/src/tools/notebook-mode/deno-binary.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { Open } from "unzipper";
 import {
 	chmodSync,
 	existsSync,
@@ -97,7 +98,6 @@ async function installDeno(
 		}
 		const actualSha256 = createHash("sha256").update(bytes).digest("hex");
 		if (actualSha256 !== asset.archiveSha256) throw new Error(`checksum mismatch for ${asset.archive}`);
-		const { Open } = await import("unzipper");
 		const archive = await Open.buffer(bytes);
 		const entry = archive.files.find((candidate) => candidate.path === asset.executable && candidate.type !== "Directory");
 		if (!entry) throw new Error(`pinned Deno archive does not contain ${asset.executable}`);


### PR DESCRIPTION
Fixes #386

Standalone Pi cannot resolve the late dynamic unzipper import during first-run Notebook Deno installation. Load `Open` through the extension’s top-level module graph instead.

Validation: package typecheck, 122 tests, build, and extension artifact verification.