### PR TITLE
fix(pi-codex-imagegen): request gpt-image-2.5

### DIFF
--- a/.changeset/patch-mtt1gniq-24d36c.md
+++ b/.changeset/patch-mtt1gniq-24d36c.md
@@ -1,0 +1,5 @@
+---
+"@howaboua/pi-codex-imagegen": patch
+---
+
+Image generation and editing now request gpt-image-2.5. Proxy model mappings must use gpt-image-2.5 as their canonical key.

--- a/packages/pi-codex-imagegen/README.md
+++ b/packages/pi-codex-imagegen/README.md
@@ -24,7 +24,7 @@ For a proxy that renames Codex providers or models, create `pi-codex-tools.json`
 {
   "providers": {
     "company-codex": {
-      "gpt-image-2": "company-image"
+      "gpt-image-2.5": "company-image"
     }
   }
 }

--- a/packages/pi-codex-imagegen/UPSTREAM_SYNC.md
+++ b/packages/pi-codex-imagegen/UPSTREAM_SYNC.md
@@ -2,4 +2,6 @@
 
 The contract follows OpenAI Codex image generation at commit b545c94041017d000e2c8b2f6272705d21b85dfb.
 
+The TypeScript implementation uses `gpt-image-2.5` instead of the snapshot's `gpt-image-2`.
+
 Reference snapshots live under upstream/. The executable implementation is TypeScript: it preserves Codex generation/edit selectors, native image endpoints, response metadata, and workspace-local artifacts without bundling the Rust client.

--- a/packages/pi-codex-imagegen/src/contract.ts
+++ b/packages/pi-codex-imagegen/src/contract.ts
@@ -5,7 +5,7 @@ import type { CodexToolProvider } from "./codex-runtime/types.js";
 export const IMAGE_GENERATION_TOOL_NAME = "imagegen";
 export const IMAGE_GENERATION_UNSUPPORTED_MESSAGE =
 	"imagegen requires an image-capable OpenAI Codex-compatible Responses provider";
-export const IMAGE_MODEL = "gpt-image-2";
+export const IMAGE_MODEL = "gpt-image-2.5";
 export const MAX_EDIT_IMAGES = 5;
 
 export const IMAGE_GENERATION_PARAMETERS = Type.Object(

--- a/packages/pi-codex-imagegen/tests/tool.test.ts
+++ b/packages/pi-codex-imagegen/tests/tool.test.ts
@@ -16,7 +16,7 @@ import { buildImageGenerationRequest } from "../src/request.js";
 test("image generation preserves Codex request and Code Mode value contracts", async () => {
 	const routes = normalizeCodexToolRouteConfig({
 		providers: {
-			"image-proxy": { "gpt-image-2": "company-image" },
+			"image-proxy": { "gpt-image-2.5": "company-image" },
 		},
 	});
 	assert.equal(
@@ -30,7 +30,7 @@ test("image generation preserves Codex request and Code Mode value contracts", a
 		resolveCodexToolModel(
 			routes,
 			{ provider: "image-proxy" } as never,
-			"gpt-image-2",
+			"gpt-image-2.5",
 		),
 		"company-image",
 	);
@@ -106,7 +106,7 @@ test("image generation preserves Codex request and Code Mode value contracts", a
 			body: {
 				images: [{ image_url: recent }],
 				prompt: "add snow",
-				model: "gpt-image-2",
+				model: "gpt-image-2.5",
 				background: "auto",
 				quality: "auto",
 				size: "auto",


### PR DESCRIPTION
Changes only the requested image model ID to gpt-image-2.5 for generation and editing. Existing tool parameters and transparency behaviour remain unchanged. Updates the proxy mapping example and existing contract test, with a patch changeset.

Validation: check:changed and changeset:check passed. Live generation and editing returned images. The Codex endpoint also accepts an invalid model name, so those probes do not establish backend model identity.